### PR TITLE
fix: headless backend が stdout.log をトランケートする問題を修正

### DIFF
--- a/scripts/shared/backends/headless.sh
+++ b/scripts/shared/backends/headless.sh
@@ -43,7 +43,7 @@ backend_spawn_worker() {
     unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
     CEKERNEL_SESSION_ID="${CEKERNEL_SESSION_ID:-}" \
     exec claude -p --agent "${CEKERNEL_AGENT_WORKER:-worker}" "$prompt"
-  ) > "$log_file" 2>&1 &
+  ) >> "$log_file" 2>&1 &
   local pid=$!
 
   # Save handle (PID)

--- a/tests/shared/test-backend-headless.sh
+++ b/tests/shared/test-backend-headless.sh
@@ -133,6 +133,40 @@ sleep 0.2
 HANDLE_FILE2="${CEKERNEL_IPC_DIR}/handle-${ISSUE2}.worker"
 assert_file_exists "Handle file created for second worker" "$HANDLE_FILE2"
 
+# ── Test 11: Log file uses append mode — Worker → Reviewer switch preserves logs ──
+# Replace mock claude with one that outputs a line and exits immediately
+cat > "${MOCK_BIN}/claude" <<'MOCK_SCRIPT'
+#!/usr/bin/env bash
+# Mock claude that outputs a marker line and exits
+echo "output: $*"
+MOCK_SCRIPT
+chmod +x "${MOCK_BIN}/claude"
+
+ISSUE3="502"
+LOG_FILE3="${CEKERNEL_IPC_DIR}/logs/worker-${ISSUE3}.stdout.log"
+
+# Spawn first process (simulates Worker)
+backend_spawn_worker "$ISSUE3" "worker" "$WORKTREE" "worker-prompt"
+sleep 0.3
+wait 2>/dev/null || true
+
+# Spawn second process (simulates Reviewer replacing Worker on same issue)
+backend_spawn_worker "$ISSUE3" "reviewer" "$WORKTREE" "reviewer-prompt"
+sleep 0.3
+wait 2>/dev/null || true
+
+# Both outputs must be present — log must not have been truncated
+WORKER_LINE=$(grep -c "worker-prompt" "$LOG_FILE3" 2>/dev/null || echo "0")
+REVIEWER_LINE=$(grep -c "reviewer-prompt" "$LOG_FILE3" 2>/dev/null || echo "0")
+
+if [[ "$WORKER_LINE" -ge 1 && "$REVIEWER_LINE" -ge 1 ]]; then
+  echo "  PASS: Log file preserved both Worker and Reviewer output (append mode)"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: Log file truncated (worker_lines=${WORKER_LINE}, reviewer_lines=${REVIEWER_LINE})"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
 # ── Restore PATH ──
 PATH="$OLD_PATH"
 


### PR DESCRIPTION
closes #321

## 概要

headless backend の `backend_spawn_worker()` で `>` リダイレクトを使用していたため、Worker → Reviewer のプロセス切り替え時にログファイルがトランケートされていた。

## 変更内容

- `scripts/shared/backends/headless.sh`: `>` → `>>` に変更（append mode）
- `tests/shared/test-backend-headless.sh`: Worker → Reviewer 切り替え後もログが残ることを確認するテスト追加（Test 11）

## テスト

```
Results: 12 passed, 0 failed
```

wezterm/tmux バックエンドは `script -a`（append mode）経由のため影響なし。