### PR TITLE
docs: fix remaining watch-worker.sh references and Structure section gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Orchestrator (agent1)             Worker (agent2, 3, 4, ...)
 | SIGSTOP / SIGCONT | `send-signal.sh SUSPEND` / `spawn-worker.sh --resume` |
 | SIGKILL | `cleanup-worktree.sh --force` |
 | SIGALRM / watchdog | `CEKERNEL_WORKER_TIMEOUT` + escalation (TERM → grace → force-kill) |
-| `waitpid` | `watch-worker.sh` (triple-path: FIFO + state file + crash detection) |
+| `waitpid` | `watch.sh` (triple-path: FIFO + state file + crash detection) |
 | zombie reaping | `health-check.sh` + `cleanup-worktree.sh` |
 | core dump / checkpoint | `.cekernel-checkpoint.md` (suspend/resume) |
 | `systemctl` | `orchctrl.sh` / `/orchctrl` skill |
@@ -88,7 +88,7 @@ docs/
   unix-philosophy.md       # UNIX philosophy reference
 envs/
   ci.env                   # CI profile (headless, 1800s timeout)
-  default.env              # Default profile (wezterm, 3 workers)
+  default.env              # Default profile (wezterm, 3 processes)
   headless.env             # Headless profile (headless, 5 workers)
   README.md                # Environment variable catalog
 Makefile                   # Runtime directory setup (make install)
@@ -100,9 +100,10 @@ scripts/
     orchctrl.sh            # Worker control interface (systemctl for cekernel)
     send-signal.sh         # Send signal (TERM/SUSPEND) to a running Worker
     spawn.sh               # Common process spawning logic (concurrency guard, FIFO, state, backend, Type)
+    spawn-reviewer.sh      # Spawn Reviewer (thin wrapper for spawn.sh --agent reviewer)
     spawn-worker.sh        # Spawn Worker (thin wrapper for spawn.sh --agent worker)
     watch-logs.sh          # Real-time Worker log monitoring
-    watch-worker.sh        # Monitor Worker completion (FIFO + state file + crash detection)
+    watch.sh               # Monitor process completion (FIFO + state file + crash detection)
     process-status.sh       # List active processes (Workers and Reviewers)
   scheduler/
     at-backend.sh          # At backend adapter (launchd/atd)

--- a/envs/README.md
+++ b/envs/README.md
@@ -11,7 +11,7 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_BACKEND` | `wezterm` | `wezterm`, `tmux`, `headless` | `backend-adapter.sh` | Select Worker process backend |
 | `CEKERNEL_MAX_PROCESSES` | `3` | Positive integer | `spawn.sh` | Maximum concurrent processes |
 | `CEKERNEL_MAX_WORKERS` | — | Positive integer | `spawn.sh` | **Deprecated**: use `CEKERNEL_MAX_PROCESSES`. If set, overrides `CEKERNEL_MAX_PROCESSES` and emits a warning |
-| `CEKERNEL_WORKER_TIMEOUT` | `3600` | Positive integer (seconds) | `watch-worker.sh` | Worker timeout before auto-termination |
+| `CEKERNEL_WORKER_TIMEOUT` | `3600` | Positive integer (seconds) | `watch.sh` | Worker timeout before auto-termination |
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Any filename | `checkpoint-file.sh` | Checkpoint file name in worktree |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Any filename | `task-file.sh` | Task file name in worktree |
 | `CEKERNEL_CI_MAX_RETRIES` | `3` | Positive integer | `worker.md` (Phase 3) | Maximum CI retry attempts before Worker reports failure |

--- a/scripts/process/notify-complete.sh
+++ b/scripts/process/notify-complete.sh
@@ -37,7 +37,7 @@ EVENT="COMPLETE"
 # ── Write JSON message to FIFO ──
 # This write unblocks the orchestrator's blocking read (primary fast path).
 # If FIFO is missing, log a warning but exit 0 — the state file fallback will
-# be detected by watch-worker.sh's polling loop.
+# be detected by watch.sh's polling loop.
 if [[ ! -p "$FIFO" ]]; then
   echo "Warning: FIFO not found at $FIFO" >&2
   echo "Orchestrator will detect completion via state file fallback." >&2


### PR DESCRIPTION
closes #280

## Summary
- `README.md`: OS Analogy table と Structure section の `watch-worker.sh` → `watch.sh` 修正
- `README.md`: Structure section の `3 workers` → `3 processes` 修正、`spawn-reviewer.sh` 追加
- `envs/README.md`: Variable catalog の `watch-worker.sh` → `watch.sh` 修正
- `scripts/process/notify-complete.sh`: コメント内の `watch-worker.sh` → `watch.sh` 修正

## Test Plan
- [ ] ドキュメントのみの変更のため、リンク切れやフォーマット崩れがないことを確認
- [ ] CI パス確認