### PR TITLE
fix: orchctrl ls の backend 検出をメタデータ方式に変更する

### DIFF
--- a/scripts/orchestrator/orchctrl.sh
+++ b/scripts/orchestrator/orchctrl.sh
@@ -161,11 +161,18 @@ compute_elapsed() {
   fi
 }
 
-# ── Helper: detect backend from handle file ──
+# ── Helper: detect backend from metadata file (with heuristic fallback) ──
 detect_backend() {
   local ipc_dir="$1" issue="$2"
 
-  # Find the first handle-{issue}.{type} file
+  # Primary: read from metadata file written at spawn time
+  local backend_file="${ipc_dir}/worker-${issue}.backend"
+  if [[ -f "$backend_file" ]]; then
+    tr -d '[:space:]' < "$backend_file"
+    return
+  fi
+
+  # Fallback: heuristic detection from handle file (pre-#311 workers)
   local handle_file=""
   for hf in "${ipc_dir}"/handle-"${issue}".*; do
     [[ -f "$hf" ]] && handle_file="$hf" && break

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -129,11 +129,12 @@ rollback() {
   # Delete log file
   rm -f "${LOG_FILE:-}"
   rmdir "${LOG_DIR:-}" 2>/dev/null || true
-  # Delete FIFO, state file, priority file, and type file
+  # Delete FIFO, state file, priority file, type file, and backend file
   rm -f "${FIFO:-}"
   rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.state"
   rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.priority"
   rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.type"
+  rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.backend"
   # Release issue lock
   if [[ -n "${REPO_ROOT:-}" ]]; then
     issue_lock_release "$REPO_ROOT" "$ISSUE_NUMBER"
@@ -154,6 +155,9 @@ worker_priority_write "$ISSUE_NUMBER" "$PRIORITY"
 
 # ── Record process type ──
 echo "$AGENT_TYPE" > "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.type"
+
+# ── Record backend name ──
+echo "$CEKERNEL_ACTIVE_BACKEND" > "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.backend"
 
 # ── Create log file ──
 LOG_DIR="${CEKERNEL_IPC_DIR}/logs"

--- a/tests/orchestrator/test-orchctrl.sh
+++ b/tests/orchestrator/test-orchctrl.sh
@@ -253,6 +253,48 @@ assert_match "inspect contains detail" '"detail":"phase1:implement"' "$OUTPUT"
 assert_match "inspect contains timestamp" '"timestamp":"2026-02-28T10:00:00Z"' "$OUTPUT"
 
 # ══════════════════════════════════════════════
+# detect_backend: metadata file
+# ══════════════════════════════════════════════
+
+# ── Test 28a: ls output contains backend from metadata file (wezterm) ──
+echo "wezterm" > "${IPC_A}/worker-10.backend"
+OUTPUT=$(bash "$ORCHCTRL" ls 2>/dev/null | grep '"issue":10')
+assert_match "ls backend metadata: wezterm" '"backend":"wezterm"' "$OUTPUT"
+
+# ── Test 28b: ls output contains backend from metadata file (headless) ──
+echo "headless" > "${IPC_A}/worker-10.backend"
+OUTPUT=$(bash "$ORCHCTRL" ls 2>/dev/null | grep '"issue":10')
+assert_match "ls backend metadata: headless" '"backend":"headless"' "$OUTPUT"
+
+# ── Test 28c: ls output contains backend from metadata file (tmux) ──
+echo "tmux" > "${IPC_A}/worker-10.backend"
+OUTPUT=$(bash "$ORCHCTRL" ls 2>/dev/null | grep '"issue":10')
+assert_match "ls backend metadata: tmux" '"backend":"tmux"' "$OUTPUT"
+
+# ── Test 28d: ls backend prefers metadata file over stdout.log heuristic ──
+# Even if stdout.log exists (which would trigger old "headless" heuristic),
+# metadata file takes precedence.
+mkdir -p "${IPC_A}/logs"
+touch "${IPC_A}/logs/worker-10.stdout.log"
+echo "wezterm" > "${IPC_A}/worker-10.backend"
+OUTPUT=$(bash "$ORCHCTRL" ls 2>/dev/null | grep '"issue":10')
+assert_match "ls backend: metadata overrides stdout.log heuristic" '"backend":"wezterm"' "$OUTPUT"
+rm -f "${IPC_A}/logs/worker-10.stdout.log"
+rmdir "${IPC_A}/logs" 2>/dev/null || true
+
+# ── Test 28e: ls backend falls back to heuristic when metadata file absent ──
+rm -f "${IPC_A}/worker-10.backend"
+# No handle file → should return "unknown"
+OUTPUT=$(bash "$ORCHCTRL" ls 2>/dev/null | grep '"issue":10')
+assert_match "ls backend fallback: no handle → unknown" '"backend":"unknown"' "$OUTPUT"
+
+# ── Test 28f: inspect output contains backend from metadata file ──
+echo "headless" > "${IPC_A}/worker-10.backend"
+OUTPUT=$(bash "$ORCHCTRL" inspect 10 --session "$SESSION_A" 2>/dev/null)
+assert_match "inspect backend metadata: headless" '"backend":"headless"' "$OUTPUT"
+rm -f "${IPC_A}/worker-10.backend"
+
+# ══════════════════════════════════════════════
 # usage / no command
 # ══════════════════════════════════════════════
 


### PR DESCRIPTION
closes #311

## 概要
- `orchctrl ls` の backend 検出ロジックをメタデータファイル方式に変更
- `spawn.sh` で spawn 時に `worker-${issue}.backend` ファイルにバックエンド名を記録
- `detect_backend()` がメタデータファイルを優先読み取り、フォールバックとして旧ヒューリスティックを維持
- #305 で全バックエンドが `stdout.log` を生成するようになったことで発生した WezTerm → headless 誤検出を修正

## 変更内容
- `scripts/orchestrator/spawn.sh`: `worker-${issue}.backend` の書き込みと rollback 時の削除
- `scripts/orchestrator/orchctrl.sh`: `detect_backend()` をメタデータファイル読み取りに変更
- `tests/orchestrator/test-orchctrl.sh`: backend メタデータ検出テスト 6 件追加（全 50 テスト通過）

## テスト計画
- [x] `bash tests/orchestrator/test-orchctrl.sh` — 50 passed, 0 failed
- [x] `bash tests/run-tests.sh` — All tests passed