### PR TITLE
fix: separate JSON and shell escaping in spawn-worker.sh payload

### DIFF
--- a/cekernel/docs/wezterm-events.lua
+++ b/cekernel/docs/wezterm-events.lua
@@ -60,7 +60,10 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
       "cd '" .. worktree .. "' && export CEKERNEL_SESSION_ID='" .. session_id .. "'\n"
     )
     if prompt ~= '' then
-      main_pane:send_text(prompt .. '\n')
+      -- シェルエスケープ: ' → '\''
+      local escaped = prompt:gsub("'", "'\\''")
+      local cmd = "claude --agent cekernel:worker '" .. escaped .. "'"
+      main_pane:send_text(cmd .. '\n')
     end
   end)
 

--- a/cekernel/scripts/orchestrator/spawn-worker.sh
+++ b/cekernel/scripts/orchestrator/spawn-worker.sh
@@ -142,15 +142,17 @@ WORKSPACE=$(terminal_resolve_workspace)
 # 3. Follow the target repository's conventions for implementation
 PROMPT="Resolve issue #${ISSUE_NUMBER}. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run ${CLAUDE_PLUGIN_ROOT}/scripts/worker/notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>."
 
-# Escape single quotes for shell embedding: ' → '\''
-PROMPT_ESCAPED="${PROMPT//\'/\'\\\'\'}"
-
 # Build JSON payload for Lua-side layout construction.
 # The wezterm.lua user-var-changed handler creates the 3-pane layout in-process,
 # reducing 7+ wezterm cli IPC calls to 3. See docs/wezterm-events.lua.
-LAYOUT_PAYLOAD=$(cat <<EOJSON
-{"worktree":"${WORKTREE}","session_id":"${CEKERNEL_SESSION_ID}","prompt":"claude --agent cekernel:worker '${PROMPT_ESCAPED}'","issue_number":"${ISSUE_NUMBER}"}
-EOJSON
+# Raw prompt is passed to JSON via jq (no shell escaping needed here).
+# The Lua handler is responsible for shell escaping when constructing the command.
+LAYOUT_PAYLOAD=$(jq -n \
+  --arg worktree "$WORKTREE" \
+  --arg session_id "$CEKERNEL_SESSION_ID" \
+  --arg prompt "$PROMPT" \
+  --arg issue_number "$ISSUE_NUMBER" \
+  '{worktree: $worktree, session_id: $session_id, prompt: $prompt, issue_number: $issue_number}'
 )
 
 MAIN_PANE=$(terminal_spawn_worker_layout "$WORKTREE" "$WORKSPACE" "$LAYOUT_PAYLOAD")


### PR DESCRIPTION
## Summary

- PR #92 の single-quote エスケープ修正が JSON ペイロードを壊していた
- `'\''` パターンのバックスラッシュが JSON の `Invalid \escape` を引き起こし、Lua `json_parse` が失敗 → Worker の 3ペインレイアウトが作られない問題
- 関心の分離で修正: bash 側は `jq` で valid JSON を生成、Lua 側でシェルエスケープを担当

## Changes

- **`spawn-worker.sh`**: heredoc による手動 JSON 構築を `jq` に置換。生の prompt（シェルエスケープなし）を渡す
- **`wezterm-events.lua`**: `prompt:gsub("'", "'\\''")` で Lua 側でシェルエスケープし `claude --agent` コマンドを構築

closes #93

## Test plan

- [x] `run-tests.sh` all pass
- [x] ローカルで Worker spawn → 3ペインレイアウト作成 → claude コマンド実行を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)