### PR TITLE
feat: add status job for ruleset required status check

### DIFF
--- a/.github/workflows/cekernel-tests.yml
+++ b/.github/workflows/cekernel-tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:


### PR DESCRIPTION
ref #167

## Summary

- `cekernel tests` workflow に paths-filter + status ジョブを追加
- `cekernel/**` に変更がない PR でも `cekernel tests` ステータスが success を返すようになる
- Ruleset の required status check として `cekernel tests` を指定可能にする

## 次のステップ

この PR マージ後に `gh api` で Ruleset を作成する（issue #167 で対応）