### PR TITLE
fix: use comma-separated format for --allowedTools

### DIFF
--- a/kernel/scripts/orchestrator/spawn-worker.sh
+++ b/kernel/scripts/orchestrator/spawn-worker.sh
@@ -165,7 +165,7 @@ wezterm cli split-pane \
 # 2. ライフサイクル（PR → CI → merge → notify）のみ kernel のプロトコルに従う
 # 3. 実装・規約は対象リポジトリに完全に従う
 PROMPT="issue #${ISSUE_NUMBER} を解決してください。まず対象リポジトリの CLAUDE.md を読み、その規約に完全に従ってください。ライフサイクルのみ kernel の Worker Protocol に従います: 実装 → PR作成 → CI確認 → merge。完了したら ${CLAUDE_PLUGIN_ROOT}/scripts/worker/notify-complete.sh ${ISSUE_NUMBER} merged <pr-number> を実行してください。"
-wezterm cli send-text --pane-id "$MAIN_PANE" -- "claude --agent kernel:worker --allowedTools 'Bash' 'Edit' 'Write' 'Read' '${PROMPT}'"
+wezterm cli send-text --pane-id "$MAIN_PANE" -- "claude --agent kernel:worker --allowedTools 'Bash,Edit,Write,Read' '${PROMPT}'"
 wezterm cli send-text --pane-id "$MAIN_PANE" --no-paste $'\r'
 
 # ── ライフサイクルイベントをログに記録 ──


### PR DESCRIPTION
## Summary
- `spawn-worker.sh` の `--allowedTools` をスペース区切りからカンマ区切りに修正
- `wezterm cli send-text` で単一文字列として送信する際、スペース区切りだとシェルの引数パースで正しく解釈されず Worker が起動しない問題を修正

## Related
- #43 — Orchestrator に自動承認機能を組み込む
- #52 — configurable allowedTools for Worker per repository

## Test plan
- [ ] `spawn-worker.sh` で起動した Worker がパーミッション確認なしで正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)