### PR TITLE
fix: remove version from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,6 @@
       "name": "kernel",
       "source": "./kernel",
       "description": "Claude Code 並列エージェント基盤。OS のプロセスモデルに倣い、issue を独立した Worker に分配・監視・回収する。",
-      "version": "0.1.0",
       "author": {
         "name": "clonable-eden"
       },


### PR DESCRIPTION
closes #31

## Summary

- `marketplace.json` から `version` フィールドを削除
- `plugin.json` を version の source of truth に一本化

両方に version が存在すると `/plugin update` の検知漏れが発生するため。

## Test plan

- [ ] `/plugin update kernel@clonable-eden-glimmer` でバージョン更新が正しく検知されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)