### PR TITLE
docs: add ADR-0009 file-based namespace detection

### DIFF
--- a/cekernel/docs/adr/0009-file-based-namespace-detection.md
+++ b/cekernel/docs/adr/0009-file-based-namespace-detection.md
@@ -170,7 +170,7 @@ Hooks execute in JSON configuration context where `${CLAUDE_PLUGIN_ROOT}` works,
 - Self-hosting always uses local definitions — no silent fallback to outdated plugin versions
 - Detection is inspectable: `ls cekernel/agents/` reveals the mode immediately
 - No dependency on Claude Code internals (`<command-name>` tag format, `${CLAUDE_PLUGIN_ROOT}` expansion)
-- Future-proof: when Claude Code adds proper namespace detection, migration is a single point of change (the detection script)
+- Future-proof: when Claude Code adds proper namespace detection, the inline Bash snippet in each SKILL.md is the only code to update — no mechanism scripts, agent definitions, or hook configurations are involved
 
 ### Negative
 


### PR DESCRIPTION
## Summary

- Add ADR-0009 documenting the decision to replace LLM-based namespace detection with deterministic file existence checks (`cekernel/agents/` directory presence)
- Includes probe verification results (4 scenarios), bootstrap constraint analysis (inline-only, no shared script), and UNIX philosophy alignment (Representation, Transparency, Robustness, Least Surprise)

## Related

- #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)