### PR TITLE
docs: add ADR-0012 worker-review-separation

### DIFF
--- a/docs/adr/0012-worker-review-separation.md
+++ b/docs/adr/0012-worker-review-separation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
closes #228

## Summary
- Worker の責務を CI pass までに限定し、レビュー・マージを分離する ADR-0012 を追加
- Worker（実装）、Reviewer（レビュー、GitHub App）、Orchestrator（マージ判断・ライフサイクル管理）の3つの役割に分離
- Issue lock の `ci-passed` 時の挙動、Reviewer エラーハンドリング、concurrency slot の振る舞いを明記

## Test plan
- [ ] ADR の内容をレビュー（UNIX 哲学との整合性、プラットフォーム制約の妥当性）
- [ ] ADR Accepted 後、sub-issue A〜F を作成して実装に移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)