### PR TITLE
docs: fix missed items in English conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This repository also serves as a Claude Code plugin marketplace.
 ## Conventions
 
 - Branch names: `issue/{number}-{short-description}`
-- Commit message titles in English, body may be in Japanese
+- Commit message titles in English, body preferably in English
 - PR body must include `closes #{issue-number}`
 - Worktrees are created under `.worktrees/` (already in .gitignore)
 - Commit messages follow conventional commits:

--- a/cekernel/.claude-plugin/plugin.json
+++ b/cekernel/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cekernel",
   "version": "0.7.1",
-  "description": "Claude Code 並列エージェント基盤。OS のプロセスモデルに倣い、issue を独立した Worker に分配・監視・回収する。",
+  "description": "Parallel agent infrastructure for Claude Code. Modeled after the OS process model, it distributes, monitors, and reaps issues via independent Workers.",
   "author": {
     "name": "clonable-eden"
   },

--- a/cekernel/CLAUDE.md
+++ b/cekernel/CLAUDE.md
@@ -248,7 +248,7 @@ The skill analyzes git log and recommends a bump level. After confirmation, it t
 Inherits from the root [CLAUDE.md](../CLAUDE.md):
 
 - Branch names: `issue/{number}-{short-description}`
-- Commit message titles in English, body may be in Japanese
+- Commit message titles in English, body preferably in English
 - PR body must include `closes #{issue-number}`
 
 ## Self-hosting

--- a/cekernel/agents/orchestrator.md
+++ b/cekernel/agents/orchestrator.md
@@ -4,7 +4,7 @@ description: Orchestrator agent that manages issue lifecycle in the main working
 tools: Read, Edit, Write, Bash
 ---
 
-# Orchestrator Agent (agent1)
+# Orchestrator Agent
 
 Operates in the main working tree and manages the issue lifecycle.
 

--- a/cekernel/agents/worker.md
+++ b/cekernel/agents/worker.md
@@ -4,7 +4,7 @@ description: Worker agent that handles implementation through merge for a single
 tools: Read, Edit, Write, Bash
 ---
 
-# Worker Agent (agent2+)
+# Worker Agent
 
 Operates within a git worktree and handles a single issue from implementation through merge.
 


### PR DESCRIPTION
closes #69

## Summary
- Convert `plugin.json` description from Japanese to English
- Remove legacy agent numbering (`(agent1)`, `(agent2+)`) from agent definition headings
- Update commit message convention: body preferably in English (was "may be in Japanese")
- Sync the same convention change in `cekernel/CLAUDE.md`

## Test Plan
- [x] All 124 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)