### PR TITLE
docs: CLAUDE.md にデザイン判断のガードレールを追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@ See [README.md](./README.md) for architecture details.
 - When uncertain about Claude Code specifications or behavior, always consult primary sources (official documentation, GitHub issues) before answering. Do not guess.
 - Links in CLAUDE.md are not references — they are part of the instructions. You MUST read linked documents and follow them.
 
+## Design Decisions
+
+When implementing something, always check existing patterns first.
+
+- **Feasibility check before implementation**: When adopting an approach different from existing patterns, verify technical constraints first (e.g., tool availability, API limitations, call depth restrictions). Do not start implementation without confirming feasibility.
+- **Document deviations in ADR**: When choosing not to use an existing pattern, record the reason in an ADR. See the [ADRs](#adrs) section for how to create one.
+
+> **Background**: When designing the Reviewer, an existing spawn pattern was overlooked and a subagent-based approach was implemented instead, requiring a rework. The technical constraint (skill → agent → agent is not allowed) could have been discovered with prior investigation.
+
 ## Philosophy
 
 cekernel's design is rooted in UNIX philosophy and TDD.


### PR DESCRIPTION
closes #287

## 概要

CLAUDE.md に新しい「Design Decisions」セクションを追加し、既存パターンを見落として作り直しが発生することを防ぐガードレールを設けた。

### 追加したルール

- **実装前のFeasibility check**: 既存パターンと異なるアプローチを採用する場合、技術的制約を先に調査・確認する
- **ADRへの記録**: 既存パターンを選ばない理由をADRに記録する

### 背景

Reviewer設計時に、既存のspawnパターンがあったにもかかわらずsubagentで実装し、作り直しが発生した。`skill → agent → agent` という技術的制約を事前に調査していれば避けられた。

## テスト計画

- [ ] CLAUDE.md の内容が正しく追加されていることを確認
- [ ] CI（run-tests.sh）がパスすること