### PR TITLE
docs: ADR群の旧スクリプト名（watch-worker.sh, worker-status.sh）に括弧書き注釈を追加

### DIFF
--- a/docs/adr/0003-worker-signal-mechanism.md
+++ b/docs/adr/0003-worker-signal-mechanism.md
@@ -13,7 +13,7 @@ Orchestrator → Worker:  spawn (one-time, at birth)
 Worker → Orchestrator:  notify-complete via FIFO (one-time, at death)
 ```
 
-Between spawn and completion, there is no communication channel from Orchestrator to Worker. The Orchestrator can detect problems (`health-check.sh` finds zombies, `watch-worker.sh`（現 `watch.sh`）detects timeouts) but cannot act on them — it can only kill the terminal pane (`cleanup-worktree.sh`), which is the equivalent of `SIGKILL`: immediate, ungraceful, no cleanup by the Worker.
+Between spawn and completion, there is no communication channel from Orchestrator to Worker. The Orchestrator can detect problems (`health-check.sh` finds zombies, `watch-worker.sh` (now `watch.sh`) detects timeouts) but cannot act on them — it can only kill the terminal pane (`cleanup-worktree.sh`), which is the equivalent of `SIGKILL`: immediate, ungraceful, no cleanup by the Worker.
 
 This creates three operational gaps:
 

--- a/docs/adr/0004-worker-state-machine.md
+++ b/docs/adr/0004-worker-state-machine.md
@@ -8,7 +8,7 @@ Accepted
 
 cekernel's Worker lifecycle visibility is binary: a Worker is either "alive" (FIFO exists) or "dead" (FIFO removed). The scripts that provide observability reflect this:
 
-- `worker-status.sh`（現 `process-status.sh`）lists Workers by enumerating FIFOs in the IPC directory. It reports issue number, worktree path, and uptime — but not what the Worker is *doing*.
+- `worker-status.sh` (now `process-status.sh`) lists Workers by enumerating FIFOs in the IPC directory. It reports issue number, worktree path, and uptime — but not what the Worker is *doing*.
 - `health-check.sh` determines "healthy" (pane alive) or "zombie" (pane dead, FIFO still exists). It cannot distinguish between a Worker actively coding and one stuck waiting on CI.
 
 In Unix terms, this is equivalent to `ps` only showing PIDs without process states. The kernel tracks NEW, READY, RUNNING, WAITING, TERMINATED — cekernel tracks nothing between spawn and completion.
@@ -165,7 +165,7 @@ Rejected:
 
 > Rule of Least Surprise: "In interface design, always do the least surprising thing."
 
-Every script that references FIFOs uses the pattern `worker-{issue}`. Changing FIFO names at runtime would break `watch-worker.sh`（現 `watch.sh`）(which opens FIFOs by known path), `notify-complete.sh` (which writes to a known path), `health-check.sh` (which finds FIFOs by glob), and `cleanup-worktree.sh` (which removes FIFOs by known path). A renaming FIFO violates the expectation that IPC endpoints have stable names.
+Every script that references FIFOs uses the pattern `worker-{issue}`. Changing FIFO names at runtime would break `watch-worker.sh` (now `watch.sh`) (which opens FIFOs by known path), `notify-complete.sh` (which writes to a known path), `health-check.sh` (which finds FIFOs by glob), and `cleanup-worktree.sh` (which removes FIFOs by known path). A renaming FIFO violates the expectation that IPC endpoints have stable names.
 
 ### Alternative: Central state database (SQLite)
 

--- a/docs/adr/0006-env-var-catalog-and-profiles.md
+++ b/docs/adr/0006-env-var-catalog-and-profiles.md
@@ -14,7 +14,7 @@ cekernel's configurable behavior is driven by `CEKERNEL_*` environment variables
 | `CEKERNEL_SESSION_ID` | auto-generated | No | `session-id.sh` → all scripts |
 | `CEKERNEL_IPC_DIR` | derived from SESSION_ID | No | `session-id.sh` → all scripts |
 | `CEKERNEL_MAX_WORKERS` | `3` | Yes | `spawn-worker.sh` |
-| `CEKERNEL_WORKER_TIMEOUT` | `3600` | Yes | `watch-worker.sh`（現 `watch.sh`）|
+| `CEKERNEL_WORKER_TIMEOUT` | `3600` | Yes | `watch-worker.sh` (now `watch.sh`) |
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Yes | `checkpoint-file.sh` |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Yes | `task-file.sh` |
 | `CEKERNEL_ACTIVE_BACKEND` | derived from BACKEND | No | `backend-adapter.sh` (internal) |

--- a/docs/adr/0007-dual-path-completion-detection.md
+++ b/docs/adr/0007-dual-path-completion-detection.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-During execution of issue #72, a Worker completed its work successfully — the state file shows `TERMINATED:merged` and the issue was closed. However, `watch-worker.sh`（現 `watch.sh`）remained blocked on FIFO read, and the FIFO (`worker-72`) was absent from the IPC directory. The Orchestrator only detected completion when the 1-hour timeout fired.
+During execution of issue #72, a Worker completed its work successfully — the state file shows `TERMINATED:merged` and the issue was closed. However, `watch-worker.sh` (now `watch.sh`) remained blocked on FIFO read, and the FIFO (`worker-72`) was absent from the IPC directory. The Orchestrator only detected completion when the 1-hour timeout fired.
 
 Observed IPC directory state:
 
@@ -206,7 +206,7 @@ Rejected: Treats the symptom, not the cause. If the FIFO was never created or wa
 
 ### Negative
 
-- `watch-worker.sh` gains a dependency on `worker-state.sh` (previously only used by `worker-status.sh`（現 `process-status.sh`）and `spawn-worker.sh`)
+- `watch-worker.sh` gains a dependency on `worker-state.sh` (previously only used by `worker-status.sh` (now `process-status.sh`) and `spawn-worker.sh`)
 - Poll interval adds a theoretical 30-second worst-case latency for the fallback path (acceptable — current worst case is 3600 seconds)
 - Slightly more complex `watch_one()` function (loop replaces single `read`)
 

--- a/docs/adr/0008-orchestrator-scheduling-policy.md
+++ b/docs/adr/0008-orchestrator-scheduling-policy.md
@@ -44,7 +44,7 @@ Priority is assigned at issue intake by the Orchestrator. The default is `normal
 
 ### 2. Timeout → TERM signal
 
-When `watch-worker.sh`（現 `watch.sh`）reports timeout, the Orchestrator sends a TERM signal before resorting to force-kill:
+When `watch-worker.sh` (now `watch.sh`) reports timeout, the Orchestrator sends a TERM signal before resorting to force-kill:
 
 ```
 timeout detected
@@ -119,7 +119,7 @@ Worker A completes → slot freed
 
 ### 5. Worker state reporting at phase boundaries
 
-Workers write their state at each phase boundary using `worker_state_write`. This makes Worker activity visible to `worker-status.sh`（現 `process-status.sh`）, `health-check.sh`, and the Orchestrator.
+Workers write their state at each phase boundary using `worker_state_write`. This makes Worker activity visible to `worker-status.sh` (now `process-status.sh`), `health-check.sh`, and the Orchestrator.
 
 State transitions map to Worker protocol phases:
 

--- a/docs/adr/0012-worker-review-separation.md
+++ b/docs/adr/0012-worker-review-separation.md
@@ -183,7 +183,7 @@ If a human later requests additional changes on an approved-but-not-merged PR, t
 
 #### Concurrency Slot Behavior
 
-The concurrency guard in `spawn-worker.sh` counts FIFOs in the IPC directory. When `watch-worker.sh`（現 `watch.sh`）receives `ci-passed`, it removes the FIFO, freeing the concurrency slot. The worktree persists (for potential re-spawn), but the slot is free for other Workers.
+The concurrency guard in `spawn-worker.sh` counts FIFOs in the IPC directory. When `watch-worker.sh` (now `watch.sh`) receives `ci-passed`, it removes the FIFO, freeing the concurrency slot. The worktree persists (for potential re-spawn), but the slot is free for other Workers.
 
 If the Reviewer rejects and the Worker is re-spawned via `spawn-worker.sh --resume`, a new FIFO is created, consuming a slot. This means the Worker only holds a concurrency slot while actively running — between `ci-passed` and any re-spawn decision, the slot is available for other Workers. This is the correct behavior: review is a lightweight subagent operation that should not block Worker slots.
 


### PR DESCRIPTION
closes #315

## Summary

v1.5.0 でのリネーム（`watch-worker.sh` → `watch.sh`、`worker-status.sh` → `process-status.sh`）に伴い、ADR内の旧スクリプト名の初出に括弧書き注釈を追加。

- ADR-0003: `watch-worker.sh`（現 `watch.sh`）初出に注釈
- ADR-0004: `worker-status.sh`（現 `process-status.sh`）初出に注釈、`watch-worker.sh`（現 `watch.sh`）初出に注釈
- ADR-0006: `watch-worker.sh`（現 `watch.sh`）初出に注釈
- ADR-0007: `watch-worker.sh`（現 `watch.sh`）初出に注釈、`worker-status.sh`（現 `process-status.sh`）初出に注釈
- ADR-0008: `watch-worker.sh`（現 `watch.sh`）初出に注釈、`worker-status.sh`（現 `process-status.sh`）初出に注釈
- ADR-0012: `watch-worker.sh`（現 `watch.sh`）初出に注釈

ADRは履歴文書のため直接書き換えではなく、初出のみに注釈を付与。同一ADR内2回目以降は注釈なし。

## Test Plan
- [ ] 各ADR内の旧スクリプト名初出に注釈があることを確認
- [ ] 2回目以降は注釈がないことを確認
- [ ] CI通過