### PR TITLE
fix: add event_name guard to prevent push-triggered failure

### DIFF
--- a/.github/workflows/plugin-release-tag.yml
+++ b/.github/workflows/plugin-release-tag.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   tag-and-release:
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `github.event_name == 'pull_request'` guard to `plugin-release-tag.yml` job condition
- Prevents GitHub Actions from failing on push events (the workflow only needs to run on `pull_request[closed]`)

closes #301

## Test plan
- [ ] After merge, verify that the next push to main does not trigger a failure for `plugin-release-tag.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)