### PR TITLE
feat: add /cekernel:dispatch skill for batch processing ready-labeled issues

### DIFF
--- a/cekernel/skills/dispatch/SKILL.md
+++ b/cekernel/skills/dispatch/SKILL.md
@@ -1,0 +1,103 @@
+---
+description: Batch-process open issues with the `ready` label — discover, triage, and delegate to the Orchestrator
+argument-hint: "[--env profile] [--label label]"
+allowed-tools: Bash, Read, Task(cekernel:orchestrator), Task(orchestrator)
+---
+
+# /dispatch
+
+Discovers open issues labeled `ready`, triages them, and delegates to the Orchestrator agent for parallel processing.
+
+## Usage
+
+No arguments required — by default, picks up all open issues with the `ready` label.
+
+Optional flags:
+
+- `--env <profile>` — Select an env profile (default: `default`). Available profiles: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`.
+- `--label <label>` — Override the target label (default: `ready`).
+
+Examples:
+
+```
+/dispatch
+/dispatch --env headless
+/dispatch --label sprint-3
+/dispatch --env ci --label ready
+```
+
+Note: In plugin mode, `/cekernel:dispatch` also works.
+
+## Idempotency
+
+- Worker merges a PR with `closes #N` which auto-closes the issue
+- Next dispatch run uses `--state open`, so closed issues are excluded
+- No label manipulation needed — pure filter, zero side effects
+
+## Workflow
+
+### Step 0: Detect Agent Names
+
+Detect whether cekernel is running as a plugin or locally using file-based detection (ADR-0009).
+
+1. Read `cekernel/skills/references/namespace-detection.md` from the repository root (`$(git rev-parse --show-toplevel)/cekernel/skills/references/namespace-detection.md`). If the Read fails (file not found), you are in plugin mode.
+2. Execute the detection Bash snippet from the reference file.
+3. Set agent names based on the result:
+   - If `CEKERNEL_NS=local`: `CEKERNEL_AGENT_ORCHESTRATOR=orchestrator`, `CEKERNEL_AGENT_WORKER=worker`
+   - If `CEKERNEL_NS=plugin`: `CEKERNEL_AGENT_ORCHESTRATOR=cekernel:orchestrator`, `CEKERNEL_AGENT_WORKER=cekernel:worker`
+
+Store these values for use in subsequent steps.
+
+### Step 1: Discover Issues
+
+Fetch all open issues with the target label:
+
+```bash
+gh issue list --label <label> --state open --json number,title --jq '.[] | "\(.number)\t\(.title)"'
+```
+
+If no issues are found, report to the user and exit — there is nothing to process.
+
+### Step 2: Triage
+
+Read `cekernel/skills/references/triage.md` from the repository root (`$(git rev-parse --show-toplevel)/cekernel/skills/references/triage.md`) and follow the triage protocol for each discovered issue.
+
+### Step 3: Confirm with User
+
+Present the triaged issue list to the user for confirmation before delegating:
+
+```
+Found N issues with label "ready":
+  #42  Fix login timeout
+  #55  Add dark mode support
+  #61  Update dependencies
+
+Proceed with delegation to Orchestrator? (y/n)
+```
+
+Wait for user confirmation. If the user declines, exit without action.
+
+### Step 4: Parse `--env` and Launch Orchestrator Agent
+
+If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
+
+Launch the Orchestrator subagent via the Task tool:
+
+- `subagent_type`: Use `CEKERNEL_AGENT_ORCHESTRATOR` determined in Step 0
+- `run_in_background`: `true`
+- `prompt`: Include issue numbers, execution order (if determined in Step 2), `CEKERNEL_ENV` value, and `CEKERNEL_AGENT_WORKER` value. Instruct the Orchestrator to pass `export CEKERNEL_ENV=<profile>` and `export CEKERNEL_AGENT_WORKER=<agent-name>` in all `spawn-worker.sh` invocations.
+
+Example prompt fragment:
+
+```
+Process issues: #42 #55 #61
+Use CEKERNEL_ENV=default and CEKERNEL_AGENT_WORKER=cekernel:worker when spawning workers:
+export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=default && export CEKERNEL_AGENT_WORKER=cekernel:worker && spawn-worker.sh 42
+```
+
+The Orchestrator autonomously executes:
+
+1. Issue verification and triage (FAIL for ambiguous issues)
+2. Worker spawning (with `CEKERNEL_ENV` propagated)
+3. Completion monitoring
+4. Cleanup

--- a/cekernel/skills/orchestrate/SKILL.md
+++ b/cekernel/skills/orchestrate/SKILL.md
@@ -42,17 +42,9 @@ Store these values for use in subsequent steps.
 
 ### Step 1: Issue Triage and Priority Assessment
 
-Check each issue's content with `gh issue view` and verify:
+Read `cekernel/skills/references/triage.md` from the repository root (`$(git rev-parse --show-toplevel)/cekernel/skills/references/triage.md`) and follow the triage protocol for each issue.
 
-1. **Clarity of requirements**: Are the required changes specifically described?
-2. **Scope**: Can the implementation scope be identified?
-
-If any issue has ambiguous or insufficient requirements, report to the user and confirm action (fix the issue, skip, proceed, etc.). If requirements become clear through user interaction, add supplementary information as a comment on the issue via `gh issue comment` so the Worker can work accurately, then delegate to the Orchestrator.
-
-For multiple issues, additionally:
-
-3. Analyze dependencies between issues (does completing A require B to finish first?)
-4. If dependencies exist, organize into phases and present the execution order to the user for confirmation
+After triage, delegate to the Orchestrator.
 
 ### Step 2: Parse `--env` and Launch Orchestrator Agent
 

--- a/cekernel/skills/references/triage.md
+++ b/cekernel/skills/references/triage.md
@@ -1,0 +1,33 @@
+# Issue Triage Protocol
+
+> Canonical source for cekernel issue triage logic.
+> Referenced by both `/orchestrate` and `/dispatch` skills.
+
+## Single Issue Triage
+
+For each issue, check its content with `gh issue view` and verify:
+
+1. **Clarity of requirements**: Are the required changes specifically described?
+2. **Scope**: Can the implementation scope be identified?
+
+If any issue has ambiguous or insufficient requirements, report to the user and confirm action (fix the issue, skip, proceed, etc.). If requirements become clear through user interaction, add supplementary information as a comment on the issue via `gh issue comment` so the Worker can work accurately.
+
+## Multi-Issue Triage
+
+When triaging multiple issues, additionally:
+
+3. **Dependency analysis**: Analyze dependencies between issues (does completing A require B to finish first?)
+4. **Phase ordering**: If dependencies exist, organize into phases and present the execution order to the user for confirmation
+
+## Usage from SKILL.md
+
+Each SKILL.md that needs triage should include a step like:
+
+> Read `triage.md` (this file) and follow the triage protocol for each issue.
+
+### Path Resolution
+
+This file is located at `cekernel/skills/references/triage.md` relative to the repository root. To find it:
+
+1. Run `git rev-parse --show-toplevel` to get the repo root
+2. Read `${REPO_ROOT}/cekernel/skills/references/triage.md`


### PR DESCRIPTION
closes #127

## Summary
- Add `/cekernel:dispatch` skill that discovers open issues with the `ready` label, triages them, and delegates to the Orchestrator for parallel processing
- Extract shared triage protocol into `cekernel/skills/references/triage.md` to avoid duplication between `orchestrate` and `dispatch`
- Update `orchestrate/SKILL.md` to reference the shared `triage.md` instead of inlining triage steps

## Test Plan
- [ ] Verify `/dispatch` skill is discoverable via Claude Code skill listing
- [ ] Verify `/orchestrate` triage behavior is unchanged (references `triage.md`)
- [ ] Verify `cekernel/tests/run-tests.sh` passes (no regressions)