### PR TITLE
feat: make CI retry count configurable via CEKERNEL_CI_MAX_RETRIES

### DIFF
--- a/cekernel/CLAUDE.md
+++ b/cekernel/CLAUDE.md
@@ -144,7 +144,14 @@ Use `${VAR:-default}` pattern for default values:
 ```bash
 MAX_WORKERS="${CEKERNEL_MAX_WORKERS:-3}"
 TIMEOUT="${CEKERNEL_WORKER_TIMEOUT:-3600}"
+CI_MAX_RETRIES="${CEKERNEL_CI_MAX_RETRIES:-3}"
 ```
+
+| Variable | Default | Description |
+|---|---|---|
+| `CEKERNEL_MAX_WORKERS` | 3 | Maximum concurrent workers per session |
+| `CEKERNEL_WORKER_TIMEOUT` | 3600 | Worker timeout in seconds |
+| `CEKERNEL_CI_MAX_RETRIES` | 3 | Maximum CI retry attempts before Worker reports failure |
 
 Use `BASH_SOURCE[0]`-based path resolution for locating files relative to the script:
 

--- a/cekernel/agents/worker.md
+++ b/cekernel/agents/worker.md
@@ -233,12 +233,14 @@ notify-complete.sh <issue-number> merged <pr-number>
 
 ## On Error
 
+The maximum number of CI retry attempts is controlled by `CEKERNEL_CI_MAX_RETRIES` (default: 3).
+
 When CI fails:
 
 1. Check failed checks with `gh pr checks`
 2. Fix and push
 3. Wait for CI again
-4. After 3 failures:
+4. After `CEKERNEL_CI_MAX_RETRIES` failures (default: 3):
    1. Post Result as a comment on the issue (Status: failed, describe failure reason in Summary)
    2. Run `notify-complete.sh <issue-number> failed "reason"`
 


### PR DESCRIPTION
closes #82

## Summary
- Introduce `CEKERNEL_CI_MAX_RETRIES` environment variable (default: 3) to make the Worker CI retry count configurable
- Update `worker.md` On Error section to reference the env var instead of hardcoded 3
- Document the env var in `cekernel/CLAUDE.md` Environment Variables section with a reference table

## Test Plan
- [x] All existing tests pass (pre-existing `test-session-isolation.sh` failure unrelated)
- [x] Default behavior preserved (default: 3 matches previous hardcoded value)
- [x] Follows existing `CEKERNEL_` prefix convention (`${VAR:-default}` pattern)