### PR TITLE
feat: resolve agent names dynamically based on plugin mode

### DIFF
--- a/cekernel/README.md
+++ b/cekernel/README.md
@@ -215,7 +215,8 @@ Worker / Orchestrator agent definitions have `tools` configured, granting access
 | `Write` | File writing |
 | `Bash` | All Bash commands including git, gh, shell scripts |
 
-`spawn-worker.sh` launches Workers with `claude --agent cekernel:worker`.
+`spawn-worker.sh` launches Workers with `claude --agent ${CEKERNEL_AGENT_WORKER}`.
+The agent name is resolved dynamically: `cekernel:worker` in plugin mode, `worker` in local mode.
 The `--agent` flag applies the agent definition's `tools`.
 
 Tool auto-approval (without permission prompts) is delegated to the target repository's `.claude/settings.json`.

--- a/cekernel/agents/orchestrator.md
+++ b/cekernel/agents/orchestrator.md
@@ -44,6 +44,17 @@ export CEKERNEL_SESSION_ID=glimmer-7861a821 && ${CLAUDE_PLUGIN_ROOT}/scripts/orc
 export CEKERNEL_SESSION_ID=glimmer-7861a821 && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/cleanup-worktree.sh 4
 ```
 
+### CEKERNEL_AGENT_WORKER Propagation
+
+When the `/orchestrate` skill detects plugin mode (`CLAUDE_PLUGIN_ROOT` is set), it determines the correct agent name (`cekernel:worker` for plugin mode, `worker` for local mode) and passes `CEKERNEL_AGENT_WORKER` to the Orchestrator. The Orchestrator must propagate this to all `spawn-worker.sh` invocations.
+
+```bash
+# Example: propagate agent name to spawn-worker.sh
+export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_AGENT_WORKER=cekernel:worker && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
+```
+
+`spawn-worker.sh` defaults `CEKERNEL_AGENT_WORKER` to `worker` if unset, ensuring safe fallback for direct execution.
+
 ### CEKERNEL_ENV (Env Profile) Propagation
 
 When the `/orchestrate` skill specifies `--env <profile>`, the Orchestrator must propagate `CEKERNEL_ENV` to all `spawn-worker.sh` invocations. `spawn-worker.sh` sources `load-env.sh` which reads the profile and exports the configured variables.
@@ -70,10 +81,10 @@ Available profiles: `default`, `headless`, `ci`, or any custom profile in `.ceke
 ### Single Issue Processing
 
 ```bash
-# CEKERNEL_SESSION_ID and CEKERNEL_ENV determined beforehand
+# CEKERNEL_SESSION_ID, CEKERNEL_ENV, and CEKERNEL_AGENT_WORKER determined beforehand
 
 # 1. Spawn Worker (CEKERNEL_ENV propagates to load-env.sh inside spawn-worker.sh)
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
 
 # 2. Monitor completion in background (Bash run_in_background: true)
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 4
@@ -92,14 +103,14 @@ While the background task is running, periodically execute `worker-status.sh` (s
 ### Parallel Multi-Issue Processing
 
 ```bash
-# CEKERNEL_SESSION_ID and CEKERNEL_ENV determined beforehand
+# CEKERNEL_SESSION_ID, CEKERNEL_ENV, and CEKERNEL_AGENT_WORKER determined beforehand
 
 # 1. Spawn Workers and watch each individually in background (Bash run_in_background: true)
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 4
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 5  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 6
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 6
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 6  # run_in_background: true
 
 # 2. While waiting, periodically check and report status
@@ -162,18 +173,18 @@ This keeps the number of active Workers at `MAX_WORKERS` at all times, maximizin
 # Queue (sorted by priority): [4(critical), 6(high), 5(normal), 7(normal), 8(low), 9(low)]
 
 # Initial: spawn first 3 (highest priority), each watched individually in background
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority critical 4
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority critical 4
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority high 6
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh --priority high 6
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 6  # run_in_background: true
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 5
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 5  # run_in_background: true
 # Queue remaining: [7(normal), 8(low), 9(low)]
 
 # Worker 6 completes (background notification arrives)
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/cleanup-worktree.sh 6
 # Spawn next highest-priority from queue
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 7
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKERNEL_AGENT_WORKER=<agent-name> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 7
 export CEKERNEL_SESSION_ID=<ID> && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/watch-worker.sh 7  # run_in_background: true
 # Queue remaining: [8(low), 9(low)]
 
@@ -213,7 +224,8 @@ Specifically, the following are under the target repository's authority, and nei
 - Merge strategy (`--merge`, `--squash`, `--rebase`)
 - Branch naming conventions
 
-spawn-worker.sh launches Workers with `claude --agent cekernel:worker`.
+spawn-worker.sh launches Workers with `claude --agent ${CEKERNEL_AGENT_WORKER}`.
+The agent name is determined by the `/orchestrate` skill: `cekernel:worker` in plugin mode, `worker` in local mode.
 The `--agent` flag applies the Worker agent definition's `tools`,
 enabling autonomous execution without permission prompts.
 

--- a/cekernel/config/wezterm.cekernel.lua
+++ b/cekernel/config/wezterm.cekernel.lua
@@ -36,6 +36,7 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
   local session_id = params.session_id or ''
   local prompt = params.prompt or ''
   local issue_number = params.issue_number or ''
+  local agent_name = params.agent_name or 'worker'
 
   wezterm.log_info('[cekernel] issue=#' .. issue_number .. ' worktree=' .. worktree)
 
@@ -66,7 +67,7 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
     if prompt ~= '' then
       -- Shell escape: ' → '\''
       local escaped = prompt:gsub("'", "'\\''")
-      local cmd = "claude --agent cekernel:worker '" .. escaped .. "'"
+      local cmd = "claude --agent " .. agent_name .. " '" .. escaped .. "'"
       main_pane:send_text(cmd .. '\n')
     end
   end)

--- a/cekernel/scripts/orchestrator/spawn-worker.sh
+++ b/cekernel/scripts/orchestrator/spawn-worker.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+CEKERNEL_AGENT_WORKER="${CEKERNEL_AGENT_WORKER:-worker}"
 source "${SCRIPT_DIR}/../shared/session-id.sh"
 source "${SCRIPT_DIR}/../shared/load-env.sh"
 source "${SCRIPT_DIR}/../shared/claude-json-helper.sh"

--- a/cekernel/scripts/shared/backends/headless.sh
+++ b/cekernel/scripts/shared/backends/headless.sh
@@ -41,7 +41,7 @@ backend_spawn_worker() {
     cd "$worktree" && \
     unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT && \
     CEKERNEL_SESSION_ID="${CEKERNEL_SESSION_ID:-}" \
-    exec claude -p --agent cekernel:worker "$prompt"
+    exec claude -p --agent "${CEKERNEL_AGENT_WORKER:-worker}" "$prompt"
   ) > "$log_file" 2>&1 &
   local pid=$!
 

--- a/cekernel/scripts/shared/backends/tmux.sh
+++ b/cekernel/scripts/shared/backends/tmux.sh
@@ -36,7 +36,7 @@ backend_spawn_worker() {
   _backend_split_pane bottom 25 "$main_pane" "$worktree" 2>/dev/null || true
 
   # Send Claude command to main pane
-  local claude_cmd="CEKERNEL_SESSION_ID='${CEKERNEL_SESSION_ID:-}' claude --agent cekernel:worker '${prompt}'"
+  local claude_cmd="CEKERNEL_SESSION_ID='${CEKERNEL_SESSION_ID:-}' claude --agent ${CEKERNEL_AGENT_WORKER:-worker} '${prompt}'"
   _backend_run_command "$main_pane" "$claude_cmd"
 
   # Save handle (pane target)

--- a/cekernel/scripts/shared/backends/wezterm.sh
+++ b/cekernel/scripts/shared/backends/wezterm.sh
@@ -31,7 +31,8 @@ backend_spawn_worker() {
     --arg session_id "${CEKERNEL_SESSION_ID:-}" \
     --arg prompt "$prompt" \
     --arg issue_number "$issue" \
-    '{worktree: $worktree, session_id: $session_id, prompt: $prompt, issue_number: $issue_number}'
+    --arg agent_name "${CEKERNEL_AGENT_WORKER:-worker}" \
+    '{worktree: $worktree, session_id: $session_id, prompt: $prompt, issue_number: $issue_number, agent_name: $agent_name}'
   )
 
   # Spawn window (IPC 1)

--- a/cekernel/skills/orchestrate/SKILL.md
+++ b/cekernel/skills/orchestrate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Delegate issues to the Orchestrator agent for parallel processing after priority assessment
 argument-hint: "[--env profile] <issue-numbers>"
-allowed-tools: Bash, Read, Task(cekernel:orchestrator)
+allowed-tools: Bash, Read, Task(cekernel:orchestrator), Task(orchestrator)
 ---
 
 # /orchestrate
@@ -26,6 +26,21 @@ Examples:
 
 ## Workflow
 
+### Step 0: Detect Agent Names
+
+Determine whether cekernel is running as a plugin (with namespace prefix) or locally (without prefix).
+
+Run the following Bash command:
+
+```bash
+test -n "${CLAUDE_PLUGIN_ROOT:-}" && echo "plugin" || echo "local"
+```
+
+- If `plugin`: `CEKERNEL_AGENT_ORCHESTRATOR=cekernel:orchestrator`, `CEKERNEL_AGENT_WORKER=cekernel:worker`
+- If `local`: `CEKERNEL_AGENT_ORCHESTRATOR=orchestrator`, `CEKERNEL_AGENT_WORKER=worker`
+
+Store these values for use in subsequent steps.
+
 ### Step 1: Issue Triage and Priority Assessment
 
 Check each issue's content with `gh issue view` and verify:
@@ -44,17 +59,17 @@ For multiple issues, additionally:
 
 If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
 
-Launch the `cekernel:orchestrator` subagent via the Task tool:
+Launch the Orchestrator subagent via the Task tool:
 
-- `subagent_type`: `cekernel:orchestrator`
+- `subagent_type`: Use `CEKERNEL_AGENT_ORCHESTRATOR` determined in Step 0
 - `run_in_background`: `true`
-- `prompt`: Include issue numbers, base branch (if specified), execution order (if determined in Step 1), and `CEKERNEL_ENV` value. Instruct the Orchestrator to pass `export CEKERNEL_ENV=<profile>` in all `spawn-worker.sh` invocations.
+- `prompt`: Include issue numbers, base branch (if specified), execution order (if determined in Step 1), `CEKERNEL_ENV` value, and `CEKERNEL_AGENT_WORKER` value. Instruct the Orchestrator to pass `export CEKERNEL_ENV=<profile>` and `export CEKERNEL_AGENT_WORKER=<agent-name>` in all `spawn-worker.sh` invocations.
 
 Example prompt fragment:
 
 ```
-Use CEKERNEL_ENV=headless when spawning workers:
-export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=headless && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 108
+Use CEKERNEL_ENV=headless and CEKERNEL_AGENT_WORKER=cekernel:worker when spawning workers:
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=headless && export CEKERNEL_AGENT_WORKER=cekernel:worker && ${CLAUDE_PLUGIN_ROOT}/scripts/orchestrator/spawn-worker.sh 108
 ```
 
 The Orchestrator autonomously executes:

--- a/cekernel/tests/orchestrator/test-agent-name-resolution.sh
+++ b/cekernel/tests/orchestrator/test-agent-name-resolution.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# test-agent-name-resolution.sh — Tests for dynamic agent name resolution
+#
+# Verifies that backends use CEKERNEL_AGENT_WORKER when set,
+# and default to 'worker' when unset.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "test: agent-name-resolution"
+
+# ── Test session ──
+export CEKERNEL_SESSION_ID="test-agent-name-001"
+source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+rm -rf "$CEKERNEL_IPC_DIR"
+mkdir -p "$CEKERNEL_IPC_DIR"
+mkdir -p "${CEKERNEL_IPC_DIR}/logs"
+
+# ── Test 1: spawn-worker.sh defaults CEKERNEL_AGENT_WORKER to 'worker' when unset ──
+# Source only the top portion to check the variable resolution
+(
+  unset CEKERNEL_AGENT_WORKER
+  SCRIPT_DIR_SW="$(cd "${CEKERNEL_DIR}/scripts/orchestrator" && pwd)"
+  CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR_SW}/../.." && pwd)}"
+  CEKERNEL_AGENT_WORKER="${CEKERNEL_AGENT_WORKER:-worker}"
+  echo "$CEKERNEL_AGENT_WORKER"
+) | {
+  read -r result
+  assert_eq "CEKERNEL_AGENT_WORKER defaults to 'worker' when unset" "worker" "$result"
+}
+
+# ── Test 2: spawn-worker.sh uses CEKERNEL_AGENT_WORKER when set ──
+(
+  export CEKERNEL_AGENT_WORKER="cekernel:worker"
+  SCRIPT_DIR_SW="$(cd "${CEKERNEL_DIR}/scripts/orchestrator" && pwd)"
+  CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SCRIPT_DIR_SW}/../.." && pwd)}"
+  CEKERNEL_AGENT_WORKER="${CEKERNEL_AGENT_WORKER:-worker}"
+  echo "$CEKERNEL_AGENT_WORKER"
+) | {
+  read -r result
+  assert_eq "CEKERNEL_AGENT_WORKER preserves 'cekernel:worker' when set" "cekernel:worker" "$result"
+}
+
+# ── Test 3: headless backend uses CEKERNEL_AGENT_WORKER in claude command ──
+# Create a mock claude that records its arguments
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP" "$CEKERNEL_IPC_DIR" 2>/dev/null || true' EXIT
+
+MOCK_BIN="${TEST_TMP}/mock-bin"
+mkdir -p "$MOCK_BIN"
+cat > "${MOCK_BIN}/claude" <<'MOCK_SCRIPT'
+#!/usr/bin/env bash
+# Record args to a file, then sleep
+echo "$@" > "${CEKERNEL_AGENT_ARGS_FILE:-/dev/null}"
+sleep 300
+MOCK_SCRIPT
+chmod +x "${MOCK_BIN}/claude"
+
+OLD_PATH="$PATH"
+export PATH="${MOCK_BIN}:${PATH}"
+
+# ── Test 3a: headless backend with CEKERNEL_AGENT_WORKER=cekernel:worker ──
+export CEKERNEL_BACKEND=headless
+export CEKERNEL_AGENT_WORKER="cekernel:worker"
+ARGS_FILE="${TEST_TMP}/args-3a.txt"
+export CEKERNEL_AGENT_ARGS_FILE="$ARGS_FILE"
+source "${CEKERNEL_DIR}/scripts/shared/backend-adapter.sh"
+
+ISSUE="600"
+WORKTREE="${TEST_TMP}/worktree"
+mkdir -p "$WORKTREE"
+
+backend_spawn_worker "$ISSUE" "$WORKTREE" "test prompt"
+sleep 0.3
+
+if [[ -f "$ARGS_FILE" ]]; then
+  ARGS=$(cat "$ARGS_FILE")
+  assert_match "headless uses CEKERNEL_AGENT_WORKER=cekernel:worker" "cekernel:worker" "$ARGS"
+else
+  echo "  FAIL: headless backend did not record claude args"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+backend_kill_worker "$ISSUE" 2>/dev/null || true
+sleep 0.2
+wait 2>/dev/null || true
+
+# ── Test 3b: headless backend with CEKERNEL_AGENT_WORKER=worker (default) ──
+export CEKERNEL_AGENT_WORKER="worker"
+ARGS_FILE="${TEST_TMP}/args-3b.txt"
+export CEKERNEL_AGENT_ARGS_FILE="$ARGS_FILE"
+
+ISSUE2="601"
+backend_spawn_worker "$ISSUE2" "$WORKTREE" "test prompt 2"
+sleep 0.3
+
+if [[ -f "$ARGS_FILE" ]]; then
+  ARGS=$(cat "$ARGS_FILE")
+  assert_match "headless uses CEKERNEL_AGENT_WORKER=worker" "--agent worker" "$ARGS"
+else
+  echo "  FAIL: headless backend did not record claude args (default)"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+backend_kill_worker "$ISSUE2" 2>/dev/null || true
+sleep 0.2
+wait 2>/dev/null || true
+
+# ── Test 4: tmux backend command contains CEKERNEL_AGENT_WORKER ──
+# We can't test tmux without tmux running, so verify the code path by sourcing
+# and checking the command string construction.
+# Instead, grep the tmux backend source for the variable reference.
+if grep -q 'CEKERNEL_AGENT_WORKER' "${CEKERNEL_DIR}/scripts/shared/backends/tmux.sh"; then
+  echo "  PASS: tmux backend references CEKERNEL_AGENT_WORKER"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: tmux backend should reference CEKERNEL_AGENT_WORKER"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 5: WezTerm backend JSON payload includes agent_name ──
+if grep -q 'agent_name' "${CEKERNEL_DIR}/scripts/shared/backends/wezterm.sh"; then
+  echo "  PASS: wezterm backend includes agent_name in payload"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: wezterm backend should include agent_name in JSON payload"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 6: WezTerm Lua reads agent_name from params ──
+if grep -q 'agent_name' "${CEKERNEL_DIR}/config/wezterm.cekernel.lua"; then
+  echo "  PASS: wezterm lua reads agent_name from params"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: wezterm lua should read agent_name from params"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Restore PATH ──
+PATH="$OLD_PATH"
+
+# ── Cleanup ──
+rm -rf "$CEKERNEL_IPC_DIR"
+
+report_results


### PR DESCRIPTION
## Summary

- Skill layer (SKILL.md) detects plugin vs local mode via `CLAUDE_PLUGIN_ROOT` and determines correct agent names (`cekernel:worker` / `worker`)
- `CEKERNEL_AGENT_WORKER` propagates from skill → orchestrator → spawn-worker.sh → backends (headless, tmux, wezterm)
- All hardcoded `cekernel:worker` references in backend scripts and WezTerm Lua replaced with dynamic resolution (defensive default: `worker`)

closes #128

## Test plan

- [x] New test `test-agent-name-resolution.sh` verifies default fallback, explicit value, headless backend behavior, and source-level checks for tmux/wezterm backends
- [x] All existing tests pass (1 pre-existing flaky test `test-session-isolation.sh` unrelated to this change)
- [x] `grep cekernel:worker cekernel/scripts/` returns no matches — no hardcoded agent names remain in scripts
- [x] `grep cekernel:worker cekernel/config/` returns no matches — WezTerm Lua uses `params.agent_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)