### PR TITLE
docs: add CEKERNEL_AUTO_MERGE and CEKERNEL_REVIEW_MAX_RETRIES to env catalog (ADR-0012)

### DIFF
--- a/envs/README.md
+++ b/envs/README.md
@@ -14,6 +14,8 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Any filename | `checkpoint-file.sh` | Checkpoint file name in worktree |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Any filename | `task-file.sh` | Task file name in worktree |
 | `CEKERNEL_CI_MAX_RETRIES` | `3` | Positive integer | `worker.md` (Phase 3) | Maximum CI retry attempts before Worker reports failure |
+| `CEKERNEL_AUTO_MERGE` | `false` | `true`, `false` | Orchestrator | `true`: Reviewer 承認後に Orchestrator が自動マージ。`false`: desktop 通知のみ、人間がマージ |
+| `CEKERNEL_REVIEW_MAX_RETRIES` | `2` | Positive integer | Orchestrator | Reviewer の reject → Worker re-implement サイクルの上限。超過時は人間にエスカレーション |
 | `CEKERNEL_VAR_DIR` | `/usr/local/var/cekernel` | Directory path | `registry.sh`, `wrapper.sh` | Runtime state directory (locks, logs, runners, registry) |
 
 ## Internal Variables


### PR DESCRIPTION
closes #251

## Summary
- ADR-0012 (Worker/Reviewer 分離) で定義された2つの環境変数を `envs/README.md` のカタログに追加
  - `CEKERNEL_AUTO_MERGE` (default: `false`) — Reviewer 承認後の自動マージ制御
  - `CEKERNEL_REVIEW_MAX_RETRIES` (default: `2`) — reject → re-implement サイクルの上限

## Test Plan
- [ ] `envs/README.md` のテーブルが正しくレンダリングされることを確認
- [ ] 既存の CI テストが通ることを確認（ドキュメントのみの変更のため既存テストに影響なし）