### PR TITLE
Add resource governance and worker scheduler

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -31,6 +31,10 @@ Orchestrator (agent1)              Worker (agent2, 3, 4, ...)
 | `waitpid` | `watch-workers.sh` |
 | zombie reaping | `cleanup-worktree.sh` |
 | PID | issue number |
+| `ulimit -u` (max processes) | `GLIMMER_MAX_WORKERS` |
+| `ps aux` | `worker-status.sh` |
+| process scheduler | Orchestrator のキューイングロジック |
+| semaphore | FIFO 数による concurrency guard |
 
 ## Structure
 
@@ -46,7 +50,8 @@ kernel/
       SKILL.md               # /kernel:orchestrate スキル
   scripts/
     session-id.sh            # セッション ID 生成 + IPC ディレクトリ導出
-    spawn-worker.sh          # worktree作成 + WezTermウィンドウ起動
+    spawn-worker.sh          # worktree作成 + WezTermウィンドウ起動（concurrency guard 付き）
+    worker-status.sh         # 稼働中 Worker の一覧表示
     notify-complete.sh       # Worker → Orchestrator 完了通知
     watch-workers.sh         # 複数Workerの完了を並列監視
     cleanup-worktree.sh      # worktree + branch 削除
@@ -76,8 +81,12 @@ Claude Code のプラグインマーケットプレイスから導入する:
 
 # または直接スクリプトを実行
 kernel/scripts/spawn-worker.sh 4        # issue #4 の Worker 起動
+kernel/scripts/worker-status.sh         # 稼働中 Worker の一覧
 kernel/scripts/watch-workers.sh 4 5 6   # 並列監視
 kernel/scripts/cleanup-worktree.sh 4    # 後片付け
+
+# 同時実行数を変更（デフォルト: 3）
+export GLIMMER_MAX_WORKERS=5
 ```
 
 ## Constraint: 権限の分離
@@ -101,6 +110,23 @@ kernel の権限          対象リポジトリの権限
 ```
 
 対象リポジトリに CLAUDE.md がない場合、Worker は既存のコード・commit・PR から規約を推測する。
+
+## Resource Governance
+
+### 同時実行数制限
+
+`GLIMMER_MAX_WORKERS` 環境変数で同時 Worker 数を制限する（デフォルト: 3）。
+`spawn-worker.sh` はセッション内のアクティブ FIFO 数をカウントし、上限に達している場合 exit 2 を返す。
+Orchestrator はこの exit code を受けてキューイングを行う。
+
+### Worker Status
+
+`worker-status.sh` でセッション内の稼働中 Worker を JSON Lines 形式で確認できる:
+
+```bash
+kernel/scripts/worker-status.sh
+# {"issue":4,"worktree":"/path/.worktrees/issue/4-...","fifo":"/tmp/glimmer-ipc/.../worker-4","uptime":"12m"}
+```
 
 ## IPC: Named Pipe
 

--- a/kernel/agents/orchestrator.md
+++ b/kernel/agents/orchestrator.md
@@ -46,10 +46,66 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/spawn-worker.sh 6
 ${CLAUDE_PLUGIN_ROOT}/scripts/watch-workers.sh 4 5 6
 ```
 
+## スケジューリング
+
+### 同時実行数の制限
+
+`GLIMMER_MAX_WORKERS` 環境変数（デフォルト: 3）で同時 Worker 数を制限する。
+`spawn-worker.sh` はセッション内のアクティブ FIFO 数をカウントし、上限到達時に exit 2 を返す。
+
+```bash
+# 例: 最大 5 Worker に設定
+export GLIMMER_MAX_WORKERS=5
+```
+
+### キューイングルール
+
+issue 数が `GLIMMER_MAX_WORKERS` を超える場合、Orchestrator は以下の手順でスケジューリングする:
+
+1. 先頭 `MAX_WORKERS` 件の独立した issue を同時起動
+2. `watch-workers.sh` でいずれかの Worker 完了を検知
+3. 完了した Worker のクリーンアップ後、キュー内の次の issue を起動
+4. 全 issue が完了するまで 2–3 を繰り返す
+
+```bash
+# キューイング付き並列処理の例
+ISSUES=(4 5 6 7 8 9)
+BATCH=()
+
+for issue in "${ISSUES[@]}"; do
+  ${CLAUDE_PLUGIN_ROOT}/scripts/spawn-worker.sh "$issue"
+  if [[ $? -eq 2 ]]; then
+    # 上限到達 — 先行 Worker の完了を待つ
+    ${CLAUDE_PLUGIN_ROOT}/scripts/watch-workers.sh "${BATCH[@]}"
+    for done_issue in "${BATCH[@]}"; do
+      ${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-worktree.sh "$done_issue"
+    done
+    BATCH=()
+    ${CLAUDE_PLUGIN_ROOT}/scripts/spawn-worker.sh "$issue"
+  fi
+  BATCH+=("$issue")
+done
+
+# 残りの Worker を監視
+[[ ${#BATCH[@]} -gt 0 ]] && ${CLAUDE_PLUGIN_ROOT}/scripts/watch-workers.sh "${BATCH[@]}"
+```
+
+### Worker 状態の確認
+
+`worker-status.sh` でセッション内の稼働中 Worker を確認できる。
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/worker-status.sh
+# 出力例 (JSON Lines):
+# {"issue":4,"worktree":"/path/.worktrees/issue/4-...","fifo":"/tmp/glimmer-ipc/.../worker-4","uptime":"12m"}
+# {"issue":5,"worktree":"/path/.worktrees/issue/5-...","fifo":"/tmp/glimmer-ipc/.../worker-5","uptime":"8m"}
+```
+
 ## 判断基準
 
-- 依存関係のない issue は並列処理
+- 依存関係のない issue は並列処理（`GLIMMER_MAX_WORKERS` の範囲内）
 - 依存関係のある issue は直列処理（先行 issue の完了を待つ）
+- `GLIMMER_MAX_WORKERS` を超える場合はキューイング（先行完了を待って次を起動）
 - Worker 失敗時: PR の状態を確認し、再試行 or エスカレーション
 
 ## Worker と対象リポジトリの関係

--- a/kernel/scripts/spawn-worker.sh
+++ b/kernel/scripts/spawn-worker.sh
@@ -3,6 +3,10 @@
 #
 # Usage: spawn-worker.sh <issue-number> [base-branch]
 # Output: FIFO path (stdout last line)
+# Exit codes:
+#   0 — Worker 起動成功
+#   1 — 一般エラー
+#   2 — 同時実行数上限到達 (GLIMMER_MAX_WORKERS)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,6 +15,20 @@ source "${SCRIPT_DIR}/session-id.sh"
 ISSUE_NUMBER="${1:?Usage: spawn-worker.sh <issue-number> [base-branch]}"
 BASE_BRANCH="${2:-main}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# ── Concurrency Guard ──
+MAX_WORKERS="${GLIMMER_MAX_WORKERS:-3}"
+
+active_worker_count() {
+  find "$SESSION_IPC_DIR" -maxdepth 1 -name 'worker-*' -type p 2>/dev/null | wc -l | tr -d ' '
+}
+
+mkdir -p "$SESSION_IPC_DIR"
+ACTIVE=$(active_worker_count)
+if [[ "$ACTIVE" -ge "$MAX_WORKERS" ]]; then
+  echo "Error: max workers ($MAX_WORKERS) reached (active: $ACTIVE). Waiting..." >&2
+  exit 2
+fi
 
 # ── Issue 情報取得 ──
 ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')

--- a/kernel/scripts/worker-status.sh
+++ b/kernel/scripts/worker-status.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# worker-status.sh — 稼働中 Worker の一覧を表示
+#
+# Usage: worker-status.sh
+# Output: JSON Lines (1 行 = 1 Worker)
+#   {"issue": 4, "worktree": "/path/to/.worktrees/issue/4-...", "fifo": "/tmp/glimmer-ipc/.../worker-4", "uptime": "12m"}
+#
+# Exit codes:
+#   0 — 正常終了
+#   1 — セッション未初期化
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/session-id.sh"
+
+if [[ ! -d "$SESSION_IPC_DIR" ]]; then
+  echo "No active session: ${SESSION_IPC_DIR}" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# FIFO 一覧から Worker 情報を収集
+find "$SESSION_IPC_DIR" -maxdepth 1 -name 'worker-*' -type p 2>/dev/null | sort | while read -r fifo; do
+  basename_fifo=$(basename "$fifo")
+  issue="${basename_fifo#worker-}"
+
+  # worktree パスを探索
+  worktree=""
+  if [[ -n "$REPO_ROOT" ]]; then
+    # issue 番号に一致する worktree を検索
+    worktree=$(git worktree list --porcelain 2>/dev/null \
+      | grep '^worktree ' \
+      | sed 's/^worktree //' \
+      | grep "/issue/${issue}-" \
+      | head -1 || true)
+  fi
+
+  # FIFO の作成時刻からの経過時間
+  if stat -f '%m' "$fifo" &>/dev/null; then
+    # macOS stat
+    created=$(stat -f '%m' "$fifo")
+  elif stat -c '%Y' "$fifo" &>/dev/null; then
+    # GNU/Linux stat
+    created=$(stat -c '%Y' "$fifo")
+  else
+    created=""
+  fi
+
+  uptime=""
+  if [[ -n "$created" ]]; then
+    now=$(date +%s)
+    elapsed=$((now - created))
+    if [[ $elapsed -ge 3600 ]]; then
+      uptime="$((elapsed / 3600))h$((elapsed % 3600 / 60))m"
+    elif [[ $elapsed -ge 60 ]]; then
+      uptime="$((elapsed / 60))m"
+    else
+      uptime="${elapsed}s"
+    fi
+  fi
+
+  # JSON 出力（jq 不要）
+  printf '{"issue":%s,"worktree":"%s","fifo":"%s","uptime":"%s"}\n' \
+    "$issue" "$worktree" "$fifo" "$uptime"
+done

--- a/kernel/tests/test-concurrency-guard.sh
+++ b/kernel/tests/test-concurrency-guard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# test-concurrency-guard.sh — spawn-worker.sh の concurrency guard テスト
+#
+# spawn-worker.sh 全体は WezTerm 依存のため直接実行できない。
+# ここでは concurrency guard ロジックを抽出してテストする。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+KERNEL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "test: concurrency-guard"
+
+# テスト用セッション
+export SESSION_ID="test-concurrency-00000001"
+source "${KERNEL_DIR}/scripts/session-id.sh"
+
+# ── セットアップ: クリーンな状態を保証 ──
+rm -rf "$SESSION_IPC_DIR"
+mkdir -p "$SESSION_IPC_DIR"
+
+# active_worker_count 関数を再定義（spawn-worker.sh からの抽出）
+active_worker_count() {
+  find "$SESSION_IPC_DIR" -maxdepth 1 -name 'worker-*' -type p 2>/dev/null | wc -l | tr -d ' '
+}
+
+# ── Test 1: Worker 0 体でカウントが 0 ──
+COUNT=$(active_worker_count)
+assert_eq "No workers: count is 0" "0" "$COUNT"
+
+# ── Test 2: FIFO を 1 つ作成 → カウント 1 ──
+mkfifo "${SESSION_IPC_DIR}/worker-10"
+COUNT=$(active_worker_count)
+assert_eq "One worker FIFO: count is 1" "1" "$COUNT"
+
+# ── Test 3: FIFO を 3 つまで増やす → カウント 3 ──
+mkfifo "${SESSION_IPC_DIR}/worker-11"
+mkfifo "${SESSION_IPC_DIR}/worker-12"
+COUNT=$(active_worker_count)
+assert_eq "Three worker FIFOs: count is 3" "3" "$COUNT"
+
+# ── Test 4: MAX_WORKERS=3 で 3 体の場合、ガードが発動する ──
+# spawn-worker.sh の該当ロジックをインラインで検証
+MAX_WORKERS=3
+ACTIVE=$(active_worker_count)
+if [[ "$ACTIVE" -ge "$MAX_WORKERS" ]]; then
+  GUARD_TRIGGERED="yes"
+else
+  GUARD_TRIGGERED="no"
+fi
+assert_eq "Guard triggers at MAX_WORKERS=3 with 3 active" "yes" "$GUARD_TRIGGERED"
+
+# ── Test 5: FIFO を 1 つ削除 → ガード解除 ──
+rm -f "${SESSION_IPC_DIR}/worker-12"
+ACTIVE=$(active_worker_count)
+if [[ "$ACTIVE" -ge "$MAX_WORKERS" ]]; then
+  GUARD_TRIGGERED="yes"
+else
+  GUARD_TRIGGERED="no"
+fi
+assert_eq "Guard released after removing one FIFO" "no" "$GUARD_TRIGGERED"
+
+# ── Test 6: MAX_WORKERS=5 で 2 体 → ガード未発動 ──
+MAX_WORKERS=5
+ACTIVE=$(active_worker_count)
+if [[ "$ACTIVE" -ge "$MAX_WORKERS" ]]; then
+  GUARD_TRIGGERED="yes"
+else
+  GUARD_TRIGGERED="no"
+fi
+assert_eq "Guard not triggered: 2 active < MAX_WORKERS=5" "no" "$GUARD_TRIGGERED"
+
+# ── Test 7: 通常ファイル (非 FIFO) はカウントされない ──
+touch "${SESSION_IPC_DIR}/worker-99"
+COUNT=$(active_worker_count)
+assert_eq "Regular file not counted as worker" "2" "$COUNT"
+
+# ── クリーンアップ ──
+rm -rf "$SESSION_IPC_DIR"
+
+report_results

--- a/kernel/tests/test-worker-status.sh
+++ b/kernel/tests/test-worker-status.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# test-worker-status.sh — worker-status.sh のテスト
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+KERNEL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STATUS_SCRIPT="${KERNEL_DIR}/scripts/worker-status.sh"
+
+echo "test: worker-status"
+
+# テスト用セッション
+export SESSION_ID="test-wstatus-00000001"
+source "${KERNEL_DIR}/scripts/session-id.sh"
+
+# ── セットアップ ──
+rm -rf "$SESSION_IPC_DIR"
+mkdir -p "$SESSION_IPC_DIR"
+
+# ── Test 1: Worker なしの場合、出力が空 ──
+OUTPUT=$(bash "$STATUS_SCRIPT")
+assert_eq "No workers: empty output" "" "$OUTPUT"
+
+# ── Test 2: FIFO 作成後に 1 行出力される ──
+mkfifo "${SESSION_IPC_DIR}/worker-20"
+OUTPUT=$(bash "$STATUS_SCRIPT")
+LINE_COUNT=$(echo "$OUTPUT" | grep -c 'issue' || true)
+assert_eq "One worker: one JSON line" "1" "$LINE_COUNT"
+
+# ── Test 3: issue 番号が正しく含まれる ──
+assert_match "Output contains issue 20" '"issue":20' "$OUTPUT"
+
+# ── Test 4: FIFO パスが含まれる ──
+assert_match "Output contains FIFO path" "worker-20" "$OUTPUT"
+
+# ── Test 5: 複数 Worker で複数行出力 ──
+mkfifo "${SESSION_IPC_DIR}/worker-21"
+mkfifo "${SESSION_IPC_DIR}/worker-22"
+OUTPUT=$(bash "$STATUS_SCRIPT")
+LINE_COUNT=$(echo "$OUTPUT" | grep -c 'issue')
+assert_eq "Three workers: three JSON lines" "3" "$LINE_COUNT"
+
+# ── Test 6: uptime フィールドが含まれる ──
+assert_match "Output contains uptime field" '"uptime":' "$OUTPUT"
+
+# ── Test 7: セッションディレクトリが存在しない場合 exit 1 ──
+rm -rf "$SESSION_IPC_DIR"
+export SESSION_ID="test-wstatus-nonexistent"
+export SESSION_IPC_DIR="/tmp/glimmer-ipc/${SESSION_ID}"
+EXIT_CODE=0
+bash "$STATUS_SCRIPT" 2>/dev/null || EXIT_CODE=$?
+assert_eq "Missing session dir: exit 1" "1" "$EXIT_CODE"
+
+# ── クリーンアップ ──
+export SESSION_ID="test-wstatus-00000001"
+export SESSION_IPC_DIR="/tmp/glimmer-ipc/${SESSION_ID}"
+rm -rf "$SESSION_IPC_DIR"
+
+report_results


### PR DESCRIPTION
## Summary

- `spawn-worker.sh` に concurrency guard を追加。`GLIMMER_MAX_WORKERS` 環境変数（デフォルト: 3）で同時 Worker 数を制限し、上限到達時は exit 2 を返す
- `worker-status.sh` を新規追加。セッション内の稼働中 Worker を JSON Lines 形式で一覧表示（`ps aux` 相当）
- `orchestrator.md` にスケジューリングルールとキューイングロジックを記載
- `README.md` に Resource Governance セクションと OS Analogy テーブルの拡張を追加

## Test plan

- [x] `test-concurrency-guard.sh`: FIFO カウント、ガード発動/解除、非 FIFO ファイル除外
- [x] `test-worker-status.sh`: 空出力、JSON Lines フォーマット、複数 Worker、セッション未初期化エラー
- [x] 既存テスト全 pass（36/36）

closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)