### PR TITLE
feat: automate kernel plugin version bump on release

### DIFF
--- a/.claude/skills/release-kernel/SKILL.md
+++ b/.claude/skills/release-kernel/SKILL.md
@@ -1,0 +1,70 @@
+---
+description: kernel プラグインのバージョンをリリースする
+allowed-tools: Read, Bash(git *), Bash(gh *)
+---
+
+# /release-kernel
+
+kernel プラグインのリリーススキル。git log を分析して semver bump レベルを推奨し、ユーザー確認後に CI をトリガーする。
+
+## Workflow
+
+### Step 1: 現在のバージョンを取得
+
+`kernel/.claude-plugin/plugin.json` から現在のバージョンを読み取る。
+
+### Step 2: 最新リリースタグを特定
+
+```bash
+git tag -l 'kernel-v*' --sort=-v:refname | head -1
+```
+
+タグが存在しない場合は全履歴を対象とする。
+
+### Step 3: 変更ログを取得
+
+```bash
+# タグが存在する場合
+git log <last-tag>..HEAD --oneline -- kernel/
+
+# タグが存在しない場合
+git log --oneline -- kernel/
+```
+
+### Step 4: bump レベルを判定
+
+セマンティックバージョニングルールに従い、変更内容を分析して bump レベルを判定する:
+
+| Bump | 条件 | 例 |
+|------|------|----|
+| **patch** | バグ修正、ドキュメント更新、テスト追加 | `fix:`, `docs:`, `test:`, `refactor:` |
+| **minor** | 新スクリプト/スキル追加、後方互換な機能拡張 | `feat:` |
+| **major** | 破壊的変更: 引数変更、環境変数廃止、スクリプト削除 | 既存の呼び出し元が壊れる変更 |
+
+conventional commits の prefix を参考にしつつ、コミット内容も考慮して判定する。
+複数の変更がある場合は最も大きい bump レベルを採用する。
+
+### Step 5: ユーザーに確認
+
+以下の情報をユーザーに提示する:
+
+- 現在のバージョン
+- 変更ログ（コミット一覧）
+- 推奨 bump レベルとその理由
+- 新バージョン
+
+ユーザーの確認を得てから次に進む。ユーザーが別の bump レベルを指定した場合はそれに従う。
+
+### Step 6: CI をトリガー
+
+```bash
+gh workflow run kernel-release.yml -f version=<new-version> -f plugin=kernel
+```
+
+### Step 7: 結果を確認
+
+ワークフローの実行状況を確認し、結果をユーザーに報告する:
+
+```bash
+gh run list --workflow=kernel-release.yml --limit=1
+```

--- a/.github/workflows/kernel-release.yml
+++ b/.github/workflows/kernel-release.yml
@@ -1,0 +1,64 @@
+name: kernel release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version (e.g. 0.3.0)'
+        required: true
+      plugin:
+        description: 'Plugin name'
+        required: true
+        default: 'kernel'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${{ inputs.version }} (expected X.Y.Z)"
+            exit 1
+          fi
+
+      - name: Validate plugin exists
+        run: |
+          if [[ ! -f "${{ inputs.plugin }}/.claude-plugin/plugin.json" ]]; then
+            echo "::error::Plugin not found: ${{ inputs.plugin }}"
+            exit 1
+          fi
+
+      - name: Update plugin.json
+        run: |
+          jq --arg v "${{ inputs.version }}" '.version = $v' \
+            "${{ inputs.plugin }}/.claude-plugin/plugin.json" > tmp.json
+          mv tmp.json "${{ inputs.plugin }}/.claude-plugin/plugin.json"
+
+      - name: Commit via API
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FILE_PATH="${{ inputs.plugin }}/.claude-plugin/plugin.json"
+          FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/${FILE_PATH}" --jq '.sha')
+          CONTENT=$(base64 -w0 < "${FILE_PATH}")
+          COMMIT_SHA=$(gh api "repos/${{ github.repository }}/contents/${FILE_PATH}" \
+            -X PUT \
+            -f message="release: ${{ inputs.plugin }} v${{ inputs.version }}" \
+            -f content="${CONTENT}" \
+            -f sha="${FILE_SHA}" \
+            --jq '.commit.sha')
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+        id: commit
+
+      - name: Create tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/${{ inputs.plugin }}-v${{ inputs.version }}" \
+            -f sha="${{ steps.commit.outputs.commit_sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,10 @@
 - commit message の title は英語、body は日本語 OK
 - PR の body に `closes #{issue-number}` を含める
 - worktree は `.worktrees/` 配下に作成（.gitignore 済み）
+- commit message は conventional commits に従う:
+  - `feat:` 新機能
+  - `fix:` バグ修正
+  - `docs:` ドキュメントのみ
+  - `test:` テストのみ
+  - `refactor:` リファクタリング
+  - `release:` バージョンバンプ（CI 自動生成）

--- a/kernel/CLAUDE.md
+++ b/kernel/CLAUDE.md
@@ -187,8 +187,32 @@ GitHub Actions が `kernel/**` パス変更時に `run-tests.sh` を実行する
 
 ## Versioning
 
-feature 追加時は `.claude-plugin/plugin.json` の `version` を bump する。
-`/plugin update` が version 差分で変更を検知するため、bump を忘れると更新が反映されない。
+`/plugin update` は `plugin.json` の version 文字列で差分を判断する。
+バージョン管理は `/release-kernel` スキルと GitHub Actions で自動化されている。
+
+### セマンティックバージョニングルール
+
+| Bump | 条件 | 例 |
+|------|------|----|
+| **patch** | バグ修正、ドキュメント更新、テスト追加 | `fix:`, `docs:`, `test:`, `refactor:` |
+| **minor** | 新スクリプト/スキル追加、後方互換な機能拡張 | `feat:` |
+| **major** | 破壊的変更: 引数変更、環境変数廃止、スクリプト削除 | 既存の呼び出し元が壊れる変更 |
+
+### リリース手順
+
+```bash
+/release-kernel
+```
+
+スキルが git log を分析し bump レベルを推奨する。確認後 `gh workflow run` で CI をトリガーし、CI が version bump + commit + tag + push を実行する。
+
+### バージョン管理対象
+
+- `kernel/.claude-plugin/plugin.json` — プラグインマニフェスト
+
+### タグ形式
+
+`kernel-v{major}.{minor}.{patch}`（将来の複数プラグイン対応のためプレフィックス付き）
 
 ## Conventions
 

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -96,6 +96,8 @@ kernel/scripts/cleanup-worktree.sh 4    # 後片付け
 export GLIMMER_MAX_WORKERS=5
 ```
 
+バージョン管理とリリース手順については [kernel/CLAUDE.md の Versioning セクション](./CLAUDE.md#versioning) を参照。
+
 ## Worker Permissions
 
 Worker / Orchestrator のエージェント定義には `allowed-tools` が設定されており、


### PR DESCRIPTION
closes #21

## Summary

- `/release-kernel` スキルを追加（git log 分析 → semver bump 推奨 → CI トリガー）
- `kernel-release.yml` ワークフローを追加（GitHub API 経由で signed commit + tag）
- `kernel/CLAUDE.md` Versioning セクションを拡充（semver ルール表、手順、タグ形式）
- `CLAUDE.md` に conventional commits ガイドラインを追加
- `kernel/README.md` にリリース手順への参照を追記

## 実行計画からの変更点

- **marketplace.json の更新を除外**: `marketplace.json` は新プラグイン登録時にのみ更新するもので、既存プラグインのバージョンバンプでは不要と判断。CI・スキル・ドキュメントすべてから除外した
- **GitHub API 経由の署名付きコミット**: 当初は `git commit` + `git push` だったが、branch protection で signed commits が要求される環境でも動作するよう Contents API 経由に変更。GitHub が自動署名する

## Test plan

- [ ] `/release-kernel` スキルが git log を正しく分析するか
- [ ] `gh workflow run` が正しくトリガーされるか
- [ ] CI が `plugin.json` を更新し、署名付きコミットとタグを作成するか

🤖 Generated with [Claude Code](https://claude.com/claude-code)