### PR TITLE
refactor: rename kernel-release.yml to plugin-release.yml

### DIFF
--- a/.claude/skills/release-kernel/SKILL.md
+++ b/.claude/skills/release-kernel/SKILL.md
@@ -58,7 +58,7 @@ conventional commits の prefix を参考にしつつ、コミット内容も考
 ### Step 6: CI をトリガー
 
 ```bash
-gh workflow run kernel-release.yml -f version=<new-version> -f plugin=kernel
+gh workflow run plugin-release.yml -f version=<new-version> -f plugin=kernel
 ```
 
 ### Step 7: 結果を確認
@@ -66,5 +66,5 @@ gh workflow run kernel-release.yml -f version=<new-version> -f plugin=kernel
 ワークフローの実行状況を確認し、結果をユーザーに報告する:
 
 ```bash
-gh run list --workflow=kernel-release.yml --limit=1
+gh run list --workflow=plugin-release.yml --limit=1
 ```

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,4 +1,4 @@
-name: kernel release
+name: plugin release
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
closes #45

## Summary
- `.github/workflows/kernel-release.yml` → `plugin-release.yml` にリネーム
- `name: kernel release` → `name: plugin release` に変更
- `/release-kernel` スキル内の workflow 参照を更新

## Test Plan
- [ ] `gh workflow list` で `plugin release` が表示されることを確認
- [ ] `gh workflow run plugin-release.yml -f version=... -f plugin=kernel` が正常に動作することを確認