### PR TITLE
feat: add platform constraints awareness to unix-architect skill

### DIFF
--- a/cekernel/docs/claude-code-constraints.md
+++ b/cekernel/docs/claude-code-constraints.md
@@ -1,0 +1,167 @@
+# Claude Code Platform Constraints
+
+> Reference document for architectural decisions involving Claude Code.
+> cekernel runs on Claude Code as its execution platform. Designs that ignore
+> these constraints produce architectures that are correct in theory but
+> unimplementable in practice.
+>
+> **Staleness warning**: Claude Code is actively evolving. Constraints listed
+> here reflect the platform as of early 2025. When making architectural
+> decisions, verify that constraints still hold — especially those marked
+> with a confidence level below "Stable".
+
+## Execution Model
+
+### Turn-Based Synchronous Execution
+
+**Confidence: Stable**
+
+Claude Code operates as a synchronous, turn-based agent. Each turn consists of:
+
+1. The model generates a response (which may include tool calls)
+2. Tool calls are executed
+3. Results are returned to the model
+4. The model generates the next response
+
+There is **no mechanism for true mid-turn interruption**. Once a turn begins,
+it runs to completion before the agent can observe new information.
+
+**Implications for cekernel**:
+- Cooperative signal checking at phase boundaries is the correct pattern
+  (not real-time signal handling)
+- Long-running tool calls (e.g., `gh pr checks --watch`) block the agent
+  from observing anything else until they complete
+- Design for "check at natural pauses" rather than "interrupt at any time"
+
+**Reference**: [anthropics/claude-code#3455](https://github.com/anthropics/claude-code/issues/3455)
+
+### Background Tasks
+
+**Confidence: Evolving**
+
+Claude Code supports `run_in_background` for Bash tasks. Background task
+completion notifications are queued and delivered at the next turn boundary.
+
+Known characteristics:
+- Notifications are cooperative, not preemptive — they arrive between turns,
+  not during them
+- Reliability of notifications has known issues
+- Background tasks are useful for long polling but should not be relied upon
+  as the sole mechanism for critical signals
+
+**Implications for cekernel**:
+- Background watchers can improve signal detection latency (seconds vs minutes)
+  but must not replace phase-boundary checks as the reliable baseline
+- Design with the assumption that background notifications may be delayed or missed
+
+**References**:
+[anthropics/claude-code#21048](https://github.com/anthropics/claude-code/issues/21048),
+[anthropics/claude-code#20525](https://github.com/anthropics/claude-code/issues/20525)
+
+## Agent Architecture
+
+### Single-Threaded Agent
+
+**Confidence: Stable**
+
+Each Claude Code session runs a single agent. There is no built-in mechanism
+for an agent to spawn peer agents within the same session. Multi-agent
+coordination requires external orchestration (separate terminal sessions,
+separate processes).
+
+**Implications for cekernel**:
+- The Orchestrator/Worker separation maps correctly to separate sessions
+- Worker isolation via git worktrees aligns with "one agent, one workspace"
+- Inter-agent communication must use external mechanisms (files, FIFOs)
+
+### Subagent (Task) Tool
+
+**Confidence: Evolving**
+
+The `Task` tool spawns a subagent with its own context window. The parent
+agent blocks until the subagent completes. Subagents inherit the parent's
+tool permissions but have a separate conversation history.
+
+Known characteristics:
+- Subagents cannot communicate with the parent during execution
+- The parent receives only the subagent's final output
+- Subagent context windows are independent (no shared memory)
+
+**Implications for cekernel**:
+- Task-based delegation is fire-and-forget from the parent's perspective
+- Status updates from subagents require external side-channels (files, issues)
+
+### Context Window Limits
+
+**Confidence: Stable**
+
+Each agent session has a finite context window. Long conversations cause
+older context to be summarized or evicted. There is no persistent memory
+across sessions beyond what is written to files.
+
+**Implications for cekernel**:
+- Workers must write progress to durable storage (git commits, issue comments)
+  not rely on conversation history surviving
+- The checkpoint mechanism (`.cekernel-checkpoint.md`) correctly externalizes
+  state to the filesystem
+- Task files (`.cekernel-task.md`) correctly pre-cache issue data to avoid
+  re-fetching within the context window
+
+## Tool Execution
+
+### File System Access
+
+**Confidence: Stable**
+
+Claude Code agents have full read/write access to the filesystem within
+their working directory. File operations are synchronous and atomic from
+the agent's perspective.
+
+**Implications for cekernel**:
+- File-based IPC (signal files, state files, FIFOs) is a natural fit
+- Atomic write patterns (temp + rename) work correctly
+
+### Permission Model
+
+**Confidence: Evolving**
+
+Tool execution requires permission grants. These can be pre-configured via
+`.claude/settings.json` (per-project) or granted interactively. The
+`allowedTools` patterns support glob matching.
+
+**Implications for cekernel**:
+- Worker automation requires pre-configured permissions in the target
+  repository's `.claude/settings.json`
+- cekernel delegates permission configuration to the target repository
+  (separation of authority)
+
+## Concurrency and Multi-Session
+
+### No Shared State Between Sessions
+
+**Confidence: Stable**
+
+Multiple Claude Code sessions (e.g., multiple terminal tabs) share no
+in-process state. Each session is fully independent. Coordination must
+occur through the filesystem or external services.
+
+**Implications for cekernel**:
+- The session IPC directory (`/tmp/cekernel-ipc/{SESSION_ID}`) is the
+  correct coordination point
+- Workers in separate terminal panes correctly communicate via files and FIFOs
+- There is no "shared memory" shortcut between agents
+
+### Terminal Backend Dependency
+
+**Confidence: Stable**
+
+cekernel spawns Worker sessions by sending commands to terminal panes.
+The terminal multiplexer (WezTerm, tmux, etc.) is an external dependency
+that cekernel does not control.
+
+**Implications for cekernel**:
+- Terminal pane state (alive/dead) must be actively monitored
+- Pane death detection (`health-check.sh`) is essential because there is
+  no callback mechanism from the terminal to cekernel
+- The terminal backend is swappable (ADR-0001, ADR-0005) — designs should
+  not assume a specific terminal

--- a/cekernel/skills/unix-architect/SKILL.md
+++ b/cekernel/skills/unix-architect/SKILL.md
@@ -13,6 +13,7 @@ You are a senior software architect who:
 
 - Has deep knowledge of the **UNIX philosophy** — the 17 principles from Eric S. Raymond's *The Art of Unix Programming* are your primary evaluation lens
 - Is well-versed in **computer science fundamentals** — algorithms, data structures, distributed systems, operating systems, concurrency, and systems design
+- Is aware of **platform constraints** — cekernel runs on Claude Code, whose execution model (turn-based, single-threaded, context-limited) directly shapes what architectures are feasible
 - Thinks in **trade-offs**, not absolutes — every decision has costs and benefits
 - Values **simplicity and composability** above all — complexity must justify itself
 - Documents decisions rigorously so future maintainers understand not just *what* was decided, but *why*
@@ -37,15 +38,16 @@ The `<target>` can be:
 
 If no mode is specified, infer from context: if the input references an existing artifact to evaluate, use `review`; if it describes a new decision to document, use `adr`.
 
-Output destination (file, issue/PR comment, conversation only) is determined interactively in Phase 6.
+Output destination (file, issue/PR comment, conversation only) is determined interactively in Phase 7.
 
 ## Workflow — Common Phases
 
 ### Phase 1: Load Knowledge Base
 
-Read the UNIX philosophy principles from the bundled `docs/unix-philosophy.md` document.
+Read the following documents from the repository:
 
-Internalize all 17 principles. These are your evaluation criteria.
+1. **UNIX philosophy** — `docs/unix-philosophy.md`. Internalize all 17 principles. These are your primary evaluation criteria.
+2. **Claude Code platform constraints** — `docs/claude-code-constraints.md`. Internalize the execution model, agent architecture, and concurrency characteristics. These inform what designs are feasible on the platform cekernel runs on.
 
 ### Phase 2: Understand the Target
 
@@ -76,9 +78,24 @@ For the proposal, decision, or changes under review:
 
 Do NOT force-fit all 17 principles. Only cite those that genuinely inform the evaluation.
 
+### Phase 5: Evaluate Against Platform Constraints
+
+Assess whether the proposal, decision, or changes are **feasible and sound** given Claude Code's platform constraints (loaded in Phase 1). This phase is unique to cekernel — most projects do not need it, but cekernel's deep dependency on Claude Code internals makes it essential.
+
+For each relevant constraint:
+
+1. **Identify applicability**: Does the design touch execution flow, agent coordination, background tasks, context management, or inter-session communication? If not, this phase may be brief or skipped entirely.
+2. **Check feasibility**: Does the design assume capabilities the platform does not provide? (e.g., mid-turn interruption, shared memory between sessions, real-time event handling)
+3. **Note constraint-driven trade-offs**: Where a platform limitation forces a design compromise, document it explicitly. These are distinct from UNIX-principle trade-offs — they are imposed by the runtime, not chosen for philosophical reasons.
+4. **Flag staleness risks**: If the design depends on a constraint marked "Evolving" in the reference document, note that the constraint may change and the design should be revisited when it does.
+
+Do NOT repeat constraints that are irrelevant to the current proposal. Only surface those that materially affect the design.
+
+**When to skip**: If the proposal is purely about data formats, naming conventions, documentation, or other aspects that do not interact with Claude Code's execution model, state "No platform constraints apply" and move on.
+
 ## Workflow — ADR Mode
 
-### Phase 5a: Write the ADR
+### Phase 6a: Write the ADR
 
 Determine the next ADR number by checking existing files in `docs/adr/`:
 
@@ -115,6 +132,12 @@ intentionally deviates from it. Quote the principle, then explain.]
 
 [How this decision relates to the principle.]
 
+### Platform Constraints
+
+[If applicable: Which Claude Code platform constraints influenced this
+decision? How do they shape or limit the design? If none apply, omit
+this section.]
+
 ## Alternatives Considered
 
 [For each alternative:]
@@ -144,22 +167,23 @@ What was sacrificed and why was it acceptable?]
 
 ## Workflow — Review Mode
 
-### Phase 5b: Conduct the Review
+### Phase 6b: Conduct the Review
 
 Evaluate the target through the UNIX philosophy lens and CS fundamentals. Structure the review as:
 
 1. **Summary**: One-paragraph understanding of what is being proposed or changed
 2. **UNIX Philosophy Assessment**: For each relevant principle, state whether the target aligns, partially aligns, or conflicts — with specific evidence from the code/proposal
-3. **Technical Observations**: Concrete issues, risks, or improvements spotted — reference specific files, lines, or design choices
-4. **Verdict**: One of:
+3. **Platform Constraint Assessment** (if applicable): Flag any design aspects that interact with Claude Code's execution model. Note feasibility issues, constraint-driven trade-offs, or assumptions about platform behavior. Omit if no constraints apply.
+4. **Technical Observations**: Concrete issues, risks, or improvements spotted — reference specific files, lines, or design choices
+5. **Verdict**: One of:
    - **Approve** — Sound architecture, aligns well with principles
    - **Approve with suggestions** — Fundamentally sound, minor improvements recommended
    - **Request changes** — Architectural concerns that should be addressed before proceeding
-5. **Suggestions** (if any): Actionable, specific recommendations
+6. **Suggestions** (if any): Actionable, specific recommendations
 
 ## Workflow — Output (shared)
 
-### Phase 6: Present and Publish
+### Phase 7: Present and Publish
 
 First, present the output (ADR or review) directly to the user in the conversation. Then ask where else to publish:
 


### PR DESCRIPTION
closes #83

## Summary
- Create `cekernel/docs/claude-code-constraints.md` — a curated reference document capturing stable Claude Code platform constraints (turn-based execution model, single-threaded agents, background task behavior, context window limits, no shared state between sessions)
- Update `cekernel/skills/unix-architect/SKILL.md` — add Phase 5 (Evaluate Against Platform Constraints) to the workflow, extend the Persona with platform awareness, update Phase 1 to load the constraints document, and add platform constraint sections to both the ADR template and review structure
- Phase numbers updated: ADR/Review output phases renumbered from 5→6 and 6→7 to accommodate the new phase

## Design Rationale
Hybrid of the three approaches identified in the issue: embed stable constraints in a reference document (always available, no per-ADR cost) while explicitly marking confidence levels and staleness risks (acknowledges that Claude Code evolves). The reference document follows the existing pattern of `docs/unix-philosophy.md` — a knowledge base loaded at skill startup.

## Test Plan
- [ ] Verify SKILL.md workflow phases are numbered consistently (1→7)
- [ ] Verify `docs/claude-code-constraints.md` is readable and referenced correctly from SKILL.md
- [ ] Verify CI passes (no executable scripts changed, so test suite should pass unchanged)