### PR TITLE
fix: clean up test IPC remnants in run-tests.sh

### DIFF
--- a/cekernel/tests/run-tests.sh
+++ b/cekernel/tests/run-tests.sh
@@ -33,6 +33,11 @@ for category in shared orchestrator worker; do
   done
 done
 
+# Cleanup test IPC remnants
+# Individual tests use trap/cleanup but some leave directories behind.
+# Remove all test-* session directories to prevent orchctrl ls pollution.
+rm -rf /tmp/cekernel-ipc/test-*
+
 echo "==========================="
 if [[ ${#FAILED_FILES[@]} -eq 0 ]]; then
   echo "All tests passed."


### PR DESCRIPTION
closes #170

## 概要
- `run-tests.sh` の末尾に `/tmp/cekernel-ipc/test-*` の一括削除を追加
- テスト実行後に残る IPC ディレクトリが `orchctrl ls` に表示される問題を修正

## テスト計画
- [x] `run-tests.sh` 実行後に `/tmp/cekernel-ipc/test-*` が残らないことを確認済み