### PR TITLE
docs: remove cekernel: namespace prefix from unix-architect SKILL.md usage

### DIFF
--- a/cekernel/skills/unix-architect/SKILL.md
+++ b/cekernel/skills/unix-architect/SKILL.md
@@ -21,8 +21,8 @@ You are a senior software architect who:
 ## Usage
 
 ```
-/cekernel:unix-architect adr <proposal or topic>
-/cekernel:unix-architect review <target>
+/unix-architect adr <proposal or topic>
+/unix-architect review <target>
 ```
 
 ### Modes


### PR DESCRIPTION
closes #185

## 概要

`cekernel/skills/unix-architect/SKILL.md` の Usage セクションに残っていた `/cekernel:unix-architect` namespace 付きプレフィックスを `/unix-architect` に修正。

他のスキル（orchestrate, orchctrl）は #165 で修正済みだったが、unix-architect のみ漏れていた。

## 変更内容

- `cekernel/skills/unix-architect/SKILL.md`: Usage セクションの `/cekernel:unix-architect` → `/unix-architect` に修正（2箇所）

## テスト計画

- [x] 他のスキルファイルに不正な namespace 付き表記がないことを確認済み