### PR TITLE
fix: plugin-release.yml が branch protection で失敗する問題を修正

### DIFF
--- a/.github/workflows/plugin-release-tag.yml
+++ b/.github/workflows/plugin-release-tag.yml
@@ -1,0 +1,52 @@
+name: plugin release tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag-and-release:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract plugin and version
+        id: extract
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # release/cekernel-v1.2.0 → cekernel-v1.2.0
+          TAG="${BRANCH#release/}"
+          # cekernel-v1.2.0 → cekernel
+          PLUGIN="${TAG%-v*}"
+          # cekernel-v1.2.0 → 1.2.0
+          VERSION="${TAG##*-v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "plugin=${PLUGIN}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.extract.outputs.tag }}"
+          PLUGIN="${{ steps.extract.outputs.plugin }}"
+          PREV_TAG=$(git tag -l "${PLUGIN}-v*" --sort=-v:refname | head -1)
+
+          if [ -n "${PREV_TAG}" ]; then
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --generate-notes \
+              --notes-start-tag "${PREV_TAG}"
+          else
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --generate-notes
+          fi

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -12,10 +12,11 @@ on:
         default: 'cekernel'
 
 jobs:
-  release:
+  create-release-pr:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -33,49 +34,38 @@ jobs:
             exit 1
           fi
 
-      - name: Update plugin.json
-        run: |
-          jq --arg v "${{ inputs.version }}" '.version = $v' \
-            "${{ inputs.plugin }}/.claude-plugin/plugin.json" > tmp.json
-          mv tmp.json "${{ inputs.plugin }}/.claude-plugin/plugin.json"
-
-      - name: Commit via API
+      - name: Create release branch and PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          FILE_PATH="${{ inputs.plugin }}/.claude-plugin/plugin.json"
-          FILE_SHA=$(gh api "repos/${{ github.repository }}/contents/${FILE_PATH}" --jq '.sha')
-          CONTENT=$(base64 -w0 < "${FILE_PATH}")
-          COMMIT_SHA=$(gh api "repos/${{ github.repository }}/contents/${FILE_PATH}" \
-            -X PUT \
-            -f message="release: ${{ inputs.plugin }} v${{ inputs.version }}" \
-            -f content="${CONTENT}" \
-            -f sha="${FILE_SHA}" \
-            --jq '.commit.sha')
-          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
-        id: commit
+          PLUGIN="${{ inputs.plugin }}"
+          VERSION="${{ inputs.version }}"
+          BRANCH="release/${PLUGIN}-v${VERSION}"
+          TAG="${PLUGIN}-v${VERSION}"
 
-      - name: Create tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/${{ inputs.plugin }}-v${{ inputs.version }}" \
-            -f sha="${{ steps.commit.outputs.commit_sha }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ inputs.plugin }}-v${{ inputs.version }}"
-          PREV_TAG=$(git tag -l '${{ inputs.plugin }}-v*' --sort=-v:refname | head -1)
-          if [ -n "${PREV_TAG}" ]; then
-            gh release create "${TAG}" \
-              --title "${TAG}" \
-              --generate-notes \
-              --notes-start-tag "${PREV_TAG}"
-          else
-            gh release create "${TAG}" \
-              --title "${TAG}" \
-              --generate-notes
-          fi
+          git checkout -b "${BRANCH}"
+
+          jq --arg v "${VERSION}" '.version = $v' \
+            "${PLUGIN}/.claude-plugin/plugin.json" > tmp.json
+          mv tmp.json "${PLUGIN}/.claude-plugin/plugin.json"
+
+          git add "${PLUGIN}/.claude-plugin/plugin.json"
+          git commit -m "release: ${PLUGIN} v${VERSION}"
+          git push -u origin "${BRANCH}"
+
+          BODY="$(cat <<EOF
+          ## Release ${PLUGIN} v${VERSION}
+
+          Version bump for ${PLUGIN} plugin.
+
+          - Updates \`${PLUGIN}/.claude-plugin/plugin.json\` version to \`${VERSION}\`
+          - On merge, \`plugin-release-tag.yml\` will automatically create tag \`${TAG}\` and GitHub Release
+          EOF
+          )"
+
+          gh pr create \
+            --title "release: ${PLUGIN} v${VERSION}" \
+            --body "${BODY}"

--- a/cekernel/CLAUDE.md
+++ b/cekernel/CLAUDE.md
@@ -194,7 +194,12 @@ Version management is automated via the `/release-cekernel` skill and GitHub Act
 /release-cekernel
 ```
 
-The skill analyzes git log and recommends a bump level. After confirmation, it triggers CI via `gh workflow run`, and CI performs the version bump + commit + tag + push.
+The skill analyzes git log and recommends a bump level. After confirmation:
+
+1. CI creates a `release/cekernel-vX.Y.Z` branch with the version bump and opens a PR
+2. Human reviews and merges the PR (follows normal branch protection)
+3. `plugin-release-tag.yml` automatically creates the tag and GitHub Release on merge
+4. Human edits the release notes to add categorized summary
 
 ### Versioned Artifacts
 

--- a/cekernel/skills/release-cekernel/SKILL.md
+++ b/cekernel/skills/release-cekernel/SKILL.md
@@ -1,0 +1,141 @@
+---
+description: Analyze git log, recommend a version bump, and trigger the plugin release workflow
+argument-hint: "[version]"
+allowed-tools: Bash, Read
+---
+
+# /release-cekernel
+
+Analyzes the git log since the last release tag, recommends a semantic version bump level, and triggers the `plugin-release.yml` workflow to create a release PR.
+
+## Usage
+
+```
+/release-cekernel
+/release-cekernel 1.3.0
+```
+
+If a version is provided, skip the analysis and use it directly. Otherwise, analyze commits and recommend a version.
+
+## Workflow
+
+### Step 1: Determine Current Version and Last Tag
+
+```bash
+PREV_TAG=$(git tag -l 'cekernel-v*' --sort=-v:refname | head -1)
+CURRENT_VERSION=$(jq -r '.version' cekernel/.claude-plugin/plugin.json)
+echo "Current version: ${CURRENT_VERSION}"
+echo "Last tag: ${PREV_TAG}"
+```
+
+### Step 2: Analyze Commits Since Last Tag
+
+```bash
+git log "${PREV_TAG}..HEAD" --oneline --no-merges
+```
+
+Classify each commit by its conventional commit prefix:
+
+| Prefix | Category | Bump |
+|--------|----------|------|
+| `feat:` | New Features | minor |
+| `fix:` | Bug Fixes | patch |
+| `docs:` | Documentation | patch |
+| `test:` | Tests | patch |
+| `refactor:` | Refactoring | patch |
+| Breaking changes | Breaking | major |
+
+The highest-level bump wins:
+- Any breaking change → **major**
+- Any `feat:` → **minor**
+- Otherwise → **patch**
+
+### Step 3: Recommend Version
+
+Calculate the recommended version from the current version and the determined bump level. Present to the user:
+
+```
+## Release Analysis
+
+Last tag: cekernel-v1.2.0
+Commits since last tag: N
+
+### Changes
+- feat: 2 commits (minor bump)
+- fix: 3 commits
+- docs: 1 commit
+
+### Recommended bump: minor
+### Proposed version: 1.3.0
+
+Proceed? (y/n)
+```
+
+If the user provided a version argument, show the analysis but use the specified version instead.
+
+Wait for user confirmation before proceeding.
+
+### Step 4: Trigger Release Workflow
+
+```bash
+gh workflow run plugin-release.yml -f version=<VERSION> -f plugin=cekernel
+```
+
+### Step 5: Monitor Workflow
+
+```bash
+# Wait a few seconds for the run to appear
+sleep 5
+RUN_ID=$(gh run list --workflow=plugin-release.yml --limit=1 --json databaseId --jq '.[0].databaseId')
+echo "Workflow run: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/runs/${RUN_ID}"
+gh run watch "${RUN_ID}"
+```
+
+### Step 6: Report Result
+
+After the workflow completes, find the created PR:
+
+```bash
+PR_NUMBER=$(gh pr list --head "release/cekernel-v<VERSION>" --json number --jq '.[0].number')
+echo "Release PR: #${PR_NUMBER}"
+```
+
+Report to the user:
+
+```
+## Release PR Created
+
+- **PR**: #<number>
+- **Branch**: release/cekernel-v<VERSION>
+- **Version**: <VERSION>
+
+### Next Steps
+1. Review the PR and merge it
+2. On merge, `plugin-release-tag.yml` will automatically create tag `cekernel-v<VERSION>` and GitHub Release
+3. Edit the release notes to add categorized summary (see format below)
+```
+
+### Step 7: Release Notes Format
+
+After the GitHub Release is auto-created, the release notes should follow this format. Instruct the user to edit the release at `https://github.com/<repo>/releases/tag/cekernel-v<VERSION>`:
+
+```markdown
+## Highlights
+- Key changes in bullet points
+
+## New Features
+- feat: commit descriptions
+
+## Bug Fixes
+- fix: commit descriptions
+
+## Documentation
+- docs: commit descriptions
+
+## What's Changed
+* Auto-generated PR list (kept from --generate-notes)
+
+**Full Changelog**: compare URL (kept from --generate-notes)
+```
+
+Generate a draft of the Highlights, New Features, Bug Fixes, and Documentation sections from the commit analysis in Step 2, and present it to the user for copy-paste into the release notes.


### PR DESCRIPTION
closes #198

## Summary
- `plugin-release.yml` を直接コミット方式から PR ベース方式に変更
- `plugin-release-tag.yml` を新規追加（release PR マージ時にタグ + GitHub Release を自動作成）
- `/release-cekernel` スキルを新規作成（git log 分析 → バージョン推薦 → ワークフロー起動）
- `cekernel/CLAUDE.md` のリリース手順セクションを更新

## 変更の背景
branch protection ruleset により `GITHUB_TOKEN` で main に直接コミットできなくなったため、リリースフローを2段階の PR ベース方式に分割:
1. `plugin-release.yml`: release ブランチ作成 + version bump + PR 作成
2. `plugin-release-tag.yml`: PR マージ時にタグ + GitHub Release を自動作成

## Test Plan
- [x] 既存の cekernel tests が全て pass
- [ ] `gh workflow run plugin-release.yml -f version=X.Y.Z -f plugin=cekernel` で release PR が作成されること
- [ ] release PR マージ後にタグと GitHub Release が自動作成されること