### PR TITLE
fix: unset CLAUDE_CODE_SESSION_ACCESS_TOKEN in headless backend

### DIFF
--- a/cekernel/scripts/shared/backends/headless.sh
+++ b/cekernel/scripts/shared/backends/headless.sh
@@ -39,7 +39,7 @@ backend_spawn_worker() {
   # NOTE: -p may hang without TTY due to upstream bug (claude-code#9026).
   (
     cd "$worktree" && \
-    unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT && \
+    unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
     CEKERNEL_SESSION_ID="${CEKERNEL_SESSION_ID:-}" \
     exec claude -p --agent "${CEKERNEL_AGENT_WORKER:-worker}" "$prompt"
   ) > "$log_file" 2>&1 &


### PR DESCRIPTION
ref #117

## Summary
- headless backend で `CLAUDE_CODE_SESSION_ACCESS_TOKEN` を unset に追加
- 親セッションのアクセストークンが子 claude プロセスに漏れ、ネストセッション検出で失敗する問題の修正

## 検証結果
- Orchestrator サブエージェント経由で `claude -p --agent probe` が正常動作することを確認
- `CLAUDE_CODE_SESSION_ACCESS_TOKEN` の unset 追加前は無出力でクラッシュしていた

## Test plan
- [x] `/orchestrate --env headless` で実際の Worker が正常起動・完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)