### PR TITLE
fix: update marketplace.json for cekernel rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
   },
   "plugins": [
     {
-      "name": "kernel",
-      "source": "./kernel",
+      "name": "cekernel",
+      "source": "./cekernel",
       "description": "Parallel agent infrastructure for Claude Code. Modeled after the OS process model, it distributes, monitors, and reaps issues via independent Workers.",
       "author": {
         "name": "clonable-eden"


### PR DESCRIPTION
closes #69

## Summary
- Update plugin `name` from `kernel` to `cekernel` in marketplace.json
- Update plugin `source` from `./kernel` to `./cekernel` in marketplace.json

This was missed during the kernel → cekernel rename, causing `/plugin install cekernel@clonable-eden-glimmer` to fail with "Plugin not found".

## Test Plan
- [x] `/plugin marketplace add clonable-eden/glimmer` + `/plugin install cekernel@clonable-eden-glimmer` should succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)