### PR TITLE
fix: propagate PATH and CEKERNEL_IPC_DIR to Worker bash prefix

### DIFF
--- a/cekernel/scripts/orchestrator/spawn-worker.sh
+++ b/cekernel/scripts/orchestrator/spawn-worker.sh
@@ -181,15 +181,20 @@ fi
 echo "worktree: $WORKTREE" >&2
 echo "branch:   $BRANCH" >&2
 
+# ── Compute cekernel script paths for Worker PATH ──
+CEKERNEL_WORKER_SCRIPTS="$(cd "${SCRIPT_DIR}/../worker" && pwd)"
+CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
+BASH_PREFIX="export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_IPC_DIR=${CEKERNEL_IPC_DIR} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export PATH=${CEKERNEL_WORKER_SCRIPTS}:${CEKERNEL_SHARED_SCRIPTS}:\$PATH"
+
 # ── Launch Worker via backend ──
 # Initial prompt for Worker:
 # 1. Read the target repository's CLAUDE.md first
 # 2. Follow kernel's protocol only for lifecycle (PR → CI → merge → notify)
 # 3. Follow the target repository's conventions for implementation
 if [[ "$RESUME" -eq 1 ]]; then
-  PROMPT="Resume issue #${ISSUE_NUMBER}. Read .cekernel-checkpoint.md to understand previous progress, then continue from where the previous Worker left off. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>. When executing Bash during processing, always prefix with: export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} &&"
+  PROMPT="Resume issue #${ISSUE_NUMBER}. Read .cekernel-checkpoint.md to understand previous progress, then continue from where the previous Worker left off. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>. When executing Bash during processing, always prefix with: ${BASH_PREFIX} &&"
 else
-  PROMPT="Resolve issue #${ISSUE_NUMBER}. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>. When executing Bash during processing, always prefix with: export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} &&"
+  PROMPT="Resolve issue #${ISSUE_NUMBER}. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI → merge. When done, run notify-complete.sh ${ISSUE_NUMBER} merged <pr-number>. When executing Bash during processing, always prefix with: ${BASH_PREFIX} &&"
 fi
 
 # Backend handles workspace resolution, window spawning, and handle file management internally.

--- a/cekernel/tests/orchestrator/test-spawn-env-propagation.sh
+++ b/cekernel/tests/orchestrator/test-spawn-env-propagation.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# test-spawn-env-propagation.sh — Tests that spawn-worker.sh propagates CEKERNEL_ENV to Worker prompts
+# test-spawn-env-propagation.sh — Tests that spawn-worker.sh propagates env to Worker prompts
 #
-# Verifies that both normal and resume PROMPT strings include
-# export CEKERNEL_ENV=${CEKERNEL_ENV}, as required by ADR-0010.
+# Verifies that the BASH_PREFIX includes CEKERNEL_SESSION_ID, CEKERNEL_IPC_DIR,
+# CEKERNEL_ENV, and PATH with cekernel script directories.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,26 +15,74 @@ echo "test: spawn-env-propagation"
 
 SCRIPT_CONTENT=$(cat "$SPAWN_SCRIPT")
 
-# ── Test 1: Normal PROMPT includes CEKERNEL_ENV export ──
-# The normal (non-resume) PROMPT should contain export CEKERNEL_ENV=
-if [[ "$SCRIPT_CONTENT" == *'export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}'*'export CEKERNEL_ENV=${CEKERNEL_ENV}'* ]]; then
-  echo "  PASS: Normal PROMPT includes CEKERNEL_ENV export"
+# ── Test 1: BASH_PREFIX includes CEKERNEL_SESSION_ID ──
+if [[ "$SCRIPT_CONTENT" == *'CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}'* ]]; then
+  echo "  PASS: BASH_PREFIX includes CEKERNEL_SESSION_ID"
   TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-  echo "  FAIL: Normal PROMPT missing CEKERNEL_ENV export"
+  echo "  FAIL: BASH_PREFIX missing CEKERNEL_SESSION_ID"
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-# ── Test 2: Resume PROMPT includes CEKERNEL_ENV export ──
-# The resume PROMPT should also contain export CEKERNEL_ENV=
-# Both PROMPT strings should have it
-PROMPT_COUNT=$(grep -c 'export CEKERNEL_ENV=\${CEKERNEL_ENV}' "$SPAWN_SCRIPT" || true)
-if [[ "$PROMPT_COUNT" -ge 2 ]]; then
-  echo "  PASS: Both PROMPT strings include CEKERNEL_ENV export (count=$PROMPT_COUNT)"
+# ── Test 2: BASH_PREFIX includes CEKERNEL_IPC_DIR ──
+if [[ "$SCRIPT_CONTENT" == *'CEKERNEL_IPC_DIR=${CEKERNEL_IPC_DIR}'* ]]; then
+  echo "  PASS: BASH_PREFIX includes CEKERNEL_IPC_DIR"
   TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-  echo "  FAIL: Expected CEKERNEL_ENV in both PROMPT strings, found $PROMPT_COUNT"
+  echo "  FAIL: BASH_PREFIX missing CEKERNEL_IPC_DIR"
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
+
+# ── Test 3: BASH_PREFIX includes CEKERNEL_ENV ──
+if [[ "$SCRIPT_CONTENT" == *'CEKERNEL_ENV=${CEKERNEL_ENV}'* ]]; then
+  echo "  PASS: BASH_PREFIX includes CEKERNEL_ENV"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: BASH_PREFIX missing CEKERNEL_ENV"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 4: BASH_PREFIX includes PATH with worker scripts ──
+if [[ "$SCRIPT_CONTENT" == *'PATH=${CEKERNEL_WORKER_SCRIPTS}:${CEKERNEL_SHARED_SCRIPTS}:'* ]]; then
+  echo "  PASS: BASH_PREFIX includes PATH with worker/shared scripts"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: BASH_PREFIX missing PATH with script directories"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 5: Worker script directories are computed from SCRIPT_DIR ──
+if [[ "$SCRIPT_CONTENT" == *'CEKERNEL_WORKER_SCRIPTS="$(cd "${SCRIPT_DIR}/../worker" && pwd)"'* ]]; then
+  echo "  PASS: CEKERNEL_WORKER_SCRIPTS computed from SCRIPT_DIR"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: CEKERNEL_WORKER_SCRIPTS not computed from SCRIPT_DIR"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 6: Shared script directories are computed from SCRIPT_DIR ──
+if [[ "$SCRIPT_CONTENT" == *'CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"'* ]]; then
+  echo "  PASS: CEKERNEL_SHARED_SCRIPTS computed from SCRIPT_DIR"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: CEKERNEL_SHARED_SCRIPTS not computed from SCRIPT_DIR"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 7: Both PROMPT strings use BASH_PREFIX ──
+PROMPT_COUNT=$(grep -c '${BASH_PREFIX}' "$SPAWN_SCRIPT" || true)
+if [[ "$PROMPT_COUNT" -ge 2 ]]; then
+  echo "  PASS: Both PROMPT strings use BASH_PREFIX (count=$PROMPT_COUNT)"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: Expected BASH_PREFIX in both PROMPT strings, found $PROMPT_COUNT"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 8: Script directories actually exist ──
+WORKER_SCRIPTS_DIR="${CEKERNEL_DIR}/scripts/worker"
+SHARED_SCRIPTS_DIR="${CEKERNEL_DIR}/scripts/shared"
+assert_dir_exists "scripts/worker directory exists" "$WORKER_SCRIPTS_DIR"
+assert_dir_exists "scripts/shared directory exists" "$SHARED_SCRIPTS_DIR"
 
 report_results


### PR DESCRIPTION
closes #160

## Summary
- Worker の bash prefix に `PATH`（`scripts/worker/` + `scripts/shared/`）と `CEKERNEL_IPC_DIR` を追加
- Worker がスクリプト（`worker-state.sh`, `notify-complete.sh` 等）をベアネームで即座に発見可能に
- 既存テスト `test-spawn-env-propagation.sh` を拡張し、PATH・IPC_DIR・BASH_PREFIX の検証を追加

## Test plan
- [x] `cekernel/tests/run-tests.sh` 全テスト通過（9テストに拡張済み）
- [ ] 実際に Worker を spawn して `source worker-state.sh` がエラーなく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)