### PR TITLE
fix: add Must Not rule to prevent Agent tool language in Orchestrator prompt

### DIFF
--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -116,6 +116,8 @@ export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=default && export CEKERNE
 export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=default && watch.sh 42  # run_in_background: true
 ```
 
+**MUST NOT**: Do not include Agent tool language (`subagent_type`, `Agent(worker)`, `Agent(reviewer)`, etc.) in the Orchestrator prompt. Workers and Reviewers are spawned by the Orchestrator via `spawn-worker.sh` / `spawn-reviewer.sh` (Bash), following its own agent definition. The skill must not dictate how the Orchestrator launches subprocesses.
+
 The Orchestrator autonomously executes:
 
 1. Issue verification and triage (FAIL for ambiguous issues)

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -82,6 +82,8 @@ export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=headless && export CEKERN
 export CEKERNEL_SESSION_ID=<ID> && export CEKERNEL_ENV=headless && watch.sh 108  # run_in_background: true
 ```
 
+**MUST NOT**: Do not include Agent tool language (`subagent_type`, `Agent(worker)`, `Agent(reviewer)`, etc.) in the Orchestrator prompt. Workers and Reviewers are spawned by the Orchestrator via `spawn-worker.sh` / `spawn-reviewer.sh` (Bash), following its own agent definition. The skill must not dictate how the Orchestrator launches subprocesses.
+
 The Orchestrator autonomously executes:
 
 1. Issue verification and triage (FAIL for ambiguous issues)


### PR DESCRIPTION
closes #282

## Summary
- `skills/orchestrate/SKILL.md` と `skills/dispatch/SKILL.md` に Must Not ルールを追加
- Orchestrator prompt に Agent ツールの言語（`subagent_type`, `Agent(worker)`, `Agent(reviewer)` 等）を含めることを禁止
- Workers/Reviewers は Orchestrator が自身の agent 定義に従い `spawn-worker.sh` / `spawn-reviewer.sh`（Bash）で起動する

## Test plan
- [ ] CI パス確認
- [ ] 次回の `/orchestrate` 実行時に Agent ツール言語が prompt に含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)