### PR TITLE
docs: add orchestrator scripts boundary rule to worker.md

### DIFF
--- a/cekernel/agents/worker.md
+++ b/cekernel/agents/worker.md
@@ -262,4 +262,5 @@ When CI fails:
 - Do not modify files outside the worktree
 - Do not interfere with other workers' branches
 - Do not delete the worktree after merge (that is the Orchestrator's responsibility)
+- Do not read or modify orchestrator scripts (`scripts/orchestrator/`) — they are outside Worker's authority
 - Do not override the target repository's conventions with cekernel rules


### PR DESCRIPTION
closes #176

## Summary
- `cekernel/agents/worker.md` の Constraints セクションに `scripts/orchestrator/` を読み書きしない旨のルールを追加
- Worker が Orchestrator のインフラスクリプトを参照することを防止する

## Test Plan
- [ ] ドキュメント変更のみのため、既存テストが通ることを確認