### PR TITLE
feat: add CODEOWNERS and enable require_code_owner_review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS
+* @clonable-eden


### PR DESCRIPTION
closes #252

## 概要

外部 PR に対する code owner review を必須化するための変更。

### 変更内容

1. **`.github/CODEOWNERS` の追加** — `* @clonable-eden` で全ファイルの code owner を設定
2. **Ruleset の更新** — `require_code_owner_review: false → true`（PR マージ後に GitHub API で適用）

### 影響

- 外部 PR のマージには `@clonable-eden` の approve が必須となる
- operator 自身の PR は引き続き admin bypass でマージ可能
- `require_last_push_approval` は `false` のまま維持
- cekernel のワークフロー（Worker/Reviewer）への影響なし