### PR TITLE
Add timeout and zombie process management to worker lifecycle

### DIFF
--- a/kernel/agents/orchestrator.md
+++ b/kernel/agents/orchestrator.md
@@ -68,8 +68,52 @@ kernel が Worker に対して定義するのはライフサイクル（PR → C
 spawn-worker.sh はデフォルトのブランチ名を生成するが、
 対象リポジトリに命名規則がある場合は Worker がリネームしてよい。
 
+## タイムアウトとゾンビ管理
+
+### タイムアウト（SIGALRM 相当）
+
+`watch-workers.sh` は環境変数 `GLIMMER_WORKER_TIMEOUT` でタイムアウトを制御する（デフォルト: 3600秒 = 1時間）。
+
+```bash
+# タイムアウトを30分に設定
+export GLIMMER_WORKER_TIMEOUT=1800
+${CLAUDE_PLUGIN_ROOT}/scripts/watch-workers.sh 4 5 6
+```
+
+タイムアウト時、以下の JSON が返る:
+
+```json
+{"issue":4,"status":"timeout","detail":"No response within 1800s"}
+```
+
+### ゾンビ検知（waitpid + WNOHANG 相当）
+
+```bash
+# 特定 Worker の状態を確認
+${CLAUDE_PLUGIN_ROOT}/scripts/health-check.sh 4
+
+# セッション内の全 Worker を検査
+${CLAUDE_PLUGIN_ROOT}/scripts/health-check.sh
+```
+
+### 強制クリーンアップ（SIGKILL 相当）
+
+```bash
+# --force: WezTerm pane を kill してから worktree を削除
+${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-worktree.sh --force 4
+```
+
+### OS アナロジー
+
+| Unix Concept | Kernel Implementation |
+|---|---|
+| `SIGALRM` / watchdog | `GLIMMER_WORKER_TIMEOUT` |
+| `kill -9` (SIGKILL) | `cleanup-worktree.sh --force` |
+| zombie reaping (`waitpid` + `WNOHANG`) | `health-check.sh` |
+
 ## エラーハンドリング
 
-- Worker が応答しない: WezTerm ウィンドウの状態を確認
+- Worker が応答しない: `health-check.sh` でゾンビ検知 → `cleanup-worktree.sh --force` で強制終了
 - merge コンフリクト: Worker が自力で解決を試みる。不可能な場合は FIFO にエラー通知
 - CI 失敗: Worker が修正を試みる。3 回失敗で人間にエスカレーション
+- タイムアウト: `watch-workers.sh` が自動で検知し、`timeout` ステータスを返す

--- a/kernel/scripts/cleanup-worktree.sh
+++ b/kernel/scripts/cleanup-worktree.sh
@@ -1,15 +1,42 @@
 #!/usr/bin/env bash
 # cleanup-worktree.sh — Worktree + branch 削除
 #
-# Usage: cleanup-worktree.sh <issue-number>
+# Usage: cleanup-worktree.sh [--force] <issue-number>
+#
+# --force: Worker プロセスと WezTerm pane を強制終了してからクリーンアップ
+#          （kill -9 / SIGKILL 相当）
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/session-id.sh"
 
-ISSUE_NUMBER="${1:?Usage: cleanup-worktree.sh <issue-number>}"
+# ── オプションパース ──
+FORCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    *) break ;;
+  esac
+done
+
+ISSUE_NUMBER="${1:?Usage: cleanup-worktree.sh [--force] <issue-number>}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 WORKTREE_DIR="${REPO_ROOT}/.worktrees"
+
+# ── --force: Worker プロセスを強制終了 ──
+if [[ "$FORCE" -eq 1 ]]; then
+  PANE_FILE="${SESSION_IPC_DIR}/pane-${ISSUE_NUMBER}"
+
+  # WezTerm pane を kill
+  if [[ -f "$PANE_FILE" ]]; then
+    PANE_ID=$(cat "$PANE_FILE")
+    if command -v wezterm >/dev/null 2>&1; then
+      wezterm cli kill-pane --pane-id "$PANE_ID" 2>/dev/null && \
+        echo "Killed WezTerm pane: ${PANE_ID}" >&2 || true
+    fi
+    rm -f "$PANE_FILE"
+  fi
+fi
 
 # issue 番号に一致する worktree を検索
 WORKTREE=$(git worktree list --porcelain \
@@ -37,6 +64,8 @@ fi
 
 # FIFO クリーンアップ（セッションスコープ）
 rm -f "${SESSION_IPC_DIR}/worker-${ISSUE_NUMBER}"
+# Pane ID ファイルのクリーンアップ
+rm -f "${SESSION_IPC_DIR}/pane-${ISSUE_NUMBER}"
 # 空のセッションディレクトリを削除
 rmdir "$SESSION_IPC_DIR" 2>/dev/null || true
 

--- a/kernel/scripts/health-check.sh
+++ b/kernel/scripts/health-check.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# health-check.sh — ゾンビ Worker の検知・報告
+#
+# Usage: health-check.sh [issue-number...]
+#   issue 番号省略時: セッション内の全 Worker を検査
+#
+# ゾンビ = FIFO が存在するが Worker プロセスが死んでいる状態
+# （waitpid + WNOHANG 相当）
+#
+# Exit code:
+#   0 — all workers healthy (or no workers found)
+#   1 — zombie workers detected
+#
+# Output (stdout): JSON Lines with worker status
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/session-id.sh"
+
+# issue 番号が指定されていれば、それだけ検査。なければセッション内全 FIFO を検査
+if [[ $# -gt 0 ]]; then
+  ISSUES=("$@")
+else
+  ISSUES=()
+  if [[ -d "$SESSION_IPC_DIR" ]]; then
+    for fifo in "${SESSION_IPC_DIR}"/worker-*; do
+      [[ -p "$fifo" ]] || continue
+      issue=$(basename "$fifo" | sed 's/^worker-//')
+      ISSUES+=("$issue")
+    done
+  fi
+fi
+
+if [[ ${#ISSUES[@]} -eq 0 ]]; then
+  echo "No active workers found in session ${SESSION_ID}" >&2
+  exit 0
+fi
+
+ZOMBIES=0
+
+check_worker() {
+  local issue="$1"
+  local fifo="${SESSION_IPC_DIR}/worker-${issue}"
+  local pane_file="${SESSION_IPC_DIR}/pane-${issue}"
+  local status="unknown"
+  local detail=""
+
+  # FIFO が存在しなければ完了済み
+  if [[ ! -p "$fifo" ]]; then
+    echo "{\"issue\":${issue},\"status\":\"completed\",\"detail\":\"No active FIFO\"}"
+    return 0
+  fi
+
+  # 1. WezTerm pane チェック（pane ID ファイルがあれば）
+  if [[ -f "$pane_file" ]]; then
+    local pane_id
+    pane_id=$(cat "$pane_file")
+    if command -v wezterm >/dev/null 2>&1; then
+      if wezterm cli list --format json 2>/dev/null | grep -q "\"pane_id\":${pane_id}[,}]"; then
+        status="healthy"
+        detail="WezTerm pane ${pane_id} alive"
+      else
+        status="zombie"
+        detail="WezTerm pane ${pane_id} dead"
+      fi
+    fi
+  fi
+
+  # 2. pane チェックで判定できなかった場合、プロセスベースでフォールバック
+  if [[ "$status" == "unknown" ]]; then
+    local worktree=""
+    worktree=$(git worktree list --porcelain 2>/dev/null \
+      | grep "issue/${issue}-" \
+      | head -1 \
+      | sed 's/^worktree //' || true)
+
+    if [[ -n "$worktree" ]]; then
+      if pgrep -f "${worktree}" >/dev/null 2>&1; then
+        status="healthy"
+        detail="Process found for worktree"
+      else
+        status="zombie"
+        detail="No process found for worktree"
+      fi
+    else
+      status="zombie"
+      detail="No worktree found"
+    fi
+  fi
+
+  echo "{\"issue\":${issue},\"status\":\"${status}\",\"detail\":\"${detail}\"}"
+
+  if [[ "$status" == "zombie" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+for issue in "${ISSUES[@]}"; do
+  if ! check_worker "$issue"; then
+    ZOMBIES=$((ZOMBIES + 1))
+  fi
+done
+
+echo "---" >&2
+echo "Health check: ${#ISSUES[@]} workers, ${ZOMBIES} zombies." >&2
+
+if [[ "$ZOMBIES" -gt 0 ]]; then
+  exit 1
+fi
+
+exit 0

--- a/kernel/scripts/spawn-worker.sh
+++ b/kernel/scripts/spawn-worker.sh
@@ -52,6 +52,9 @@ echo "branch:   $BRANCH" >&2
 
 # Worker に SESSION_ID を伝播
 MAIN_PANE=$(wezterm cli spawn --new-window --cwd "$WORKTREE")
+
+# Pane ID を保存（health-check / cleanup --force で使用）
+echo "$MAIN_PANE" > "${SESSION_IPC_DIR}/pane-${ISSUE_NUMBER}"
 wezterm cli send-text --pane-id "$MAIN_PANE" -- "export SESSION_ID='${SESSION_ID}'"
 wezterm cli send-text --pane-id "$MAIN_PANE" --no-paste $'\r'
 

--- a/kernel/scripts/watch-workers.sh
+++ b/kernel/scripts/watch-workers.sh
@@ -3,6 +3,9 @@
 #
 # Usage: watch-workers.sh <issue-number> [issue-number...]
 #
+# Environment:
+#   GLIMMER_WORKER_TIMEOUT — Worker のタイムアウト秒数（デフォルト: 3600）
+#
 # 各 Worker の FIFO をバックグラウンドで並列監視し、
 # 全 Worker の完了を待つ。結果を標準出力に JSON Lines で出力する。
 set -euo pipefail
@@ -16,6 +19,7 @@ ISSUE_NUMBERS=("$@")
 FIFO_DIR="$SESSION_IPC_DIR"
 RESULT_DIR=$(mktemp -d)
 PIDS=()
+TIMEOUT="${GLIMMER_WORKER_TIMEOUT:-3600}"
 
 # 各 FIFO を並列監視
 watch_one() {
@@ -27,17 +31,23 @@ watch_one() {
     return 1
   fi
 
-  echo "Watching issue #${issue}..." >&2
+  echo "Watching issue #${issue} (timeout: ${TIMEOUT}s)..." >&2
 
-  # ブロッキング読み取り — Worker が書き込むまで待機
+  # FIFO を read-write で開いて open() のブロッキングを回避（SIGALRM 相当）
   local result
-  result=$(cat "$fifo")
-  echo "$result" > "${RESULT_DIR}/${issue}"
-
-  # FIFO を即座にクリーンアップ
-  rm -f "$fifo"
-
-  echo "Issue #${issue} completed." >&2
+  exec 3<>"$fifo"
+  if read -t "$TIMEOUT" result <&3; then
+    exec 3>&-
+    echo "$result" > "${RESULT_DIR}/${issue}"
+    rm -f "$fifo"
+    echo "Issue #${issue} completed." >&2
+  else
+    exec 3>&-
+    echo "{\"issue\":${issue},\"status\":\"timeout\",\"detail\":\"No response within ${TIMEOUT}s\"}" > "${RESULT_DIR}/${issue}"
+    rm -f "$fifo"
+    echo "Issue #${issue} timed out after ${TIMEOUT}s." >&2
+    return 1
+  fi
 }
 
 for issue in "${ISSUE_NUMBERS[@]}"; do
@@ -45,12 +55,12 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
   PIDS+=($!)
 done
 
-echo "Watching ${#ISSUE_NUMBERS[@]} workers..." >&2
+echo "Watching ${#ISSUE_NUMBERS[@]} workers (timeout: ${TIMEOUT}s)..." >&2
 
 # 全バックグラウンドプロセスの完了を待機
 FAILED=0
 for pid in "${PIDS[@]}"; do
-  wait "$pid" || ((FAILED++))
+  wait "$pid" || FAILED=$((FAILED + 1))
 done
 
 # 結果を出力

--- a/kernel/tests/test-health-check.sh
+++ b/kernel/tests/test-health-check.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# test-health-check.sh — ゾンビ Worker 検知テスト
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+KERNEL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "test: health-check"
+
+export SESSION_ID="test-health-00000001"
+source "${KERNEL_DIR}/scripts/session-id.sh"
+
+cleanup() {
+  rm -rf "$SESSION_IPC_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$SESSION_IPC_DIR"
+
+# ── Test 1: FIFO なし → completed ──
+RESULT=$(bash "${KERNEL_DIR}/scripts/health-check.sh" 70 2>/dev/null)
+assert_match "No FIFO reports completed" '"status":"completed"' "$RESULT"
+
+# ── Test 2: FIFO あり、pane なし、worktree なし → zombie ──
+mkfifo "${SESSION_IPC_DIR}/worker-71"
+RESULT=$(bash "${KERNEL_DIR}/scripts/health-check.sh" 71 2>/dev/null || true)
+assert_match "Orphaned FIFO reports zombie" '"status":"zombie"' "$RESULT"
+assert_match "Zombie detail mentions no worktree" 'No worktree found' "$RESULT"
+
+# ── Test 3: 引数なしで全 Worker を検査 ──
+mkfifo "${SESSION_IPC_DIR}/worker-72"
+RESULT=$(bash "${KERNEL_DIR}/scripts/health-check.sh" 2>/dev/null || true)
+assert_match "Issue 71 found in scan" '"issue":71' "$RESULT"
+assert_match "Issue 72 found in scan" '"issue":72' "$RESULT"
+
+# ── Test 4: FIFO がないセッションでは正常終了 ──
+rm -f "${SESSION_IPC_DIR}/worker-71" "${SESSION_IPC_DIR}/worker-72"
+EXIT_CODE=0
+bash "${KERNEL_DIR}/scripts/health-check.sh" 2>/dev/null || EXIT_CODE=$?
+assert_eq "No workers returns exit 0" "0" "$EXIT_CODE"
+
+report_results

--- a/kernel/tests/test-timeout.sh
+++ b/kernel/tests/test-timeout.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test-timeout.sh — watch-workers タイムアウト機構テスト
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/helpers.sh"
+
+KERNEL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "test: timeout"
+
+export SESSION_ID="test-timeout-00000001"
+source "${KERNEL_DIR}/scripts/session-id.sh"
+
+ISSUE=99
+
+cleanup() {
+  rm -f "${SESSION_IPC_DIR}/worker-${ISSUE}"
+  rmdir "$SESSION_IPC_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$SESSION_IPC_DIR"
+mkfifo "${SESSION_IPC_DIR}/worker-${ISSUE}"
+
+# ── Test 1: タイムアウトで適切な JSON が返る ──
+RESULT_FILE=$(mktemp)
+
+# 2秒タイムアウトで watch-workers を起動（Writer は書き込まない）
+GLIMMER_WORKER_TIMEOUT=2 \
+  bash "${KERNEL_DIR}/scripts/watch-workers.sh" "$ISSUE" > "$RESULT_FILE" 2>/dev/null &
+WATCH_PID=$!
+
+# 完了をポーリング（最大 10 秒）
+WATCH_DONE=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$WATCH_PID" 2>/dev/null; then
+    WATCH_DONE=1
+    break
+  fi
+  sleep 0.1
+done
+
+wait "$WATCH_PID" 2>/dev/null || true
+
+assert_eq "watch-workers exited within timeout" "1" "$WATCH_DONE"
+
+RESULT=$(cat "$RESULT_FILE")
+rm -f "$RESULT_FILE"
+
+assert_match "Timeout status in result" '"status":"timeout"' "$RESULT"
+assert_match "Issue number in result" '"issue":99' "$RESULT"
+assert_match "Timeout detail in result" 'No response within' "$RESULT"
+
+# ── Test 2: 正常完了はタイムアウト前に返る ──
+# FIFO を再作成（Test 1 の watch_one で削除済み）
+mkfifo "${SESSION_IPC_DIR}/worker-${ISSUE}"
+
+RESULT_FILE=$(mktemp)
+
+GLIMMER_WORKER_TIMEOUT=10 \
+  bash "${KERNEL_DIR}/scripts/watch-workers.sh" "$ISSUE" > "$RESULT_FILE" 2>/dev/null &
+WATCH_PID=$!
+
+# watch-workers が FIFO を開くのを待つ
+sleep 0.5
+
+# 即座に書き込み
+echo '{"issue":99,"status":"merged","detail":"PR-99"}' > "${SESSION_IPC_DIR}/worker-${ISSUE}" &
+WRITER_PID=$!
+
+# 完了をポーリング（3秒以内に完了するはず）
+WATCH_DONE=0
+for _ in $(seq 1 30); do
+  if ! kill -0 "$WATCH_PID" 2>/dev/null; then
+    WATCH_DONE=1
+    break
+  fi
+  sleep 0.1
+done
+
+kill "$WRITER_PID" 2>/dev/null || true
+rm -f "${SESSION_IPC_DIR}/worker-${ISSUE}"
+wait "$WRITER_PID" 2>/dev/null || true
+wait "$WATCH_PID" 2>/dev/null || true
+
+assert_eq "Completed before timeout" "1" "$WATCH_DONE"
+
+RESULT=$(cat "$RESULT_FILE")
+rm -f "$RESULT_FILE"
+
+assert_match "Normal result contains merged" '"status":"merged"' "$RESULT"
+
+report_results


### PR DESCRIPTION
closes #6

## Summary

- `watch-workers.sh`: `cat $FIFO` → `read -t` に変更し `GLIMMER_WORKER_TIMEOUT` 環境変数でタイムアウト制御（デフォルト 3600秒）。FIFO を r/w で開いて `open()` のブロッキングも回避
- `health-check.sh`: 新規スクリプト。ゾンビ Worker の検知・報告（`waitpid` + `WNOHANG` 相当）
- `cleanup-worktree.sh`: `--force` フラグ追加。WezTerm pane を kill してから worktree を削除（`SIGKILL` 相当）
- `spawn-worker.sh`: pane ID を `SESSION_IPC_DIR/pane-{issue}` に保存
- `orchestrator.md`: タイムアウト・ゾンビ管理・OS アナロジーテーブルを追記
- `((FAILED++))` の `set -e` 問題を修正（`0++` は偽値を返すため）

## OS Analogy

| Unix Concept | Kernel Implementation |
|---|---|
| `SIGALRM` / watchdog | `GLIMMER_WORKER_TIMEOUT` |
| `kill -9` (SIGKILL) | `cleanup-worktree.sh --force` |
| zombie reaping (`waitpid` + `WNOHANG`) | `health-check.sh` |

## Test plan

- [x] `test-timeout.sh`: タイムアウトで適切な JSON が返る / 正常完了はタイムアウト前に返る
- [x] `test-health-check.sh`: FIFO なし → completed / 孤立 FIFO → zombie / 引数なしで全 Worker 検査
- [x] 既存テスト全 pass（34 tests, 0 failures）

🤖 Generated with [Claude Code](https://claude.com/claude-code)