### PR TITLE
feat: display worker status and logs in right pane

### DIFF
--- a/cekernel/config/wezterm.cekernel.lua
+++ b/cekernel/config/wezterm.cekernel.lua
@@ -51,12 +51,18 @@ wezterm.on('user-var-changed', function(window, pane, name, value)
   }
   bottom_pane:send_text("watch -n3 -t -c 'git --no-pager log --oneline --graph --color=always'\n")
 
-  -- Right pane (40%): general-purpose terminal
-  main_pane:split {
+  -- Right pane (40%): worker status monitor
+  local right_pane = main_pane:split {
     direction = 'Right',
     size = 0.4,
     cwd = worktree,
   }
+  local ipc_dir = os.getenv('CEKERNEL_IPC_DIR') or ('/tmp/cekernel-ipc/' .. session_id)
+  right_pane:send_text(
+    "watch -n 5 'cat " .. ipc_dir .. "/worker-" .. issue_number .. ".state 2>/dev/null"
+    .. ' && echo "---"'
+    .. " && tail -5 " .. ipc_dir .. "/logs/worker-" .. issue_number .. ".log 2>/dev/null'\n"
+  )
 
   -- Send cd + export + claude command to main pane
   -- Wait for shell to be ready before send_text

--- a/cekernel/scripts/shared/backends/tmux.sh
+++ b/cekernel/scripts/shared/backends/tmux.sh
@@ -29,8 +29,13 @@ backend_spawn_worker() {
   local main_pane
   main_pane=$(_backend_spawn_window "$worktree" "$session")
 
-  # Create right pane (40%) — terminal
-  _backend_split_pane right 40 "$main_pane" "$worktree" 2>/dev/null || true
+  # Create right pane (40%) — worker status monitor
+  local right_pane
+  right_pane=$(_backend_split_pane right 40 "$main_pane" "$worktree" 2>/dev/null) || true
+  if [[ -n "$right_pane" ]]; then
+    local watch_cmd="watch -n 5 'cat ${CEKERNEL_IPC_DIR}/worker-${issue}.state 2>/dev/null && echo \"---\" && tail -5 ${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log 2>/dev/null'"
+    _backend_run_command "$right_pane" "$watch_cmd"
+  fi
 
   # Create bottom pane (25%) — git log
   _backend_split_pane bottom 25 "$main_pane" "$worktree" 2>/dev/null || true

--- a/cekernel/tests/shared/test-backend-tmux.sh
+++ b/cekernel/tests/shared/test-backend-tmux.sh
@@ -47,6 +47,7 @@ PATH="$OLD_PATH"
 
 # ── Test 3: backend_spawn_worker — spawns window and saves handle ──
 MOCK_LOG=$(mktemp)
+SPLIT_CALL_COUNT=0
 export TMUX="/tmp/tmux-501/default,12345,0"
 tmux() {
   echo "tmux $*" >> "$MOCK_LOG"
@@ -57,7 +58,12 @@ tmux() {
     echo "my-session"
   fi
   if [[ "$1" == "split-window" ]]; then
-    echo "my-session:1.1"
+    SPLIT_CALL_COUNT=$((SPLIT_CALL_COUNT + 1))
+    if [[ "$SPLIT_CALL_COUNT" -eq 1 ]]; then
+      echo "my-session:1.1"  # right pane
+    else
+      echo "my-session:1.2"  # bottom pane
+    fi
   fi
 }
 export -f tmux
@@ -71,6 +77,10 @@ assert_file_exists "Handle file created after spawn" "$HANDLE_FILE"
 
 HANDLE=$(cat "$HANDLE_FILE")
 assert_eq "Handle contains pane target" "my-session:1.0" "$HANDLE"
+
+# ── Test 3b: backend_spawn_worker — sends watch command to right pane ──
+LOGGED=$(cat "$MOCK_LOG")
+assert_match "watch command sent to right pane" ".*send-keys -t my-session:1.1 watch -n 5.*" "$LOGGED"
 rm -f "$MOCK_LOG"
 
 # ── Test 4: backend_worker_alive — alive pane ──


### PR DESCRIPTION
closes #169

## 概要
Worker の wezterm / tmux レイアウトで未使用だった右ペインに、Worker の state ファイルと直近ログ 5 行を定期表示する `watch` コマンドを送信するようにした。

## 変更内容
- `backends/tmux.sh`: 右ペインの pane target をキャプチャし、`watch -n 5` コマンドを送信
- `config/wezterm.cekernel.lua`: 右ペインオブジェクトをキャプチャし、`send_text` で `watch -n 5` コマンドを送信
- `tests/shared/test-backend-tmux.sh`: 右ペインに watch コマンドが送信されることを検証するテストを追加

## テスト
- [x] `test-backend-tmux.sh` — 10 passed, 0 failed (新規テスト含む)
- [x] 全バックエンドテスト通過