### PR TITLE
fix: terminal_pane_alive regex doesn't match WezTerm JSON whitespace

### DIFF
--- a/cekernel/scripts/shared/terminal-adapter.sh
+++ b/cekernel/scripts/shared/terminal-adapter.sh
@@ -118,7 +118,8 @@ terminal_kill_window() {
 # exit 0 if alive, exit 1 if dead
 terminal_pane_alive() {
   local pane_id="$1"
-  wezterm cli list --format json 2>/dev/null | grep -q "\"pane_id\":${pane_id}[,}]"
+  wezterm cli list --format json 2>/dev/null \
+    | jq -e --argjson target "$pane_id" 'any(.[]; .pane_id == $target)' >/dev/null 2>&1
 }
 
 # terminal_spawn_worker_layout <cwd> <workspace> <json-payload>

--- a/cekernel/tests/shared/test-terminal-adapter.sh
+++ b/cekernel/tests/shared/test-terminal-adapter.sh
@@ -194,10 +194,15 @@ else
 fi
 rm -f "$MOCK_LOG"
 
-# ── Test 13: terminal_pane_alive — alive ──
+# ── Test 13: terminal_pane_alive — alive (WezTerm JSON with spaces) ──
 wezterm() {
   if [[ "$1" == "cli" && "$2" == "list" ]]; then
-    echo '[{"pane_id":10},{"pane_id":20}]'
+    cat <<'MOCK_JSON'
+[
+  {"pane_id": 10, "window_id": 1, "workspace": "default"},
+  {"pane_id": 20, "window_id": 1, "workspace": "default"}
+]
+MOCK_JSON
   fi
 }
 export -f wezterm
@@ -216,6 +221,21 @@ if terminal_pane_alive "999"; then
 else
   echo "  PASS: pane_alive returns 1 for dead pane"
   ((TESTS_PASSED++)) || true
+fi
+
+# ── Test 15: terminal_pane_alive — compact JSON (no spaces) ──
+wezterm() {
+  if [[ "$1" == "cli" && "$2" == "list" ]]; then
+    echo '[{"pane_id":10},{"pane_id":20}]'
+  fi
+}
+export -f wezterm
+if terminal_pane_alive "10"; then
+  echo "  PASS: pane_alive handles compact JSON"
+  ((TESTS_PASSED++)) || true
+else
+  echo "  FAIL: pane_alive should handle compact JSON"
+  ((TESTS_FAILED++)) || true
 fi
 
 # ── Cleanup ──


### PR DESCRIPTION
## Summary

- Replace brittle `grep` pattern in `terminal_pane_alive` with `jq`-based JSON parsing to correctly handle WezTerm's JSON output format (space after colon: `"pane_id": 15`)
- Update test mock to use realistic multi-line WezTerm JSON and add a compact JSON test case for coverage

## Root Cause

The grep pattern `"pane_id":${pane_id}[,}]` expected no whitespace after the colon, but WezTerm outputs `"pane_id": 15` with a space. This caused live panes to be reported as dead/zombie.

## Fix

Use `jq -e --argjson target "$pane_id" 'any(.[]; .pane_id == $target)'` which properly parses JSON regardless of formatting. This is consistent with how `terminal_resolve_workspace` and `terminal_kill_window` already use `jq` in the same file.

## Test plan

- [x] All 24 terminal-adapter tests pass (including new Test 15 for compact JSON)
- [x] Full test suite passes (all categories: shared, orchestrator, worker)

Closes #94

Generated with [Claude Code](https://claude.com/claude-code)