### PR TITLE
docs: ADR-0011 の設計改善 — launchd 採用、ロック粒度変更、通知追加

### DIFF
--- a/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
+++ b/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
@@ -182,7 +182,7 @@ Skill names (`cron`, `at`) and subcommands (`register`, `list`, `cancel`) follow
 
 > **Rule of Extensibility**: "Design for the future, because it will be here sooner than you think."
 
-The `os_backend` field enables tracking the transition from crontab to launchd/systemd/schtasks at the registry level. The skill interface (`register`/`list`/`cancel`) remains unchanged.
+The `os_backend` field identifies which backend manages each entry and tracks Tier 1 → Tier 2 migrations (e.g., crontab to systemd on Linux). The skill interface (`register`/`list`/`cancel`) remains unchanged regardless of backend.
 
 ### Platform Constraints
 
@@ -197,7 +197,7 @@ The `os_backend` field enables tracking the transition from crontab to launchd/s
 When a scheduled run fails (non-zero exit from `claude -p` or `/dispatch`), the failure is:
 
 1. **Logged**: stdout/stderr is appended to `/usr/local/var/cekernel/logs/schedule.log` via the `>> ... 2>&1` redirect in the scheduled command. Diagnosis starts here. Session persistence is enabled (no `--no-session-persistence`), so `--resume` can be used to inspect the execution context after the fact.
-2. **Recorded**: The wrapper script updates the registry entry's `last_run_status` (to `"error"`) and `last_run_at` fields after each execution. `/cron list` displays these fields, enabling at-a-glance health monitoring.
+2. **Recorded**: The wrapper script updates the registry entry's `last_run_status` (to `"error"`) and `last_run_at` fields after each execution. `/cron list` (or `/at list`) displays these fields, enabling at-a-glance health monitoring.
 3. **Notified (best-effort)**: The wrapper sends an OS-native desktop notification on failure — `osascript` on macOS, `notify-send` on Linux (WSL with WSLg). Notification is best-effort; the primary diagnostic sources are the log file and registry status. This follows the Rule of Silence — successful runs produce no notification.
 4. **Not retried automatically**: Tier 1 does not implement retry logic. A failed run simply waits for the next scheduled invocation. This follows the Rule of Repair ("When you must fail, fail noisily and as soon as possible") — failures are visible in the log, registry, and notification, not silently retried.
 


### PR DESCRIPTION
## Summary

ADR-0011 (Scheduled Trigger via OS-native Schedulers) のレビューにより特定された設計上の問題を修正する。

- macOS Tier 1 バックエンドを crontab → **launchd** に変更（スリープ中のジョブスキップ問題）
- ロック粒度を per-repo → **repo × issue** に細粒度化（cekernel の並列モデルと整合）
- OS ネイティブ失敗通知の追加（Rule of Silence: 失敗時のみ）
- `--no-session-persistence` 削除（障害診断に `--resume` が必要）
- `--max-budget-usd` をデフォルトから除外（Pro Max 前提）
- PATH スナップショット制約の明記
- ランタイム状態を `/usr/local/var/cekernel/` に統一（UNIX `/var/` 慣習）
- `/at` バックエンドの明文化（macOS: launchd, Linux: atd）
- API キー動的取得パターンへの変更

## Test plan

- [ ] ADR ドキュメントの内部整合性確認（パス、用語、セクション間参照）
- [ ] UNIX philosophy review による設計評価（3回実施、Approve 取得済み）

closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)