### PR TITLE
fix: strip newlines from base64 payload in WezTerm backend

### DIFF
--- a/cekernel/scripts/shared/backends/wezterm.sh
+++ b/cekernel/scripts/shared/backends/wezterm.sh
@@ -41,7 +41,7 @@ backend_spawn_worker() {
 
   # Send OSC user-var to trigger Lua handler (IPC 2-3)
   local payload_b64
-  payload_b64=$(printf '%s' "$layout_payload" | base64)
+  payload_b64=$(printf '%s' "$layout_payload" | base64 | tr -d '\n')
   local osc_cmd="printf '\\033]1337;SetUserVar=%s=%s\\007' cekernel_worker_layout '${payload_b64}'"
   wezterm cli send-text --pane-id "$pane_id" -- "$osc_cmd"
   sleep 0.1


### PR DESCRIPTION
## Summary
- macOS の `base64` が76文字で改行を挿入し、OSCエスケープシーケンスが途中で壊れていた
- WezTerm の VT パーサーが改行でシーケンスを打ち切り、Lua ハンドラ (`user-var-changed`) が発火しない
- `| tr -d '\n'` を追加して改行を除去

## Test plan
- [x] `run-tests.sh` 全パス
- [ ] 実際に `spawn-worker.sh` で Worker を起動し、3ペインレイアウトが構築されることを確認

closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)