### PR TITLE
fix: add Agent tool to Orchestrator for Reviewer subagent launch

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrator
 description: Orchestrator agent that manages issue lifecycle in the main working tree. Handles issue intake, worktree creation, Worker spawning, completion monitoring, review coordination, and cleanup.
-tools: Read, Edit, Write, Bash, Agent
+tools: Read, Edit, Write, Bash, Agent(reviewer)
 ---
 
 # Orchestrator Agent


### PR DESCRIPTION
## Summary

- Orchestrator の `tools` frontmatter に `Agent` を追加
- ADR-0012 の Reviewer フェーズで、Orchestrator が Reviewer をサブエージェントとして起動するために必要

#248 の実装漏れ。`Agent` ツールがないため、Orchestrator が Bash で無理やり Reviewer を起動しようとしていた。

## Test plan

- [x] `agents/orchestrator.md` frontmatter に `Agent` が含まれることを確認
- [ ] `/orchestrate` で Worker `ci-passed` 後に Reviewer が Agent ツールで起動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)