### PR TITLE
fix(cekernel): Lua イベントで Worker レイアウト構築し UI フリーズ防止

### DIFF
--- a/cekernel/docs/wezterm-events.lua
+++ b/cekernel/docs/wezterm-events.lua
@@ -1,0 +1,68 @@
+-- cekernel: Worker レイアウトを WezTerm Lua イベントで in-process 構築
+--
+-- このスニペットを ~/.config/wezterm/wezterm.lua の `return config` の前に追加してください。
+-- spawn-worker.sh が OSC user-var 経由でトリガーし、3 ペインレイアウトを
+-- GUI プロセス内部で構築します（IPC 7+ 回 → 3 回に削減、UI フリーズ防止）。
+--
+-- レイアウト:
+--   ┌──────────────┬──────────┐
+--   │  Claude Code │ Terminal │
+--   │   (60%)      │  (40%)   │
+--   ├──────────────┴──────────┤
+--   │  git log (25%)          │
+--   └─────────────────────────┘
+--
+-- デバッグ: Ctrl+Shift+L で WezTerm デバッグオーバーレイを開き、
+-- [cekernel] プレフィックスのログを確認できます。
+
+wezterm.on('user-var-changed', function(window, pane, name, value)
+  if name ~= 'cekernel_worker_layout' then
+    return
+  end
+
+  wezterm.log_info('[cekernel] worker layout triggered')
+
+  local ok, params = pcall(wezterm.json_parse, value)
+  if not ok then
+    wezterm.log_error('[cekernel] JSON parse failed: ' .. tostring(params))
+    return
+  end
+
+  local worktree = params.worktree or wezterm.home_dir
+  local session_id = params.session_id or ''
+  local prompt = params.prompt or ''
+  local issue_number = params.issue_number or ''
+
+  wezterm.log_info('[cekernel] issue=#' .. issue_number .. ' worktree=' .. worktree)
+
+  local main_pane = pane
+
+  -- 下部ペイン (25%): git log watch — top_level で全幅に
+  local bottom_pane = main_pane:split {
+    direction = 'Bottom',
+    size = 0.25,
+    cwd = worktree,
+    top_level = true,
+  }
+  bottom_pane:send_text("watch -n3 -t -c 'git --no-pager log --oneline --graph --color=always'\n")
+
+  -- 右ペイン (40%): 汎用ターミナル
+  main_pane:split {
+    direction = 'Right',
+    size = 0.4,
+    cwd = worktree,
+  }
+
+  -- メインペインに cd + export + claude コマンドを送信
+  -- shell 起動完了を待ってから send_text
+  wezterm.time.call_after(0.3, function()
+    main_pane:send_text(
+      "cd '" .. worktree .. "' && export CEKERNEL_SESSION_ID='" .. session_id .. "'\n"
+    )
+    if prompt ~= '' then
+      main_pane:send_text(prompt .. '\n')
+    end
+  end)
+
+  wezterm.log_info('[cekernel] layout complete: 3 panes created')
+end)

--- a/cekernel/scripts/orchestrator/spawn-worker.sh
+++ b/cekernel/scripts/orchestrator/spawn-worker.sh
@@ -134,19 +134,6 @@ echo "branch:   $BRANCH" >&2
 # Propagate CEKERNEL_SESSION_ID to Worker
 # Create Worker in the same workspace as Orchestrator
 WORKSPACE=$(terminal_resolve_workspace)
-MAIN_PANE=$(terminal_spawn_window "$WORKTREE" "$WORKSPACE")
-
-# Save pane ID (used by health-check / cleanup)
-echo "$MAIN_PANE" > "${CEKERNEL_IPC_DIR}/pane-${ISSUE_NUMBER}"
-# Explicit cd in case --cwd doesn't take effect reliably
-terminal_run_command "$MAIN_PANE" "cd '${WORKTREE}' && export CEKERNEL_SESSION_ID='${CEKERNEL_SESSION_ID}'"
-
-# Bottom: auto-refresh git log
-terminal_split_pane bottom 25 "$MAIN_PANE" "$WORKTREE" \
-  watch -n3 -t -c "git --no-pager log --oneline --graph --color=always"
-
-# Right: general-purpose terminal
-terminal_split_pane right 40 "$MAIN_PANE" "$WORKTREE"
 
 # Launch Claude Code in main pane
 # Initial prompt for Worker:
@@ -154,7 +141,19 @@ terminal_split_pane right 40 "$MAIN_PANE" "$WORKTREE"
 # 2. Follow kernel's protocol only for lifecycle (PR → CI → merge → notify)
 # 3. Follow the target repository's conventions for implementation
 PROMPT="Resolve issue #${ISSUE_NUMBER}. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run ${CLAUDE_PLUGIN_ROOT}/scripts/worker/notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>."
-terminal_run_command "$MAIN_PANE" "claude --agent cekernel:worker '${PROMPT}'"
+
+# Build JSON payload for Lua-side layout construction.
+# The wezterm.lua user-var-changed handler creates the 3-pane layout in-process,
+# reducing 7+ wezterm cli IPC calls to 3. See docs/wezterm-events.lua.
+LAYOUT_PAYLOAD=$(cat <<EOJSON
+{"worktree":"${WORKTREE}","session_id":"${CEKERNEL_SESSION_ID}","prompt":"claude --agent cekernel:worker '${PROMPT}'","issue_number":"${ISSUE_NUMBER}"}
+EOJSON
+)
+
+MAIN_PANE=$(terminal_spawn_worker_layout "$WORKTREE" "$WORKSPACE" "$LAYOUT_PAYLOAD")
+
+# Save pane ID (used by health-check / cleanup)
+echo "$MAIN_PANE" > "${CEKERNEL_IPC_DIR}/pane-${ISSUE_NUMBER}"
 
 # ── Record lifecycle event in log ──
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] SPAWN issue=#${ISSUE_NUMBER} branch=${BRANCH}" >> "$LOG_FILE"

--- a/cekernel/scripts/shared/terminal-adapter.sh
+++ b/cekernel/scripts/shared/terminal-adapter.sh
@@ -120,3 +120,28 @@ terminal_pane_alive() {
   local pane_id="$1"
   wezterm cli list --format json 2>/dev/null | grep -q "\"pane_id\":${pane_id}[,}]"
 }
+
+# terminal_spawn_worker_layout <cwd> <workspace> <json-payload>
+# Spawn a new window and trigger the Lua-side worker layout via OSC user-var.
+# This reduces 7+ wezterm cli IPC calls to 3 (spawn + send-text + Enter),
+# preventing UI freezes on macOS. See docs/wezterm-events.lua for the Lua handler.
+# stdout: main pane ID
+terminal_spawn_worker_layout() {
+  local cwd="$1"
+  local workspace="${2:-}"
+  local payload="$3"
+
+  # 1) Spawn window (IPC 1)
+  local pane_id
+  pane_id=$(terminal_spawn_window "$cwd" "$workspace")
+
+  # 2) Send OSC user-var to trigger Lua handler (IPC 2-3)
+  local payload_b64
+  payload_b64=$(printf '%s' "$payload" | base64)
+  local osc_cmd="printf '\\033]1337;SetUserVar=%s=%s\\007' cekernel_worker_layout '${payload_b64}'"
+  wezterm cli send-text --pane-id "$pane_id" -- "$osc_cmd"
+  sleep 0.1
+  wezterm cli send-text --pane-id "$pane_id" --no-paste $'\r'
+
+  echo "$pane_id"
+}


### PR DESCRIPTION
## Summary

- `spawn-worker.sh` の `wezterm cli` IPC 呼び出しを **7+ 回 → 3 回**に削減
- WezTerm Lua の `user-var-changed` イベントでレイアウト構築を GUI プロセス内部で実行
- `terminal-adapter.sh` に `terminal_spawn_worker_layout()` 関数を追加
- Lua イベントハンドラのスニペットを `docs/wezterm-events.lua` として同梱

## 変更の仕組み

**Before (7+ IPC):**
```
spawn-worker.sh → [socket] → GUI  ← spawn
spawn-worker.sh → [socket] → GUI  ← send-text (cd + export)
spawn-worker.sh → [socket] → GUI  ← send-text (Enter)
spawn-worker.sh → [socket] → GUI  ← split-pane (bottom)
spawn-worker.sh → [socket] → GUI  ← split-pane (right)
spawn-worker.sh → [socket] → GUI  ← send-text (claude)
spawn-worker.sh → [socket] → GUI  ← send-text (Enter)
```

**After (3 IPC):**
```
spawn-worker.sh → [socket] → GUI  ← spawn
spawn-worker.sh → [socket] → GUI  ← send-text (OSC user-var)
spawn-worker.sh → [socket] → GUI  ← send-text (Enter)
                              GUI内: pane:split()      ← IPC なし
                              GUI内: pane:split()      ← IPC なし
                              GUI内: pane:send_text()  ← IPC なし
```

## セットアップ

ユーザーは `docs/wezterm-events.lua` のスニペットを `~/.config/wezterm/wezterm.lua` に追加する必要あり。

## 動作検証

macOS + WezTerm (20240203-110809-5046fc22) で以下を確認済み:

### テスト 1: user-var-changed イベントの発火確認
既存ペイン内で OSC シーケンスを手動送信し、Lua ハンドラが発火することを確認:
```bash
PAYLOAD='{"worktree":"/tmp","session_id":"test","prompt":"echo hello","issue_number":"0"}'
PAYLOAD_B64=$(printf '%s' "$PAYLOAD" | base64)
wezterm cli send-text --pane-id <pane> -- "printf '\033]1337;SetUserVar=%s=%s\007' cekernel_worker_layout '$PAYLOAD_B64'"
wezterm cli send-text --pane-id <pane> --no-paste $'\r'
```
→ 3 ペイン (メイン / 右 / 下) が即座に作成された。`wezterm cli list` で pane_id が 3 つに増加。

### テスト 2: spawn + OSC の統合テスト
新ウィンドウ生成 → OSC user-var 送信 → Lua レイアウト構築の全フローを確認:
```bash
PANE_ID=$(wezterm cli spawn --new-window --cwd "$PWD")
wezterm cli send-text --pane-id "$PANE_ID" -- "<OSC command>"
wezterm cli send-text --pane-id "$PANE_ID" --no-paste $'\r'
```
→ 新ウィンドウに 3 ペインが作成、git log watch が下ペインで動作、**UI フリーズなし**。

### テスト 3: spawn 時の bash -c 内蔵 OSC（失敗ケース）
最初は `wezterm cli spawn -- bash -c "printf OSC...; exec bash"` で 1 IPC に収めようとしたが、
spawn 完了前に printf が実行されてしまい user-var イベントが捕捉されなかった。
→ spawn 後に外部から send-text する方式（3 IPC）に変更して解決。

### 確認結果
| 項目 | 結果 |
|------|------|
| 3 ペインレイアウト作成 | OK |
| git log watch (下ペイン) | OK |
| 汎用ターミナル (右ペイン) | OK |
| UI フリーズ | **なし** |
| Ctrl+Shift+L デバッグログ | `[cekernel]` ログ出力確認 |

## Test plan

- [x] `docs/wezterm-events.lua` を wezterm.lua に追加して hot-reload 確認
- [x] `/cekernel:orchestrate` で実際の issue を処理し Worker ウィンドウが 3 ペインで起動するか確認
- [x] UI フリーズが発生しないことを確認

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)