### PR TITLE
docs: add ADR-0011 scheduled trigger via OS-native schedulers

### DIFF
--- a/cekernel/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
+++ b/cekernel/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

- ADR-0011: cron/at スケジューリングスキルのアーキテクチャ決定記録
- OS ネイティブスケジューラ（crontab → launchd/systemd/schtasks）の Tiered Backend 設計
- #79 の検証結果（Step 1-3）に基づく

## Key Decisions

- **Skills**: `cekernel:cron`（定期）+ `cekernel:at`（ワンショット）
- **Registry**: `~/.claude/cekernel/schedules.json`
- **Tier 1 (MVP)**: crontab（macOS/Linux/WSL 統一）
- **Tier 2**: launchd / systemd --user / schtasks
- **必須条件**: `ANTHROPIC_API_KEY`, Project Configuration, PATH 解決

## Test plan

- [ ] ADR の内容がレビュー済み
- [ ] 既存 ADR との整合性確認

closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)