### PR TITLE
feat: add Reviewer agent definition (ADR-0012)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -35,8 +35,8 @@ Read the target repository's CLAUDE.md and any referenced documents to understan
 - Project-specific rules
 
 ```bash
-# Read CLAUDE.md from the repository root
-cat CLAUDE.md
+# Read CLAUDE.md from the repository root (may be at <root>/CLAUDE.md or <root>/.claude/CLAUDE.md)
+cat CLAUDE.md 2>/dev/null || cat .claude/CLAUDE.md
 ```
 
 If CLAUDE.md references other documents, read those as well.
@@ -94,7 +94,7 @@ The review body must clearly describe what needs to be fixed so that the Worker 
 Return a single word to the Orchestrator indicating the verdict:
 
 - `approved` — PR is ready for merge (Orchestrator decides whether to auto-merge or wait for human)
-- `changes-requested` — PR needs rework (Orchestrator re-spawns Worker with `--resume`)
+- `changes-requested` — PR needs rework (Orchestrator spawns a new Worker with `--resume` to reuse the existing worktree)
 
 ## Constraints
 


### PR DESCRIPTION
closes #247

## Summary
- ADR-0012 に基づき、Reviewer Agent の定義ファイル `agents/reviewer.md` を新設
- Reviewer は Orchestrator の subagent として `run_in_background` で起動し、Worker が作成した PR を独立したコンテキストウィンドウでレビューする
- Tools: `Bash` のみ（`gh` CLI 経由の read-only 操作）
- 判定結果: `approved` または `changes-requested` を Orchestrator に返す
- Reviewer はマージしない、ファイルを変更しない（read-only review）

## Test Plan
- [ ] ドキュメントのみの変更のため、実行可能スクリプトのテストは不要
- [ ] CI パス確認