### PR TITLE
fix: unset CLAUDECODE env and add -p flag in headless backend

### DIFF
--- a/cekernel/scripts/shared/backends/headless.sh
+++ b/cekernel/scripts/shared/backends/headless.sh
@@ -34,10 +34,14 @@ backend_spawn_worker() {
   # Bash creates a new process group for background jobs automatically,
   # so kill -- -$PID can terminate the entire group.
   # SESSION_ID is propagated as a direct environment variable.
+  # Unset Claude Code session markers to avoid nested-session detection.
+  # Use -p (print mode) for non-TTY execution.
+  # NOTE: -p may hang without TTY due to upstream bug (claude-code#9026).
   (
     cd "$worktree" && \
+    unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT && \
     CEKERNEL_SESSION_ID="${CEKERNEL_SESSION_ID:-}" \
-    exec claude --agent cekernel:worker "$prompt"
+    exec claude -p --agent cekernel:worker "$prompt"
   ) > "$log_file" 2>&1 &
   local pid=$!
 


### PR DESCRIPTION
related to #117

## Summary
- `headless.sh` の `backend_spawn_worker` で `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` を unset してネストセッション検知を回避
- `-p` (print mode) フラグを追加して非 TTY 環境での実行に対応
- upstream の claude-code#9026 により `-p` でもハングする可能性があるため、完全な修正ではない

## Test plan
- [ ] headless バックエンドで Worker が起動することを確認
- [ ] 既存テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)