### PR TITLE
feat: wire env profile integration and add --env UX to orchestrate skill

### DIFF
--- a/cekernel/agents/orchestrator.md
+++ b/cekernel/agents/orchestrator.md
@@ -44,13 +44,36 @@ export CEKERNEL_SESSION_ID=glimmer-7861a821 && ${CLAUDE_PLUGIN_ROOT}/scripts/orc
 export CEKERNEL_SESSION_ID=glimmer-7861a821 && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/cleanup-worktree.sh 4
 ```
 
+### CEKERNEL_ENV (Env Profile) Propagation
+
+When the `/orchestrate` skill specifies `--env <profile>`, the Orchestrator must propagate `CEKERNEL_ENV` to all `spawn-worker.sh` invocations. `spawn-worker.sh` sources `load-env.sh` which reads the profile and exports the configured variables.
+
+If no `--env` is specified, `CEKERNEL_ENV` defaults to `default` (handled by `load-env.sh`).
+
+```bash
+# Example: propagate headless profile to spawn-worker.sh
+export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_ENV=headless && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
+```
+
+The propagation chain:
+
+```
+/cekernel:orchestrate --env headless #108
+  → skill: parses --env, includes CEKERNEL_ENV=headless in orchestrator prompt
+    → orchestrator: passes export CEKERNEL_ENV=headless before spawn-worker.sh
+      → spawn-worker.sh: sources load-env.sh → loads headless.env
+        → env vars (CEKERNEL_BACKEND, CEKERNEL_MAX_WORKERS, etc.) are set
+```
+
+Available profiles: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`. See `envs/README.md` for details.
+
 ### Single Issue Processing
 
 ```bash
-# CEKERNEL_SESSION_ID generated beforehand
+# CEKERNEL_SESSION_ID and CEKERNEL_ENV determined beforehand
 
-# 1. Spawn Worker
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
+# 1. Spawn Worker (CEKERNEL_ENV propagates to load-env.sh inside spawn-worker.sh)
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
 
 # 2. Monitor completion in background (Bash run_in_background: true)
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 4
@@ -69,14 +92,14 @@ While the background task is running, periodically execute `worker-status.sh` (s
 ### Parallel Multi-Issue Processing
 
 ```bash
-# CEKERNEL_SESSION_ID generated beforehand
+# CEKERNEL_SESSION_ID and CEKERNEL_ENV determined beforehand
 
 # 1. Spawn Workers and watch each individually in background (Bash run_in_background: true)
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 5  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 6
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 6
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 6  # run_in_background: true
 
 # 2. While waiting, periodically check and report status
@@ -139,18 +162,18 @@ This keeps the number of active Workers at `MAX_WORKERS` at all times, maximizin
 # Queue (sorted by priority): [4(critical), 6(high), 5(normal), 7(normal), 8(low), 9(low)]
 
 # Initial: spawn first 3 (highest priority), each watched individually in background
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority critical 4
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority critical 4
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority high 6
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority high 6
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 6  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 5  # run_in_background: true
 # Queue remaining: [7(normal), 8(low), 9(low)]
 
 # Worker 6 completes (background notification arrives)
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/cleanup-worktree.sh 6
 # Spawn next highest-priority from queue
-export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 7
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 7
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 7  # run_in_background: true
 # Queue remaining: [8(low), 9(low)]
 

--- a/cekernel/docs/adr/0006-env-var-catalog-and-profiles.md
+++ b/cekernel/docs/adr/0006-env-var-catalog-and-profiles.md
@@ -193,6 +193,41 @@ Rejected:
 
 Loading once at the Orchestrator level propagates to all child scripts via the environment. Loading in every script is redundant and risks inconsistency if scripts source different profiles. The Orchestrator is the natural configuration boundary — it's where the session begins.
 
+## Integration Points
+
+### Propagation Chain
+
+The env profile mechanism requires wiring at specific points in the execution chain:
+
+```
+/cekernel:orchestrate --env headless #108
+  → skill (SKILL.md): parses --env argument, defaults to "default"
+    → skill includes CEKERNEL_ENV=headless in orchestrator agent prompt
+      → orchestrator agent: passes export CEKERNEL_ENV=headless before spawn-worker.sh
+        → spawn-worker.sh: sources load-env.sh early (before other shared helpers)
+          → load-env.sh: reads headless.env, exports CEKERNEL_BACKEND=headless etc.
+            → remaining spawn-worker.sh logic uses configured values
+```
+
+### Scripts That Source `load-env.sh`
+
+| Script | Role | Why |
+|--------|------|-----|
+| `spawn-worker.sh` | Only integration point | All user-configurable vars are consumed by Orchestrator-side scripts. Loading once at spawn time propagates to backend-adapter, concurrency guard, etc. via the environment. |
+
+`load-env.sh` is sourced immediately after `session-id.sh` and before other shared helpers, ensuring that profile values are available when `backend-adapter.sh`, `worker-state.sh`, etc. are loaded.
+
+### Why Not Load in Other Scripts
+
+Per the "Key observation" in the Context section, all user-configurable variables are consumed by Orchestrator-side scripts. Worker agents inherit only `CEKERNEL_SESSION_ID`. Therefore:
+
+- `watch-worker.sh`, `cleanup-worktree.sh`, `health-check.sh` — These run in the Orchestrator's shell where `CEKERNEL_ENV` is already exported. They use `${VAR:-default}` which is sufficient since `spawn-worker.sh` already set the environment.
+- Worker-side scripts — Do not need profile loading; they only use `CEKERNEL_SESSION_ID`.
+
+### Skill UX
+
+The `/cekernel:orchestrate` skill accepts `--env <profile>` as an optional argument (via `argument-hint` frontmatter). When unspecified, `default` is used. The skill passes the profile name to the Orchestrator agent's prompt, which in turn exports it before each `spawn-worker.sh` call.
+
 ## Consequences
 
 ### Positive

--- a/cekernel/scripts/orchestrator/spawn-worker.sh
+++ b/cekernel/scripts/orchestrator/spawn-worker.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
 source "${SCRIPT_DIR}/../shared/session-id.sh"
+source "${SCRIPT_DIR}/../shared/load-env.sh"
 source "${SCRIPT_DIR}/../shared/claude-json-helper.sh"
 source "${SCRIPT_DIR}/../shared/backend-adapter.sh"
 source "${SCRIPT_DIR}/../shared/worker-state.sh"

--- a/cekernel/skills/orchestrate/SKILL.md
+++ b/cekernel/skills/orchestrate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: Delegate issues to the Orchestrator agent for parallel processing after priority assessment
+argument-hint: "[--env profile] <issue-numbers>"
 allowed-tools: Bash, Read, Task(cekernel:orchestrator)
 ---
 
@@ -10,6 +11,18 @@ Delegates specified issues to the Orchestrator agent for parallel processing usi
 ## Usage
 
 Receive issue numbers (single or multiple) from the user.
+
+Optional flags:
+
+- `--env <profile>` — Select an env profile (default: `default`). Available profiles: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`.
+
+Examples:
+
+```
+/cekernel:orchestrate #108
+/cekernel:orchestrate --env headless #108 #109
+/cekernel:orchestrate --env ci #42
+```
 
 ## Workflow
 
@@ -27,18 +40,27 @@ For multiple issues, additionally:
 3. Analyze dependencies between issues (does completing A require B to finish first?)
 4. If dependencies exist, organize into phases and present the execution order to the user for confirmation
 
-### Step 2: Launch Orchestrator Agent
+### Step 2: Parse `--env` and Launch Orchestrator Agent
+
+If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
 
 Launch the `cekernel:orchestrator` subagent via the Task tool:
 
 - `subagent_type`: `cekernel:orchestrator`
 - `run_in_background`: `true`
-- `prompt`: Include issue numbers, base branch (if specified), and execution order (if determined in Step 1)
+- `prompt`: Include issue numbers, base branch (if specified), execution order (if determined in Step 1), and `CEKERNEL_ENV` value. Instruct the Orchestrator to pass `export CEKERNEL_ENV=<profile>` in all `spawn-worker.sh` invocations.
+
+Example prompt fragment:
+
+```
+Use CEKERNEL_ENV=headless when spawning workers:
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=headless && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 108
+```
 
 The Orchestrator autonomously executes:
 
 1. Issue verification and triage (FAIL for ambiguous issues)
-2. Worker spawning
+2. Worker spawning (with `CEKERNEL_ENV` propagated)
 3. Completion monitoring
 4. Cleanup
 


### PR DESCRIPTION
closes #114

## Summary
- Wire `load-env.sh` into `spawn-worker.sh` so env profiles (default.env, headless.env, ci.env) are actually loaded at spawn time
- Add `argument-hint` frontmatter and `--env <profile>` argument support to `/cekernel:orchestrate` SKILL.md
- Document the full `CEKERNEL_ENV` propagation chain (skill → orchestrator → spawn-worker → load-env.sh) in `orchestrator.md`
- Add Integration Points section to ADR-0006 describing which scripts source `load-env.sh`, why only `spawn-worker.sh`, and the skill UX design

## Test Plan
- [x] All 233 existing tests pass (including 8 load-env.sh tests)
- [x] `spawn-worker.sh` sources `load-env.sh` after `session-id.sh` and before other shared helpers
- [x] SKILL.md has `argument-hint` frontmatter for discoverability
- [x] ADR-0006 documents the propagation chain end-to-end