### PR TITLE
feat: wire ADR-0008 scheduling policy into agent prompts

### DIFF
--- a/cekernel/agents/orchestrator.md
+++ b/cekernel/agents/orchestrator.md
@@ -238,7 +238,7 @@ export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=<profile> && export CEKER
 export CEKERNEL_SESSION_ID=<ID> && watch-worker.sh <issue>  # run_in_background: true
 ```
 
-**IMPORTANT**: Do NOT call `cleanup-worktree.sh` on the suspended Worker — its worktree must be preserved for future resume. The SUSPEND-ed Worker's completion notification (status: `cancelled`, detail: `"SUSPEND signal received"`) indicates that the issue should be added to the **Suspended Issues List** for auto-resume.
+**IMPORTANT**: Do NOT call `cleanup-worktree.sh` on a successfully suspended Worker — its worktree must be preserved for future resume. If the Worker fails to exit after escalation (step 5 above), `cleanup-worktree.sh --force` is the last resort and the worktree is no longer recoverable. The SUSPEND-ed Worker's completion notification (status: `cancelled`, detail: `"SUSPEND signal received"`) indicates that the issue should be added to the **Suspended Issues List** for auto-resume.
 
 **Example**:
 

--- a/cekernel/agents/worker.md
+++ b/cekernel/agents/worker.md
@@ -139,7 +139,7 @@ Write state at the **start** of each phase:
 
 | Phase | State | Detail | When |
 |---|---|---|---|
-| Phase 0 | RUNNING | `phase0:plan` | Before reading issue and posting plan |
+| Phase 0 | RUNNING | `phase0:plan` | Before posting execution plan |
 | Phase 1 | RUNNING | `phase1:implement` | Before starting implementation |
 | Phase 2 | RUNNING | `phase2:create-pr` | Before `git push` and `gh pr create` |
 | Phase 3 (CI wait) | WAITING | `phase3:ci-waiting` | Before `gh pr checks --watch` |


### PR DESCRIPTION
closes clonable-eden/cekernel#124

## Summary

- **worker.md**: State Reporting セクション新設 + 各フェーズ境界に `worker_state_write` の blockquote reminder 追加（ADR-0008 Decision 5）
- **orchestrator.md**: Environment Variables テーブル、Preemption（Decision 3）、Auto-Resume（Decision 4）、graceful shutdown（Decision 2）を追加。Queuing Rules に FIFO タイブレーク・SUSPENDED 対応を反映
- ADR-0008 Decision 1-5 が全てエージェントプロンプトに配線済み

## Test plan

- [x] `cekernel/tests/run-tests.sh` pass（プロンプトのみ変更のため既存テストに影響なし）
- [x] Markdown フォーマットが既存スタイルと統一されていることを目視確認
- [ ] コマンド例が `${CLAUDE_PLUGIN_ROOT}` なしのスクリプト名のみパターンに統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)