### PR TITLE
fix: marketplace update step fails on git push — migrate to actions/checkout

### DIFF
--- a/.github/workflows/plugin-release-tag.yml
+++ b/.github/workflows/plugin-release-tag.yml
@@ -63,11 +63,11 @@ jobs:
 
       - name: Checkout plugins repository
         if: ${{ secrets.MARKETPLACE_PAT != '' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: clonable-eden/plugins
           token: ${{ secrets.MARKETPLACE_PAT }}
-          path: /tmp/plugins
+          path: plugins-checkout
 
       - name: Update marketplace
         if: ${{ secrets.MARKETPLACE_PAT != '' }}
@@ -77,7 +77,7 @@ jobs:
           TAG="${{ steps.extract.outputs.tag }}"
           PLUGIN="${{ steps.extract.outputs.plugin }}"
 
-          cd /tmp/plugins
+          cd ${{ github.workspace }}/plugins-checkout
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
closes #290

## 概要

`plugin-release-tag.yml` の `Update marketplace` ステップが `git push` 時に認証エラーで失敗する問題を修正。

### 原因

`gh repo clone` は `GH_TOKEN` を使ってcloneするが、clone後のURLは `https://github.com/...` のままで、その後の `git push` 時にgit credential helperが `GH_TOKEN` を参照しないため認証エラーになる。

```
fatal: could not read Username for 'https://github.com': No such device or address
```

### 修正内容

- `gh repo clone` + `git push` パターンを `actions/checkout@v4` に移行
- `actions/checkout` は `token` を指定することでgit credential helperを自動設定するため、`git push` がそのまま通る
- シェルレベルのスキップ判定（`if [ -z "${GH_TOKEN}" ]`）を、ワークフローレベルの `if: ${{ secrets.MARKETPLACE_PAT != '' }}` に変更（GitHub Actionsの慣用パターン）

## テスト計画

- [ ] `MARKETPLACE_PAT` が設定されていない場合、`Checkout plugins repository` と `Update marketplace` ステップがスキップされることを確認
- [ ] `MARKETPLACE_PAT` が設定されている場合、`git push` が認証エラーなく成功することを確認（次回リリース時）