### PR TITLE
docs: add kernel/CLAUDE.md development guide

### DIFF
--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -1,0 +1,204 @@
+# kernel Development Guide
+
+kernel は Claude Code の並列エージェント基盤。
+Unix の概念（プロセス、IPC、スケジューラ）を Claude ワークフローにマッピングしている。
+アーキテクチャの詳細は [README.md](./README.md) を参照。
+
+## Architecture
+
+```
+kernel/
+├── agents/          # エージェント定義 (orchestrator, worker)
+├── scripts/         # ライフサイクル管理スクリプト群
+├── skills/          # スキル定義 (/kernel:orchestrate)
+└── tests/           # テストスイート
+```
+
+主要なマッピング:
+
+| Unix | kernel |
+|------|--------|
+| scheduler | Orchestrator agent |
+| process | Worker agent |
+| `fork` + `exec` | `spawn-worker.sh` |
+| address space | git worktree |
+| IPC pipe | named pipe (FIFO) |
+| IPC namespace | `SESSION_ID` |
+
+## Scripts
+
+### 基本ルール
+
+すべてのスクリプトは先頭に以下を記述する:
+
+```bash
+set -euo pipefail
+```
+
+`session-id.sh` を source してセッションスコープを確保する:
+
+```bash
+source "$(dirname "$0")/session-id.sh"
+```
+
+### 既知の罠
+
+`((var++))` は `var=0` のとき exit 1 を返す（bash の算術式で 0 は falsy）。
+`set -e` 下では即死するため、代わりに `var=$((var + 1))` を使う:
+
+```bash
+# NG: FAILED=0 のとき set -e で死ぬ
+((FAILED++))
+
+# OK
+FAILED=$((FAILED + 1))
+```
+
+### 環境変数
+
+`KERNEL_` プレフィックスを使用する。`GLIMMER_*` は anti-pattern（#24 でリネーム予定）。
+
+デフォルト値には `${VAR:-default}` パターンを使う:
+
+```bash
+MAX_WORKERS="${KERNEL_MAX_WORKERS:-3}"
+TIMEOUT="${KERNEL_WORKER_TIMEOUT:-3600}"
+```
+
+`CLAUDE_PLUGIN_ROOT` はスキル経由の実行時のみ Claude Code が自動設定する。
+直接実行にも対応するため `SCRIPT_DIR` からのフォールバックを入れる:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+```
+
+### フラグパース
+
+`while-case` ループで処理する（`cleanup-worktree.sh --force` 参照）:
+
+```bash
+FORCE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    *) break ;;
+  esac
+done
+```
+
+### Positional 引数のバリデーション
+
+`${1:?Usage: ...}` パターンを使う:
+
+```bash
+ISSUE_NUMBER="${1:?Usage: spawn-worker.sh <issue-number> [base-branch]}"
+BASE_BRANCH="${2:-main}"
+```
+
+## Agents
+
+### Frontmatter
+
+エージェント定義ファイルには以下の frontmatter を記述する:
+
+```yaml
+name: <agent-name>
+description: <description>
+allowed-tools: Read, Edit, Write, Bash(git *), Bash(gh *), Bash(bash *)
+```
+
+### 権限の分離
+
+kernel はライフサイクルのみを定義する（spawn → PR → merge → notify）。
+実装の規約は対象リポジトリの CLAUDE.md に従う。
+
+Worker の起動プロンプトにも「対象リポジトリの CLAUDE.md を読み、その規約に完全に従う」旨を含める。
+
+権限は agent frontmatter の `allowed-tools` で定義する。`.claude/settings.json` ではなく frontmatter を使うことで、worktree ごとの設定が不要になる。Worker は `claude --agent kernel:worker` で起動され、`--agent` フラグにより `allowed-tools` が自動適用される。
+
+### Worker Protocol
+
+`worker.md` は以下のフェーズを定義する:
+
+1. **Phase 0** — 対象リポジトリの CLAUDE.md を読む
+2. **Phase 1** — 実装（コード変更を伴う場合は TDD: RED → GREEN → REFACTOR）
+3. **Phase 2** — PR 作成
+4. **Phase 3** — CI 確認・merge
+5. **Phase 4** — 完了通知（`notify-complete.sh`）
+
+TDD はコード変更を伴う issue では常に実施する。ドキュメントのみの変更等は Worker が判断して省略してよい。
+
+TDD 実施時は commit message に phase suffix を付ける: `(RED)`, `(GREEN)`, `(REFACTOR)`。
+
+## Testing
+
+### テスト対象
+
+**実行可能なスクリプトの振る舞い**のみをテストする。
+
+- OK: `session-id.sh` が `SESSION_ID` を生成・エクスポートする
+- OK: `spawn-worker.sh` が同時実行数を超えたとき exit 2 を返す
+- NG: `*.md` の内容を grep して特定の文字列が含まれるか確認するだけのテスト
+
+### テストファイル命名
+
+```
+tests/
+├── run-tests.sh          # テストランナー
+├── helpers.sh            # アサーション関数
+├── test-session-id.sh    # session-id.sh のテスト
+├── test-concurrency-guard.sh
+└── test-{feature}.sh     # 機能ごとのテストファイル
+```
+
+### アサーション関数
+
+`helpers.sh` が提供する関数を使用する:
+
+```bash
+assert_eq <label> <expected> <actual>
+assert_match <label> <regex-pattern> <actual>
+assert_file_exists <label> <path>
+assert_fifo_exists <label> <path>
+assert_dir_exists <label> <path>
+assert_not_exists <label> <path>
+report_results  # "Results: N passed, M failed"
+```
+
+### テスト分離
+
+副作用のあるコマンド（WezTerm, `gh`, `git worktree`）はテストから分離するか、モック可能な構造にする。
+
+テストでは専用の `SESSION_ID` を使い、前後でクリーンアップする:
+
+```bash
+export SESSION_ID="test-feature-00000001"
+source "${KERNEL_DIR}/scripts/session-id.sh"
+rm -rf "$SESSION_IPC_DIR"
+mkdir -p "$SESSION_IPC_DIR"
+# ... tests ...
+rm -rf "$SESSION_IPC_DIR"
+```
+
+## CI
+
+GitHub Actions が `kernel/**` パス変更時に `run-tests.sh` を実行する。テストが通らない PR は merge しない。
+
+## Versioning
+
+feature 追加時は `.claude-plugin/plugin.json` の `version` を bump する。
+`/plugin update` が version 差分で変更を検知するため、bump を忘れると更新が反映されない。
+
+## Conventions
+
+ルートの [CLAUDE.md](../CLAUDE.md) を継承する:
+
+- ブランチ名: `issue/{number}-{short-description}`
+- commit message の title は英語、body は日本語 OK
+- PR の body に `closes #{issue-number}` を含める
+
+## Self-hosting
+
+kernel 自身の issue も `/kernel:orchestrate` で解決していく。
+この CLAUDE.md は Worker が kernel を開発する際のガイドでもある。


### PR DESCRIPTION
## Summary
- kernel プラグインの開発規約を `kernel/CLAUDE.md` に集約
- 過去の issue/PR で得た知見を反映:
  - `set -euo pipefail` と `((var++))` の罠 (#16)
  - `CLAUDE_PLUGIN_ROOT` フォールバックパターン (#20)
  - `--agent` による権限適用の設計判断 (#13, #25)
  - TDD commit message の phase suffix (#9, #15)
  - CI・Plugin versioning の規約 (#10, #19)

## Test plan
- [x] ドキュメントのみの変更のため、既存テストへの影響なし
- [x] 記載内容が既存スクリプト・エージェント定義と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)