### PR TITLE
Bump kernel plugin version to 0.2.0

### DIFF
--- a/kernel/.claude-plugin/plugin.json
+++ b/kernel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kernel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Claude Code 並列エージェント基盤。OS のプロセスモデルに倣い、issue を独立した Worker に分配・監視・回収する。",
   "author": {
     "name": "clonable-eden"


### PR DESCRIPTION
## Summary

- kernel plugin のバージョンを 0.1.0 → 0.2.0 に更新
- #6, #7, #8 で追加された機能を反映するためのバージョンバンプ
- `/plugin update` がバージョン文字列で差分判断するため、更新が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)