### PR TITLE
test: add dispatch symlink for self-hosting

### DIFF
--- a/.claude/skills/dispatch
+++ b/.claude/skills/dispatch
@@ -1,0 +1,1 @@
+../../cekernel/skills/dispatch


### PR DESCRIPTION
## Summary

- Add `.claude/skills/dispatch` symlink for self-hosting local skill resolution

ref #127

## Test plan

- [ ] `/dispatch` resolves in local mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)