### PR TITLE
fix: escape single quotes in spawn-worker.sh prompt payload

### DIFF
--- a/cekernel/scripts/orchestrator/spawn-worker.sh
+++ b/cekernel/scripts/orchestrator/spawn-worker.sh
@@ -142,11 +142,14 @@ WORKSPACE=$(terminal_resolve_workspace)
 # 3. Follow the target repository's conventions for implementation
 PROMPT="Resolve issue #${ISSUE_NUMBER}. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run ${CLAUDE_PLUGIN_ROOT}/scripts/worker/notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>."
 
+# Escape single quotes for shell embedding: ' → '\''
+PROMPT_ESCAPED="${PROMPT//\'/\'\\\'\'}"
+
 # Build JSON payload for Lua-side layout construction.
 # The wezterm.lua user-var-changed handler creates the 3-pane layout in-process,
 # reducing 7+ wezterm cli IPC calls to 3. See docs/wezterm-events.lua.
 LAYOUT_PAYLOAD=$(cat <<EOJSON
-{"worktree":"${WORKTREE}","session_id":"${CEKERNEL_SESSION_ID}","prompt":"claude --agent cekernel:worker '${PROMPT}'","issue_number":"${ISSUE_NUMBER}"}
+{"worktree":"${WORKTREE}","session_id":"${CEKERNEL_SESSION_ID}","prompt":"claude --agent cekernel:worker '${PROMPT_ESCAPED}'","issue_number":"${ISSUE_NUMBER}"}
 EOJSON
 )
 


### PR DESCRIPTION
## Summary

- Fix Worker spawn failure caused by unescaped single quote in the prompt payload
- The prompt contains `repository's` — the `'` broke shell parsing when sent via WezTerm `send_text` to execute `claude --agent cekernel:worker '...'`
- Added `PROMPT_ESCAPED` variable using the standard `' → '\''` shell escaping pattern

## Test plan

- [x] `run-tests.sh` passes (no script behavior change, only payload escaping)
- [ ] Verify Workers spawn correctly via `/cekernel:orchestrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)