### PR TITLE
fix: handle stale worktree/branch on retry and ensure correct cwd

### DIFF
--- a/kernel/scripts/spawn-worker.sh
+++ b/kernel/scripts/spawn-worker.sh
@@ -87,9 +87,33 @@ LOG_DIR="${SESSION_IPC_DIR}/logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="${LOG_DIR}/worker-${ISSUE_NUMBER}.log"
 
+# ── Stale worktree/branch cleanup (retry safety) ──
+# 前回の spawn 失敗 + 不完全な rollback で worktree や branch が残っている場合、
+# 再作成前にクリーンアップする。
+cleanup_stale_worktree() {
+  local worktree="$1" branch="$2"
+  # git worktree として登録されている場合（.git ファイルが worktree 参照を持つ）
+  if [[ -f "${worktree}/.git" ]]; then
+    echo "Warning: stale worktree found at ${worktree}, removing..." >&2
+    git worktree remove --force "$worktree" 2>/dev/null || true
+  fi
+  # git worktree list に登録されていないが、ディレクトリだけ残っている場合
+  if [[ -d "$worktree" ]]; then
+    echo "Warning: orphaned worktree directory found at ${worktree}, removing..." >&2
+    rm -rf "$worktree"
+    git worktree prune 2>/dev/null || true
+  fi
+  # stale branch を削除
+  if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+    echo "Warning: stale branch found: ${branch}, deleting..." >&2
+    git branch -D "$branch" 2>/dev/null || true
+  fi
+}
+
 # ── Worktree 作成 ──
 mkdir -p "$WORKTREE_DIR"
 git fetch origin "${BASE_BRANCH}" --quiet
+cleanup_stale_worktree "$WORKTREE" "$BRANCH"
 git worktree add -b "$BRANCH" "$WORKTREE" "origin/${BASE_BRANCH}"
 
 # ── Trust 登録（Worker が trust プロンプトなしで起動できるように） ──
@@ -118,7 +142,8 @@ MAIN_PANE=$(wezterm cli spawn --new-window "${WORKSPACE_ARGS[@]}" --cwd "$WORKTR
 
 # Pane ID を保存（health-check / cleanup --force で使用）
 echo "$MAIN_PANE" > "${SESSION_IPC_DIR}/pane-${ISSUE_NUMBER}"
-wezterm cli send-text --pane-id "$MAIN_PANE" -- "export SESSION_ID='${SESSION_ID}'"
+# WezTerm の --cwd が確実に反映されないケースに備え、明示的に cd する
+wezterm cli send-text --pane-id "$MAIN_PANE" -- "cd '${WORKTREE}' && export SESSION_ID='${SESSION_ID}'"
 wezterm cli send-text --pane-id "$MAIN_PANE" --no-paste $'\r'
 
 # 下部: auto-refresh git log

--- a/kernel/tests/test-spawn-retry.sh
+++ b/kernel/tests/test-spawn-retry.sh
@@ -49,6 +49,7 @@ echo "  Test 1: stale worktree + branch cleanup"
 
   # worktree と branch が存在することを確認
   assert_dir_exists "Stale worktree exists before cleanup" "$WORKTREE"
+  assert_file_exists "Stale worktree has .git file" "${WORKTREE}/.git"
 
   # cleanup_stale_worktree を実行
   source_cleanup_stale


### PR DESCRIPTION
closes #23

## Summary
- `spawn-worker.sh` にリトライ時の stale worktree/branch クリーンアップ関数 `cleanup_stale_worktree()` を追加
  - 登録済み worktree（`.git` ファイル検出）→ `git worktree remove --force`
  - 孤児ディレクトリ → `rm -rf` + `git worktree prune`
  - 残留 branch → `git branch -D`
- WezTerm pane で明示的に `cd` を実行してから Claude Code を起動（`--cwd` オプションだけに依存しない）

## Test Plan
- [x] stale worktree + branch が存在する状態でクリーンアップ → 再作成成功
- [x] stale branch のみ → 再作成成功
- [x] stale リソースなし → エラーなしで完了
- [x] 孤児ディレクトリのみ → クリーンアップ後に再作成成功
- [x] 既存テスト全件通過