### PR TITLE
fix: make orchctrl gc detect and clean stale FIFOs with state/handle awareness

### DIFF
--- a/scripts/orchestrator/orchctrl.sh
+++ b/scripts/orchestrator/orchctrl.sh
@@ -527,8 +527,101 @@ cmd_gc() {
   local cleaned=0
   local locks_dir="${CEKERNEL_VAR_DIR}/locks"
 
+  # Stale timeout for NEW/READY state (seconds). Default: 30 minutes.
+  local stale_timeout="${CEKERNEL_GC_STALE_TIMEOUT:-1800}"
+
+  # ── Helper: check if a FIFO is stale ──
+  # Returns 0 (stale) or 1 (active).
+  # A FIFO is stale when:
+  #   - State is TERMINATED and no live handle exists
+  #   - No handle exists and state is NEW/READY past stale_timeout
+  #   - Handle exists but the referenced process is dead
+  _gc_is_stale_fifo() {
+    local sdir="$1" issue="$2" fifo="$3" timeout="$4"
+
+    # Check for any handle file
+    local has_live_handle=0
+    local has_any_handle=0
+    for hf in "${sdir}"handle-"${issue}".*; do
+      [[ -f "$hf" ]] || continue
+      has_any_handle=1
+      local handle_content
+      handle_content=$(tr -d '[:space:]' < "$hf")
+      # For headless backend, handle is a PID
+      # For tmux, handle is session:window.pane — check if tmux session exists
+      # For wezterm, handle is a pane ID
+      # Simple heuristic: if handle is numeric, check kill -0; otherwise assume stale
+      if [[ "$handle_content" =~ ^[0-9]+$ ]]; then
+        if kill -0 "$handle_content" 2>/dev/null; then
+          has_live_handle=1
+          break
+        fi
+      elif [[ "$handle_content" == *:*.* ]]; then
+        # tmux pane target — check if tmux session exists
+        if tmux has-session -t "${handle_content%%:*}" 2>/dev/null; then
+          has_live_handle=1
+          break
+        fi
+      else
+        # Unknown handle format — assume alive to be safe
+        has_live_handle=1
+        break
+      fi
+    done
+
+    # If there's a live handle, the FIFO is active
+    if [[ "$has_live_handle" -eq 1 ]]; then
+      return 1
+    fi
+
+    # Read state from state file
+    local state="UNKNOWN"
+    local state_file="${sdir}worker-${issue}.state"
+    if [[ -f "$state_file" ]]; then
+      local line
+      line=$(cat "$state_file")
+      state="${line%%:*}"
+    fi
+
+    # TERMINATED → always stale (process completed, FIFO should have been cleaned)
+    if [[ "$state" == "TERMINATED" ]]; then
+      return 0
+    fi
+
+    # Handle exists but process is dead → stale
+    if [[ "$has_any_handle" -eq 1 ]]; then
+      return 0
+    fi
+
+    # No handle, state is NEW/READY → check timeout
+    if [[ "$state" == "NEW" || "$state" == "READY" ]]; then
+      local created=""
+      if stat -f '%m' "$fifo" &>/dev/null; then
+        created=$(stat -f '%m' "$fifo")
+      elif stat -c '%Y' "$fifo" &>/dev/null; then
+        created=$(stat -c '%Y' "$fifo")
+      fi
+      if [[ -n "$created" ]]; then
+        local now elapsed
+        now=$(date +%s)
+        elapsed=$((now - created))
+        if [[ "$elapsed" -ge "$timeout" ]]; then
+          return 0
+        fi
+      fi
+      # Within timeout — still active
+      return 1
+    fi
+
+    # No handle, non-terminal state (RUNNING/WAITING/SUSPENDED/UNKNOWN) → stale
+    # (A RUNNING worker without any handle is abnormal)
+    return 0
+  }
+
   # ── 1. Collect active issues (FIFOs across all sessions) ──
-  # Build a set of active issue numbers per session for orphan detection
+  # Build a set of active issue numbers per session for orphan detection.
+  # FIFOs are checked for staleness: if the process is dead or state is
+  # TERMINATED, the FIFO is removed and not added to active_issues.
   declare -A active_issues  # key: "session_dir:issue" value: 1
 
   if [[ -d "$IPC_BASE" ]]; then
@@ -541,7 +634,19 @@ cmd_gc() {
         # Only match worker-{issue} FIFOs (not worker-{issue}.state etc)
         [[ "$fname" == worker-* && "$fname" != *.* ]] || continue
         local issue="${fname#worker-}"
-        active_issues["${session_dir}:${issue}"]=1
+
+        # Check if this FIFO is stale
+        if _gc_is_stale_fifo "$session_dir" "$issue" "$fifo" "$stale_timeout"; then
+          # Stale: remove FIFO and do NOT add to active_issues
+          if [[ "$dry_run" -eq 1 ]]; then
+            echo "[dry-run] would remove stale FIFO: $fifo" >&2
+          else
+            rm -f "$fifo"
+          fi
+          cleaned=$((cleaned + 1))
+        else
+          active_issues["${session_dir}:${issue}"]=1
+        fi
       done
     done
   fi

--- a/tests/orchestrator/test-orchctrl-gc.sh
+++ b/tests/orchestrator/test-orchctrl-gc.sh
@@ -69,13 +69,15 @@ echo "TERMINATED:2026-02-28T10:00:00Z:done" > "${SESSION_DIR}/worker-50.state"
 bash "$ORCHCTRL" gc >/dev/null 2>&1
 assert_not_exists "gc removes orphan state file" "${SESSION_DIR}/worker-50.state"
 
-# ── Test 6: gc preserves state file with active FIFO ──
+# ── Test 6: gc preserves state file with active FIFO + live handle ──
 SESSION_DIR2="${IPC_BASE}/session-gc-03"
 mkdir -p "$SESSION_DIR2"
 mkfifo "${SESSION_DIR2}/worker-51"
 echo "RUNNING:2026-02-28T10:00:00Z:working" > "${SESSION_DIR2}/worker-51.state"
 echo "10" > "${SESSION_DIR2}/worker-51.priority"
 echo "worker" > "${SESSION_DIR2}/worker-51.type"
+# A live handle (our own PID) makes this an active worker
+echo "$$" > "${SESSION_DIR2}/handle-51.worker"
 bash "$ORCHCTRL" gc >/dev/null 2>&1
 assert_file_exists "gc preserves state with FIFO" "${SESSION_DIR2}/worker-51.state"
 assert_file_exists "gc preserves priority with FIFO" "${SESSION_DIR2}/worker-51.priority"
@@ -128,6 +130,77 @@ echo "stdout data" > "${SESSION_DIR}/logs/worker-50.stdout.log"
 bash "$ORCHCTRL" gc >/dev/null 2>&1
 assert_not_exists "gc removes orphan log" "${SESSION_DIR}/logs/worker-50.log"
 assert_not_exists "gc removes orphan stdout log" "${SESSION_DIR}/logs/worker-50.stdout.log"
+
+# ══════════════════════════════════════════════
+# gc — stale FIFO cleanup (issue #303)
+# ══════════════════════════════════════════════
+
+# ── Test 16: gc removes stale FIFO when TERMINATED + no handle ──
+SESSION_DIR_STALE="${IPC_BASE}/session-gc-stale"
+mkdir -p "$SESSION_DIR_STALE"
+mkfifo "${SESSION_DIR_STALE}/worker-296"
+echo "TERMINATED:2026-02-28T10:00:00Z:done" > "${SESSION_DIR_STALE}/worker-296.state"
+echo "worker" > "${SESSION_DIR_STALE}/worker-296.type"
+echo "10" > "${SESSION_DIR_STALE}/worker-296.priority"
+bash "$ORCHCTRL" gc >/dev/null 2>&1
+assert_not_exists "gc removes stale FIFO (TERMINATED + no handle)" "${SESSION_DIR_STALE}/worker-296"
+assert_not_exists "gc removes state for stale FIFO" "${SESSION_DIR_STALE}/worker-296.state"
+assert_not_exists "gc removes type for stale FIFO" "${SESSION_DIR_STALE}/worker-296.type"
+assert_not_exists "gc removes priority for stale FIFO" "${SESSION_DIR_STALE}/worker-296.priority"
+
+# ── Test 17: gc removes stale FIFO when NEW + no handle + old (stale timeout) ──
+SESSION_DIR_STALE2="${IPC_BASE}/session-gc-stale2"
+mkdir -p "$SESSION_DIR_STALE2"
+mkfifo "${SESSION_DIR_STALE2}/worker-297"
+# State is NEW with old timestamp (>30 min ago)
+echo "NEW:2026-02-28T01:00:00Z:spawning" > "${SESSION_DIR_STALE2}/worker-297.state"
+echo "worker" > "${SESSION_DIR_STALE2}/worker-297.type"
+# Override staleness: set CEKERNEL_GC_STALE_TIMEOUT=0 to force stale
+CEKERNEL_GC_STALE_TIMEOUT=0 bash "$ORCHCTRL" gc >/dev/null 2>&1
+assert_not_exists "gc removes stale FIFO (NEW + timeout)" "${SESSION_DIR_STALE2}/worker-297"
+assert_not_exists "gc removes state for stale NEW FIFO" "${SESSION_DIR_STALE2}/worker-297.state"
+assert_not_exists "gc removes type for stale NEW FIFO" "${SESSION_DIR_STALE2}/worker-297.type"
+
+# ── Test 18: gc removes stale FIFO with handle but dead process ──
+SESSION_DIR_STALE3="${IPC_BASE}/session-gc-stale3"
+mkdir -p "$SESSION_DIR_STALE3"
+mkfifo "${SESSION_DIR_STALE3}/worker-298"
+echo "RUNNING:2026-02-28T10:00:00Z:working" > "${SESSION_DIR_STALE3}/worker-298.state"
+echo "worker" > "${SESSION_DIR_STALE3}/worker-298.type"
+# Create a handle file with a dead PID
+echo "99999999" > "${SESSION_DIR_STALE3}/handle-298.worker"
+bash "$ORCHCTRL" gc >/dev/null 2>&1
+assert_not_exists "gc removes stale FIFO (dead handle PID)" "${SESSION_DIR_STALE3}/worker-298"
+assert_not_exists "gc removes state for dead handle" "${SESSION_DIR_STALE3}/worker-298.state"
+assert_not_exists "gc removes handle for dead process" "${SESSION_DIR_STALE3}/handle-298.worker"
+
+# ── Test 19: gc preserves FIFO with live handle ──
+SESSION_DIR_LIVE="${IPC_BASE}/session-gc-live"
+mkdir -p "$SESSION_DIR_LIVE"
+mkfifo "${SESSION_DIR_LIVE}/worker-299"
+echo "RUNNING:2026-02-28T10:00:00Z:working" > "${SESSION_DIR_LIVE}/worker-299.state"
+echo "worker" > "${SESSION_DIR_LIVE}/worker-299.type"
+# Create a handle file with our own (live) PID
+echo "$$" > "${SESSION_DIR_LIVE}/handle-299.worker"
+bash "$ORCHCTRL" gc >/dev/null 2>&1
+assert_fifo_exists "gc preserves FIFO with live handle" "${SESSION_DIR_LIVE}/worker-299"
+assert_file_exists "gc preserves state with live handle" "${SESSION_DIR_LIVE}/worker-299.state"
+assert_file_exists "gc preserves handle with live process" "${SESSION_DIR_LIVE}/handle-299.worker"
+# Cleanup
+rm -f "${SESSION_DIR_LIVE}/worker-299" "${SESSION_DIR_LIVE}/worker-299.state" "${SESSION_DIR_LIVE}/worker-299.type" "${SESSION_DIR_LIVE}/handle-299.worker"
+rmdir "$SESSION_DIR_LIVE" 2>/dev/null || true
+
+# ── Test 20: gc --dry-run shows stale FIFO but doesn't remove it ──
+SESSION_DIR_DRY="${IPC_BASE}/session-gc-stale-dry"
+mkdir -p "$SESSION_DIR_DRY"
+mkfifo "${SESSION_DIR_DRY}/worker-300"
+echo "TERMINATED:2026-02-28T10:00:00Z:done" > "${SESSION_DIR_DRY}/worker-300.state"
+OUTPUT=$(bash "$ORCHCTRL" gc --dry-run 2>&1)
+assert_fifo_exists "dry-run preserves stale FIFO" "${SESSION_DIR_DRY}/worker-300"
+assert_match "dry-run mentions stale FIFO" "stale FIFO" "$OUTPUT"
+# Cleanup the stale resources for subsequent tests
+rm -f "${SESSION_DIR_DRY}/worker-300" "${SESSION_DIR_DRY}/worker-300.state"
+rmdir "$SESSION_DIR_DRY" 2>/dev/null || true
 
 # ══════════════════════════════════════════════
 # gc --dry-run


### PR DESCRIPTION
closes #303

## 概要
`orchctrl gc` が FIFO の存在だけで active 判定していたため、プロセス死亡後もstate/type/priority ファイルが残り続ける問題を修正。

## 変更内容
- `_gc_is_stale_fifo` ヘルパーを追加し、FIFO の stale 判定を handle の生死 + state で行うように改善
  - `TERMINATED` + handle なし → stale（即座に削除）
  - handle あり + プロセス死亡 → stale
  - `NEW`/`READY` + handle なし + タイムアウト超過（デフォルト30分） → stale
  - `RUNNING`/`WAITING` + handle なし → stale（異常状態）
- `CEKERNEL_GC_STALE_TIMEOUT` 環境変数でタイムアウトを設定可能（テストで使用）
- 既存テスト（Test 6）を修正: RUNNING 状態の FIFO は live handle が必要

## テスト
- 5件の新規テスト（Test 16-20）を追加
  - stale FIFO の各パターン（TERMINATED, NEW+timeout, dead handle）
  - live handle 保持の保護
  - dry-run 対応
- 全テストスイート通過確認済み（37 gc tests + full suite）