### PR TITLE
refactor: rename all glimmer references to cekernel

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "clonable-eden"
   },
-  "repository": "https://github.com/clonable-eden/glimmer",
+  "repository": "https://github.com/clonable-eden/cekernel",
   "license": "MIT",
   "keywords": [
     "parallel",

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ Install from the Claude Code plugin marketplace:
 
 ```bash
 # 1. Add marketplace
-/plugin marketplace add clonable-eden/glimmer
+/plugin marketplace add clonable-eden/cekernel
 
 # 2. Install cekernel plugin
-/plugin install cekernel@clonable-eden-glimmer
+/plugin install cekernel@clonable-eden-cekernel
 ```
 
 ### Update

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -36,12 +36,12 @@ Source `session-id.sh` at the start to generate CEKERNEL_SESSION_ID, then explic
 ```bash
 # 1. Generate CEKERNEL_SESSION_ID (using the centralized generation logic in session-id.sh)
 source session-id.sh && echo $CEKERNEL_SESSION_ID
-# => glimmer-7861a821
+# => cekernel-7861a821
 
 # 2. Pass CEKERNEL_SESSION_ID as environment variable in all subsequent commands
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && spawn-worker.sh 4
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && watch-worker.sh 4   # run_in_background: true
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && cleanup-worktree.sh 4
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && spawn-worker.sh 4
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && watch-worker.sh 4   # run_in_background: true
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && cleanup-worktree.sh 4
 ```
 
 ### CEKERNEL_AGENT_WORKER Propagation
@@ -50,7 +50,7 @@ When the `/orchestrate` skill detects plugin mode (skill namespace prefix `ceker
 
 ```bash
 # Example: propagate agent name to spawn-worker.sh
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_AGENT_WORKER=cekernel:worker && spawn-worker.sh 4
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && export CEKERNEL_AGENT_WORKER=cekernel:worker && spawn-worker.sh 4
 ```
 
 `spawn-worker.sh` defaults `CEKERNEL_AGENT_WORKER` to `worker` if unset, ensuring safe fallback for direct execution.
@@ -63,10 +63,10 @@ If no `--env` is specified, `CEKERNEL_ENV` defaults to `default` (handled by `lo
 
 ```bash
 # Example: propagate headless profile to all script calls
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_ENV=headless && spawn-worker.sh 4
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_ENV=headless && watch-worker.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_ENV=headless && worker-status.sh
-export CEKERNEL_SESSION_ID=glimmer-7861a821 && export CEKERNEL_ENV=headless && cleanup-worktree.sh 4
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && export CEKERNEL_ENV=headless && spawn-worker.sh 4
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && export CEKERNEL_ENV=headless && watch-worker.sh 4  # run_in_background: true
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && export CEKERNEL_ENV=headless && worker-status.sh
+export CEKERNEL_SESSION_ID=cekernel-7861a821 && export CEKERNEL_ENV=headless && cleanup-worktree.sh 4
 ```
 
 The propagation chain:

--- a/docs/adr/0006-env-var-catalog-and-profiles.md
+++ b/docs/adr/0006-env-var-catalog-and-profiles.md
@@ -25,7 +25,7 @@ Additionally, common configurations recur: "local dev with WezTerm", "headless C
 
 ### Plugin context
 
-cekernel is distributed as a Claude Code plugin. When installed via `/plugin install cekernel@clonable-eden-glimmer`, the plugin files reside in the Claude Code plugin directory (`.claude/plugins/` hierarchy). Files within it are **overwritten on `/plugin update`** — users should not edit plugin-internal files for project-specific configuration.
+cekernel is distributed as a Claude Code plugin. When installed via `/plugin install cekernel@clonable-eden-cekernel`, the plugin files reside in the Claude Code plugin directory (`.claude/plugins/` hierarchy). Files within it are **overwritten on `/plugin update`** — users should not edit plugin-internal files for project-specific configuration.
 
 This creates a tension: the plugin ships sensible defaults, but each project may need different settings (e.g., one project uses WezTerm, another uses headless for CI). Configuration must live in a place that survives plugin updates and is scoped to the project.
 

--- a/docs/adr/0007-dual-path-completion-detection.md
+++ b/docs/adr/0007-dual-path-completion-detection.md
@@ -11,7 +11,7 @@ During execution of issue #72, a Worker completed its work successfully — the 
 Observed IPC directory state:
 
 ```
-/tmp/cekernel-ipc/glimmer-11535bdc/
+/tmp/cekernel-ipc/cekernel-11535bdc/
   ├── pane-72              # handle file (old naming — see note)
   ├── worker-72.state      # TERMINATED:2026-02-27T09:00:28Z:merged
   ├── worker-72.priority   # exists

--- a/docs/adr/0009-file-based-namespace-detection.md
+++ b/docs/adr/0009-file-based-namespace-detection.md
@@ -10,7 +10,7 @@ cekernel operates in two modes depending on how it is installed:
 
 | Mode | Installation | Agent invocation |
 |------|-------------|-----------------|
-| Plugin | `/plugin install cekernel@clonable-eden-glimmer` | `cekernel:orchestrator`, `cekernel:worker` |
+| Plugin | `/plugin install cekernel@clonable-eden-cekernel` | `cekernel:orchestrator`, `cekernel:worker` |
 | Local | Project-local `.claude/agents/`, `.claude/skills/` | `orchestrator`, `worker` |
 
 The Orchestrator must know which mode it is running in to spawn Workers with the correct agent name. If a plugin-mode Orchestrator spawns `claude --agent worker`, the agent is not found. If a local-mode Orchestrator spawns `claude --agent cekernel:worker`, it silently uses the outdated plugin-installed version instead of the local development version.
@@ -99,9 +99,9 @@ The probe skill (`skills/probe/SKILL.md`) and probe agent (`agents/probe.md`) we
 
 | # | Repository | Invocation | LLM detection | D2 (file) | Agent spawn | Correct answer |
 |---|-----------|------------|:---:|:---:|:---:|:---:|
-| 1 | glimmer (no symlinks) | `cekernel:probe` | `cekernel` | `local` | `probe` — **failed** | `local` |
-| 2 | glimmer (symlinks) | `probe` | `local` | `local` | `probe` — success | `local` |
-| 3 | glimmer (symlinks) | `cekernel:probe` | `cekernel` | `local` | `probe` — success | `local`* |
+| 1 | cekernel (no symlinks) | `cekernel:probe` | `cekernel` | `local` | `probe` — **failed** | `local` |
+| 2 | cekernel (symlinks) | `probe` | `local` | `local` | `probe` — success | `local` |
+| 3 | cekernel (symlinks) | `cekernel:probe` | `cekernel` | `local` | `probe` — success | `local`* |
 | 4 | dotfiles (external repo) | `cekernel:probe` | `cekernel` | `cekernel` | `cekernel:probe` — success | `cekernel` |
 
 **Key findings:**
@@ -111,7 +111,7 @@ The probe skill (`skills/probe/SKILL.md`) and probe agent (`agents/probe.md`) we
 - **Scenario 3**: D2 detects `local` while LLM detects `cekernel` — D2 is correct because the local source exists and should be used. The namespaced invocation in a self-hosting context is the user error, not a D2 failure
 - **Scenario 4**: Both methods agree — external repository correctly resolves to plugin mode
 
-\* Scenario 3: In a self-hosting repository, D2 always returns `local` regardless of invocation namespace. This is the intended behavior — self-hosting means "use the local version". Using `cekernel:probe` in the glimmer repository is an operational error (convention violation, not a detection bug).
+\* Scenario 3: In a self-hosting repository, D2 always returns `local` regardless of invocation namespace. This is the intended behavior — self-hosting means "use the local version". Using `cekernel:probe` in the cekernel repository is an operational error (convention violation, not a detection bug).
 
 D2 achieved **4/4 correct results** under the convention that self-hosting repositories use non-namespaced invocation.
 
@@ -208,7 +208,7 @@ The symlink targets are also updated: `../../cekernel/agents/*.md` → `../../ag
 
 ## References
 
-- Issue: [#137](https://github.com/clonable-eden/glimmer/issues/137) — Namespace resolution bug
-- Probe verification: [#137 comment](https://github.com/clonable-eden/glimmer/issues/137) — D2 verification results
+- Issue: [#137](https://github.com/clonable-eden/cekernel/issues/137) — Namespace resolution bug
+- Probe verification: [#137 comment](https://github.com/clonable-eden/cekernel/issues/137) — D2 verification results
 - Claude Code limitations: [anthropics/claude-code#9354](https://github.com/anthropics/claude-code/issues/9354), [#11011](https://github.com/anthropics/claude-code/issues/11011), [#10113](https://github.com/anthropics/claude-code/issues/10113), [#12541](https://github.com/anthropics/claude-code/issues/12541)
 - ADR-0006 Amendment: `BASH_SOURCE[0]` migration for `CLAUDE_PLUGIN_ROOT` removal

--- a/docs/adr/0010-worker-env-profile-loading.md
+++ b/docs/adr/0010-worker-env-profile-loading.md
@@ -204,7 +204,7 @@ The rest of ADR-0006 remains valid: the profile mechanism, loading order, `.env`
 
 ## References
 
-- Issue: [#82](https://github.com/clonable-eden/glimmer/issues/82) — Make CI retry count configurable
+- Issue: [#82](https://github.com/clonable-eden/cekernel/issues/82) — Make CI retry count configurable
 - ADR-0006: [Centralized Environment Variable Catalog and Profiles](./0006-env-var-catalog-and-profiles.md)
 - `load-env.sh`: `scripts/shared/load-env.sh`
 - `worker.md` On Error: `agents/worker.md` (line 234-243)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -104,7 +104,7 @@ This reduces the `send-text` command from ~1173 bytes to ~124 bytes, well within
 | `spawn-worker.sh` rollback | Deletes `payload-{issue}.b64` |
 | `cleanup-worktree.sh` | Deletes `payload-{issue}.b64` |
 
-Related: [#173](https://github.com/clonable-eden/glimmer/issues/173), [PR #175](https://github.com/clonable-eden/glimmer/pull/175).
+Related: [#173](https://github.com/clonable-eden/cekernel/issues/173), [PR #175](https://github.com/clonable-eden/cekernel/pull/175).
 
 ## Claude Code Environment Variable Cleanup
 
@@ -140,4 +140,4 @@ Or in a subshell to avoid affecting the parent:
 
 The headless backend (`scripts/shared/backends/headless.sh`) applies this cleanup when spawning Workers. Terminal-based backends (WezTerm, tmux) naturally get a clean environment because they create new shell sessions.
 
-Related: [#117](https://github.com/clonable-eden/glimmer/issues/117), [PR #178](https://github.com/clonable-eden/glimmer/pull/178).
+Related: [#117](https://github.com/clonable-eden/cekernel/issues/117), [PR #178](https://github.com/clonable-eden/cekernel/pull/178).

--- a/scripts/shared/session-id.sh
+++ b/scripts/shared/session-id.sh
@@ -8,8 +8,8 @@
 #   CEKERNEL_IPC_DIR    — Exports /tmp/cekernel-ipc/${CEKERNEL_SESSION_ID}
 
 if [[ -z "${CEKERNEL_SESSION_ID:-}" ]]; then
-  # Get repository name (fallback to "glimmer" outside git)
-  _repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "glimmer")
+  # Get repository name (fallback to "cekernel" outside git)
+  _repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "cekernel")
   # Random 8-digit hex
   _hex=$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')
   export CEKERNEL_SESSION_ID="${_repo_name}-${_hex}"

--- a/skills/orchctrl/SKILL.md
+++ b/skills/orchctrl/SKILL.md
@@ -30,8 +30,8 @@ All commands except `ls` require a `<target>` to identify the Worker.
 | Format | Example | Usage |
 |--------|---------|-------|
 | `<issue>` | `4` | Unique across all sessions |
-| `<repo>:<issue>` | `glimmer:4` | Filter by repo name |
-| `<issue> --session <id>` | `4 --session glimmer-7861a821` | Explicit session ID |
+| `<repo>:<issue>` | `cekernel:4` | Filter by repo name |
+| `<issue> --session <id>` | `4 --session cekernel-7861a821` | Explicit session ID |
 
 Rules:
 - Try `<issue>` alone first; if unique, execute


### PR DESCRIPTION
## Summary

- リポジトリ名変更 (`clonable-eden/glimmer` → `clonable-eden/cekernel`) に伴い、コード・ドキュメント内の全 `glimmer` 参照を `cekernel` に更新
- 動作影響: `plugin.json` の repository URL、`session-id.sh` のフォールバック名
- ドキュメント: README, orchestrator.md, orchctrl SKILL.md, internals.md, ADR-0006/0007/0009/0010 の例示・issue/PRリンク

## Test plan

- [x] `grep -r glimmer` で残存参照がゼロであることを確認
- [x] `run-tests.sh` で回帰なし（失敗2件は既知の既存問題）

closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)