### PR TITLE
fix: type-aware handle files to prevent Worker pane orphaning

### DIFF
--- a/scripts/orchestrator/cleanup-worktree.sh
+++ b/scripts/orchestrator/cleanup-worktree.sh
@@ -25,12 +25,12 @@ ISSUE_NUMBER="${1:?Usage: cleanup-worktree.sh [--force] <issue-number>}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 WORKTREE_DIR="${REPO_ROOT}/.worktrees"
 
-# ── Kill Worker via backend ──
-# Backend reads handle file internally and kills the worker.
+# ── Kill all processes via backend (Worker + Reviewer) ──
+# Backend reads handle files internally and kills the processes.
 if backend_available; then
   backend_kill_worker "$ISSUE_NUMBER" 2>/dev/null || true
 fi
-rm -f "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+rm -f "${CEKERNEL_IPC_DIR}"/handle-"${ISSUE_NUMBER}".*
 
 # Find worktree matching issue number
 WORKTREE=$(git worktree list --porcelain \
@@ -68,7 +68,7 @@ rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.type"
 # Signal file cleanup
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.signal"
 # Handle file cleanup (in case not already removed)
-rm -f "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+rm -f "${CEKERNEL_IPC_DIR}"/handle-"${ISSUE_NUMBER}".*
 # Payload file cleanup (wezterm backend: avoids send-text 1024-byte limit)
 rm -f "${CEKERNEL_IPC_DIR}/payload-${ISSUE_NUMBER}.b64"
 

--- a/scripts/orchestrator/orchctrl.sh
+++ b/scripts/orchestrator/orchctrl.sh
@@ -161,9 +161,14 @@ compute_elapsed() {
 # ── Helper: detect backend from handle file ──
 detect_backend() {
   local ipc_dir="$1" issue="$2"
-  local handle_file="${ipc_dir}/handle-${issue}"
 
-  if [[ ! -f "$handle_file" ]]; then
+  # Find the first handle-{issue}.{type} file
+  local handle_file=""
+  for hf in "${ipc_dir}"/handle-"${issue}".*; do
+    [[ -f "$hf" ]] && handle_file="$hf" && break
+  done
+
+  if [[ -z "$handle_file" ]]; then
     echo "unknown"
     return
   fi
@@ -430,9 +435,9 @@ cmd_kill() {
   resolve_target "$@" || return 1
   set_ipc_context
 
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${RESOLVED_ISSUE}"
-
-  if [[ -f "$handle_file" ]]; then
+  # Kill all handle files for this issue (Worker + Reviewer)
+  for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${RESOLVED_ISSUE}".*; do
+    [[ -f "$handle_file" ]] || continue
     local handle_content
     handle_content=$(tr -d '[:space:]' < "$handle_file")
 
@@ -448,7 +453,7 @@ cmd_kill() {
       # wezterm — handle is pane ID
       wezterm cli kill-pane --pane-id "$handle_content" 2>/dev/null || true
     fi
-  fi
+  done
 
   # Mark as terminated
   worker_state_write "$RESOLVED_ISSUE" TERMINATED "killed"

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -104,8 +104,8 @@ WORKTREE="${WORKTREE_DIR}/${BRANCH}"
 rollback() {
   echo "Error: spawn.sh failed. Rolling back..." >&2
   # Kill process via backend (handle file managed internally)
-  backend_kill_worker "$ISSUE_NUMBER" 2>/dev/null || true
-  rm -f "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+  backend_kill_worker "$ISSUE_NUMBER" "$AGENT_TYPE" 2>/dev/null || true
+  rm -f "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}.${AGENT_TYPE}"
   # In resume mode, do not destroy the existing worktree/branch
   if [[ "${RESUME:-0}" -eq 0 ]]; then
     # Unregister trust
@@ -251,8 +251,8 @@ else
 fi
 
 # Backend handles workspace resolution, window spawning, and handle file management internally.
-# Callers pass only (issue, worktree, prompt) — the backend decides how to launch.
-backend_spawn_worker "$ISSUE_NUMBER" "$WORKTREE" "$PROMPT"
+# Callers pass (issue, type, worktree, prompt) — the backend decides how to launch.
+backend_spawn_worker "$ISSUE_NUMBER" "$AGENT_TYPE" "$WORKTREE" "$PROMPT"
 
 # ── State: READY (Worktree ready, Claude agent starting) ──
 worker_state_write "$ISSUE_NUMBER" READY "agent-starting"

--- a/scripts/orchestrator/watch.sh
+++ b/scripts/orchestrator/watch.sh
@@ -98,9 +98,13 @@ watch_one() {
       break
     fi
 
-    # Crash detection: if handle file exists but Worker process is dead, it crashed
+    # Crash detection: if any handle file exists but process is dead, it crashed
     # Only check when handle file is present (without it, we can't verify process status)
-    if [[ -f "${CEKERNEL_IPC_DIR}/handle-${issue}" ]] && ! backend_worker_alive "$issue" 2>/dev/null; then
+    local has_handle=0
+    for _hf in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$_hf" ]] && has_handle=1 && break
+    done
+    if [[ "$has_handle" -eq 1 ]] && ! backend_worker_alive "$issue" 2>/dev/null; then
       result="{\"issue\":${issue},\"result\":\"crashed\",\"detail\":\"Worker process died without completing\"}"
       echo "Error: issue #${issue} Worker process crashed (state: ${state})." >&2
       log_event "$issue" "WORKER_CRASH" "issue=#${issue} state=${state}"

--- a/scripts/shared/backends/headless.sh
+++ b/scripts/shared/backends/headless.sh
@@ -7,7 +7,7 @@
 #
 # Sourced by backend-adapter.sh when CEKERNEL_BACKEND=headless.
 #
-# Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue} contains PID (numeric).
+# Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains PID (numeric).
 # Process group: setsid creates a new process group for clean termination.
 
 # ── External API ──
@@ -17,13 +17,14 @@ backend_available() {
   return 0
 }
 
-# backend_spawn_worker <issue> <worktree> <prompt>
+# backend_spawn_worker <issue> <type> <worktree> <prompt>
 # Spawns a Worker as a background process via setsid.
 # Saves PID to handle file internally.
 backend_spawn_worker() {
   local issue="$1"
-  local worktree="$2"
-  local prompt="$3"
+  local type="$2"
+  local worktree="$3"
+  local prompt="$4"
 
   # Ensure log directory exists
   local log_dir="${CEKERNEL_IPC_DIR}/logs"
@@ -46,35 +47,57 @@ backend_spawn_worker() {
   local pid=$!
 
   # Save handle (PID)
-  echo "$pid" > "${CEKERNEL_IPC_DIR}/handle-${issue}"
+  echo "$pid" > "${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
 }
 
-# backend_worker_alive <issue>
+# backend_worker_alive <issue> [type]
 # exit 0 if alive, exit 1 if dead or no handle
+# If type is omitted, checks any handle-{issue}.* file.
 backend_worker_alive() {
   local issue="$1"
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}"
+  local type="${2:-}"
 
-  [[ -f "$handle_file" ]] || return 1
-
-  local pid
-  pid=$(cat "$handle_file")
-  kill -0 "$pid" 2>/dev/null
+  if [[ -n "$type" ]]; then
+    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    [[ -f "$handle_file" ]] || return 1
+    local pid
+    pid=$(cat "$handle_file")
+    kill -0 "$pid" 2>/dev/null
+  else
+    local found=0
+    for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$handle_file" ]] || continue
+      found=1
+      local pid
+      pid=$(cat "$handle_file")
+      if kill -0 "$pid" 2>/dev/null; then
+        return 0
+      fi
+    done
+    [[ "$found" -eq 1 ]] || return 1
+    return 1
+  fi
 }
 
-# backend_kill_worker <issue>
+# backend_kill_worker <issue> [type]
 # Kills the entire process group. No error if handle missing or process dead.
+# If type is omitted, kills all handle-{issue}.* handles.
 backend_kill_worker() {
   local issue="$1"
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}"
+  local type="${2:-}"
 
-  [[ -f "$handle_file" ]] || return 0
-
-  local pid
-  pid=$(cat "$handle_file")
-
-  # Kill the Worker process and its children.
-  # First try to kill the process group (negative PID).
-  # Fall back to killing just the PID if process group kill fails.
-  kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+  if [[ -n "$type" ]]; then
+    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    [[ -f "$handle_file" ]] || return 0
+    local pid
+    pid=$(cat "$handle_file")
+    kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+  else
+    for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$handle_file" ]] || continue
+      local pid
+      pid=$(cat "$handle_file")
+      kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+    done
+  fi
 }

--- a/scripts/shared/backends/tmux.sh
+++ b/scripts/shared/backends/tmux.sh
@@ -4,7 +4,7 @@
 # Implements 4 external API functions using tmux.
 # Sourced by backend-adapter.sh when CEKERNEL_BACKEND=tmux.
 #
-# Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue} contains tmux pane target
+# Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains tmux pane target
 # (e.g., "session:window.pane").
 
 # ── External API ──
@@ -15,13 +15,14 @@ backend_available() {
   tmux list-sessions >/dev/null 2>&1
 }
 
-# backend_spawn_worker <issue> <worktree> <prompt>
+# backend_spawn_worker <issue> <type> <worktree> <prompt>
 # Spawns a Worker in a tmux 3-pane layout.
 # Saves pane target to handle file internally.
 backend_spawn_worker() {
   local issue="$1"
-  local worktree="$2"
-  local prompt="$3"
+  local type="$2"
+  local worktree="$3"
+  local prompt="$4"
 
   # Resolve session (tmux-specific)
   local session=""
@@ -51,33 +52,59 @@ backend_spawn_worker() {
   _backend_run_command "$main_pane" "$claude_cmd"
 
   # Save handle (pane target)
-  echo "$main_pane" > "${CEKERNEL_IPC_DIR}/handle-${issue}"
+  echo "$main_pane" > "${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
 }
 
-# backend_worker_alive <issue>
+# backend_worker_alive <issue> [type]
 # exit 0 if alive, exit 1 if dead or no handle
+# If type is omitted, checks any handle-{issue}.* file.
 backend_worker_alive() {
   local issue="$1"
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}"
+  local type="${2:-}"
 
-  [[ -f "$handle_file" ]] || return 1
-
-  local pane_target
-  pane_target=$(cat "$handle_file")
-  _backend_pane_alive "$pane_target"
+  if [[ -n "$type" ]]; then
+    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    [[ -f "$handle_file" ]] || return 1
+    local pane_target
+    pane_target=$(cat "$handle_file")
+    _backend_pane_alive "$pane_target"
+  else
+    local found=0
+    for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$handle_file" ]] || continue
+      found=1
+      local pane_target
+      pane_target=$(cat "$handle_file")
+      if _backend_pane_alive "$pane_target"; then
+        return 0
+      fi
+    done
+    [[ "$found" -eq 1 ]] || return 1
+    return 1
+  fi
 }
 
-# backend_kill_worker <issue>
+# backend_kill_worker <issue> [type]
 # Kills the entire window. No error if handle missing.
+# If type is omitted, kills all handle-{issue}.* handles.
 backend_kill_worker() {
   local issue="$1"
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}"
+  local type="${2:-}"
 
-  [[ -f "$handle_file" ]] || return 0
-
-  local pane_target
-  pane_target=$(cat "$handle_file")
-  _backend_kill_window "$pane_target"
+  if [[ -n "$type" ]]; then
+    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    [[ -f "$handle_file" ]] || return 0
+    local pane_target
+    pane_target=$(cat "$handle_file")
+    _backend_kill_window "$pane_target"
+  else
+    for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$handle_file" ]] || continue
+      local pane_target
+      pane_target=$(cat "$handle_file")
+      _backend_kill_window "$pane_target"
+    done
+  fi
 }
 
 # ── Private API (internal to tmux backend) ──

--- a/scripts/shared/backends/wezterm.sh
+++ b/scripts/shared/backends/wezterm.sh
@@ -4,7 +4,7 @@
 # Implements 4 external API functions using WezTerm CLI.
 # Sourced by backend-adapter.sh when CEKERNEL_BACKEND=wezterm.
 #
-# Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue} contains WezTerm pane ID (numeric).
+# Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains WezTerm pane ID (numeric).
 
 # ── External API ──
 
@@ -12,13 +12,14 @@ backend_available() {
   command -v wezterm >/dev/null 2>&1
 }
 
-# backend_spawn_worker <issue> <worktree> <prompt>
+# backend_spawn_worker <issue> <type> <worktree> <prompt>
 # Spawns a Worker in a WezTerm 3-pane layout.
 # Saves pane ID to handle file internally.
 backend_spawn_worker() {
   local issue="$1"
-  local worktree="$2"
-  local prompt="$3"
+  local type="$2"
+  local worktree="$3"
+  local prompt="$4"
 
   # Resolve workspace (WezTerm-specific)
   local workspace=""
@@ -52,37 +53,63 @@ backend_spawn_worker() {
   wezterm cli send-text --pane-id "$pane_id" --no-paste $'\r'
 
   # Save handle (pane ID)
-  echo "$pane_id" > "${CEKERNEL_IPC_DIR}/handle-${issue}"
+  echo "$pane_id" > "${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
 }
 
-# backend_worker_alive <issue>
+# backend_worker_alive <issue> [type]
 # exit 0 if alive, exit 1 if dead or no handle
+# If type is omitted, checks any handle-{issue}.* file.
 backend_worker_alive() {
   local issue="$1"
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}"
+  local type="${2:-}"
 
-  [[ -f "$handle_file" ]] || return 1
-
-  local pane_id
-  pane_id=$(cat "$handle_file")
-  _backend_pane_alive "$pane_id"
+  if [[ -n "$type" ]]; then
+    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    [[ -f "$handle_file" ]] || return 1
+    local pane_id
+    pane_id=$(cat "$handle_file")
+    _backend_pane_alive "$pane_id"
+  else
+    local found=0
+    for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$handle_file" ]] || continue
+      found=1
+      local pane_id
+      pane_id=$(cat "$handle_file")
+      if _backend_pane_alive "$pane_id"; then
+        return 0
+      fi
+    done
+    [[ "$found" -eq 1 ]] || return 1
+    return 1
+  fi
 }
 
-# backend_kill_worker <issue>
+# backend_kill_worker <issue> [type]
 # Kills all panes in the worker's window. No error if handle missing.
 # Also cleans up the payload file created by backend_spawn_worker.
+# If type is omitted, kills all handle-{issue}.* handles.
 backend_kill_worker() {
   local issue="$1"
-  local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}"
+  local type="${2:-}"
 
   # Clean up payload file (created by backend_spawn_worker to avoid send-text 1024-byte limit)
   rm -f "${CEKERNEL_IPC_DIR}/payload-${issue}.b64"
 
-  [[ -f "$handle_file" ]] || return 0
-
-  local pane_id
-  pane_id=$(cat "$handle_file")
-  _backend_kill_window "$pane_id"
+  if [[ -n "$type" ]]; then
+    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    [[ -f "$handle_file" ]] || return 0
+    local pane_id
+    pane_id=$(cat "$handle_file")
+    _backend_kill_window "$pane_id"
+  else
+    for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
+      [[ -f "$handle_file" ]] || continue
+      local pane_id
+      pane_id=$(cat "$handle_file")
+      _backend_kill_window "$pane_id"
+    done
+  fi
 }
 
 # ── Private API (internal to WezTerm backend) ──

--- a/tests/orchestrator/test-agent-name-resolution.sh
+++ b/tests/orchestrator/test-agent-name-resolution.sh
@@ -69,7 +69,7 @@ ISSUE="600"
 WORKTREE="${TEST_TMP}/worktree"
 mkdir -p "$WORKTREE"
 
-backend_spawn_worker "$ISSUE" "$WORKTREE" "test prompt"
+backend_spawn_worker "$ISSUE" "worker" "$WORKTREE" "test prompt"
 sleep 0.3
 
 if [[ -f "$ARGS_FILE" ]]; then
@@ -90,7 +90,7 @@ ARGS_FILE="${TEST_TMP}/args-3b.txt"
 export CEKERNEL_AGENT_ARGS_FILE="$ARGS_FILE"
 
 ISSUE2="601"
-backend_spawn_worker "$ISSUE2" "$WORKTREE" "test prompt 2"
+backend_spawn_worker "$ISSUE2" "worker" "$WORKTREE" "test prompt 2"
 sleep 0.3
 
 if [[ -f "$ARGS_FILE" ]]; then

--- a/tests/orchestrator/test-cleanup-pane.sh
+++ b/tests/orchestrator/test-cleanup-pane.sh
@@ -67,7 +67,7 @@ WORKTREE=$(setup_worktree "$ISSUE" "$FAKE_REPO")
 mkdir -p "$CEKERNEL_IPC_DIR"
 mkfifo "${CEKERNEL_IPC_DIR}/worker-${ISSUE}"
 # Use handle-{issue} (ADR-0005 format)
-echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 
 cd "$FAKE_REPO"
 CEKERNEL_BACKEND=wezterm bash "${CEKERNEL_DIR}/scripts/orchestrator/cleanup-worktree.sh" "$ISSUE" 2>/dev/null
@@ -82,7 +82,7 @@ else
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-assert_not_exists "Handle file removed after cleanup" "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+assert_not_exists "Handle file removed after cleanup" "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 
 # ── Test 2: cleanup with --force → Worker is killed ──
 rm -rf "$CEKERNEL_IPC_DIR"
@@ -93,7 +93,7 @@ WORKTREE=$(setup_worktree "$ISSUE" "$FAKE_REPO")
 
 mkdir -p "$CEKERNEL_IPC_DIR"
 mkfifo "${CEKERNEL_IPC_DIR}/worker-${ISSUE}"
-echo "99" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+echo "99" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 
 CEKERNEL_BACKEND=wezterm bash "${CEKERNEL_DIR}/scripts/orchestrator/cleanup-worktree.sh" --force "$ISSUE" 2>/dev/null
 
@@ -106,7 +106,7 @@ else
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-assert_not_exists "Handle file removed after --force cleanup" "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+assert_not_exists "Handle file removed after --force cleanup" "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 
 # ── Test 3: No handle file → skips without error ──
 rm -rf "$CEKERNEL_IPC_DIR"
@@ -172,7 +172,7 @@ WORKTREE=$(setup_worktree "$ISSUE" "$FAKE_REPO")
 
 mkdir -p "$CEKERNEL_IPC_DIR"
 mkfifo "${CEKERNEL_IPC_DIR}/worker-${ISSUE}"
-echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 
 cd "$FAKE_REPO"
 CEKERNEL_BACKEND=wezterm bash "${CEKERNEL_DIR}/scripts/orchestrator/cleanup-worktree.sh" "$ISSUE" 2>/dev/null
@@ -228,7 +228,7 @@ WORKTREE=$(setup_worktree "$ISSUE" "$FAKE_REPO")
 
 mkdir -p "$CEKERNEL_IPC_DIR"
 mkfifo "${CEKERNEL_IPC_DIR}/worker-${ISSUE}"
-echo "55" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+echo "55" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 
 cd "$FAKE_REPO"
 CEKERNEL_BACKEND=wezterm bash "${CEKERNEL_DIR}/scripts/orchestrator/cleanup-worktree.sh" "$ISSUE" 2>/dev/null

--- a/tests/orchestrator/test-rollback.sh
+++ b/tests/orchestrator/test-rollback.sh
@@ -86,7 +86,8 @@ mkdir -p "$CEKERNEL_IPC_DIR"
   LOG_FILE="${LOG_DIR}/worker-${ISSUE_NUMBER}.log"
   echo "test log" > "$LOG_FILE"
 
-  echo "fake-pane-id" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+  AGENT_TYPE="worker"
+  echo "fake-pane-id" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}.${AGENT_TYPE}"
 
   # Register trust
   register_trust "$WORKTREE"
@@ -97,7 +98,7 @@ mkdir -p "$CEKERNEL_IPC_DIR"
 
   # Verify
   assert_not_exists "FIFO removed after rollback" "$FIFO"
-  assert_not_exists "Handle file removed after rollback" "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+  assert_not_exists "Handle file removed after rollback" "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}.${AGENT_TYPE}"
   assert_not_exists "Worktree removed after rollback" "$WORKTREE"
   assert_not_exists "Log file removed after rollback" "$LOG_FILE"
 
@@ -135,6 +136,7 @@ rm -f "$FAKE_CLAUDE_JSON"
 
   # Create only FIFO (worktree, handle not created)
   ISSUE_NUMBER="101"
+  AGENT_TYPE="worker"
   FIFO="${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}"
   mkfifo "$FIFO"
 
@@ -159,6 +161,7 @@ mkdir -p "$CEKERNEL_IPC_DIR"
   source "${CEKERNEL_DIR}/scripts/shared/backend-adapter.sh"
 
   ISSUE_NUMBER="102"
+  AGENT_TYPE="worker"
   # Create nothing
 
   source_rollback

--- a/tests/orchestrator/test-watch-crash-detection.sh
+++ b/tests/orchestrator/test-watch-crash-detection.sh
@@ -32,7 +32,7 @@ worker_state_write "$ISSUE_NUMBER" RUNNING "phase1:implement"
 
 # Create a handle file pointing to a dead PID (PID 99999 is almost certainly not running)
 # Use headless backend so backend_worker_alive checks kill -0 $PID
-echo "99999" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+echo "99999" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}.worker"
 
 RESULT_FILE=$(mktemp)
 STDERR_FILE=$(mktemp)

--- a/tests/orchestrator/test-watch-env-backend.sh
+++ b/tests/orchestrator/test-watch-env-backend.sh
@@ -43,7 +43,7 @@ mkdir -p "$CEKERNEL_IPC_DIR/logs"
 # Create a live process and record its PID in a handle file
 sleep 300 &
 SLEEP_PID=$!
-echo "$SLEEP_PID" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}"
+echo "$SLEEP_PID" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE_NUMBER}.worker"
 
 # Write RUNNING state
 worker_state_write "$ISSUE_NUMBER" RUNNING "phase1:implement"

--- a/tests/shared/test-backend-headless.sh
+++ b/tests/shared/test-backend-headless.sh
@@ -53,9 +53,9 @@ ISSUE="500"
 WORKTREE="${TEST_TMP}/worktree"
 mkdir -p "$WORKTREE"
 
-backend_spawn_worker "$ISSUE" "$WORKTREE" "test prompt"
+backend_spawn_worker "$ISSUE" "worker" "$WORKTREE" "test prompt"
 
-HANDLE_FILE="${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+HANDLE_FILE="${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 assert_file_exists "Handle file created after spawn" "$HANDLE_FILE"
 
 # Handle file should contain a numeric PID
@@ -109,7 +109,7 @@ assert_eq "kill_worker for non-existent handle exits cleanly" "0" "$EXIT_CODE"
 
 # ── Test 7: Log file is created for spawned worker ──
 ISSUE2="501"
-backend_spawn_worker "$ISSUE2" "$WORKTREE" "test prompt 2"
+backend_spawn_worker "$ISSUE2" "worker" "$WORKTREE" "test prompt 2"
 sleep 0.2
 
 LOG_FILE="${CEKERNEL_IPC_DIR}/logs/worker-${ISSUE2}.stdout.log"
@@ -121,7 +121,7 @@ sleep 0.2
 
 # ── Test 8: SESSION_ID is propagated to worker process ──
 # We can't easily check this with a mock, but verify the handle exists
-HANDLE_FILE2="${CEKERNEL_IPC_DIR}/handle-${ISSUE2}"
+HANDLE_FILE2="${CEKERNEL_IPC_DIR}/handle-${ISSUE2}.worker"
 assert_file_exists "Handle file created for second worker" "$HANDLE_FILE2"
 
 # ── Restore PATH ──

--- a/tests/shared/test-backend-tmux.sh
+++ b/tests/shared/test-backend-tmux.sh
@@ -70,9 +70,9 @@ export -f tmux
 
 ISSUE="400"
 WORKTREE="/tmp/test-worktree"
-backend_spawn_worker "$ISSUE" "$WORKTREE" "test prompt"
+backend_spawn_worker "$ISSUE" "worker" "$WORKTREE" "test prompt"
 
-HANDLE_FILE="${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+HANDLE_FILE="${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 assert_file_exists "Handle file created after spawn" "$HANDLE_FILE"
 
 HANDLE=$(cat "$HANDLE_FILE")
@@ -155,7 +155,7 @@ tmux() {
   fi
 }
 export -f tmux
-backend_spawn_worker "410" "$WORKTREE" "Read the target repository's CLAUDE.md"
+backend_spawn_worker "410" "worker" "$WORKTREE" "Read the target repository's CLAUDE.md"
 LOGGED=$(cat "$MOCK_LOG")
 # The send-keys line for the claude command must not have an unescaped single quote
 # that would break the shell. Check that repository's is intact and properly quoted.
@@ -201,7 +201,7 @@ tmux() {
   fi
 }
 export -f tmux
-backend_spawn_worker "411" "$WORKTREE" "test prompt"
+backend_spawn_worker "411" "worker" "$WORKTREE" "test prompt"
 LOGGED=$(cat "$MOCK_LOG")
 CLAUDE_LINE=$(echo "$LOGGED" | grep "send-keys" | grep "claude")
 assert_match "unset CLAUDECODE in claude command" "unset CLAUDECODE" "$CLAUDE_LINE"

--- a/tests/shared/test-backend-wezterm.sh
+++ b/tests/shared/test-backend-wezterm.sh
@@ -63,9 +63,9 @@ export -f wezterm
 export WEZTERM_PANE=42
 ISSUE="300"
 WORKTREE="/tmp/test-worktree"
-backend_spawn_worker "$ISSUE" "$WORKTREE" "test prompt"
+backend_spawn_worker "$ISSUE" "worker" "$WORKTREE" "test prompt"
 
-HANDLE_FILE="${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+HANDLE_FILE="${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 assert_file_exists "Handle file created after spawn" "$HANDLE_FILE"
 
 HANDLE=$(cat "$HANDLE_FILE")
@@ -154,7 +154,7 @@ backend_kill_worker "99999" 2>/dev/null || EXIT_CODE=$?
 assert_eq "kill_worker for missing handle exits cleanly" "0" "$EXIT_CODE"
 
 # ── Test 9: backend_worker_alive — compact JSON (no spaces) ──
-echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 wezterm() {
   if [[ "$1" == "cli" && "$2" == "list" ]]; then
     echo '[{"pane_id":42},{"pane_id":43}]'
@@ -185,7 +185,7 @@ export -f wezterm
 export WEZTERM_PANE=42
 ISSUE="301"
 WORKTREE="/tmp/test-worktree"
-backend_spawn_worker "$ISSUE" "$WORKTREE" "test prompt with long content"
+backend_spawn_worker "$ISSUE" "worker" "$WORKTREE" "test prompt with long content"
 
 PAYLOAD_FILE="${CEKERNEL_IPC_DIR}/payload-${ISSUE}.b64"
 assert_file_exists "Payload file created after spawn" "$PAYLOAD_FILE"
@@ -218,7 +218,7 @@ rm -f "$MOCK_LOG"
 assert_file_exists "Payload file exists before kill" "$PAYLOAD_FILE"
 
 # Create handle file for the kill
-echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}"
+echo "42" > "${CEKERNEL_IPC_DIR}/handle-${ISSUE}.worker"
 MOCK_LOG=$(mktemp)
 wezterm() {
   echo "wezterm $*" >> "$MOCK_LOG"


### PR DESCRIPTION
## Summary

- Handle ファイル名を `handle-{issue}` → `handle-{issue}.{type}` に変更し、Worker と Reviewer の pane ID を独立管理
- Reviewer spawn 時に Worker の pane ID が上書きされ、cleanup で Worker pane が残る問題を修正
- 全3 backend (wezterm, tmux, headless) と呼び出し側 (spawn.sh, cleanup-worktree.sh, watch.sh, orchctrl.sh) を更新

## Test plan

- [x] 全既存テスト通過 (run-tests.sh)
- [ ] 実際の Worker → Reviewer フローで両 pane が正しくクローズされることを確認

closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)