### PR TITLE
fix: add missing reviewer agent symlink

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,1 @@
+../../agents/reviewer.md


### PR DESCRIPTION
## Summary

- `agents/reviewer.md` の `.claude/agents/` への symlink が欠けていたのを追加

#248 の作業漏れ。

## Test plan

- [x] `ls -la .claude/agents/reviewer.md` で symlink 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)