### PR TITLE
feat: configure Renovate GHA grouping, pinDigests, minimumReleaseAge, automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "pinDigests": true
+    },
+    {
+      "matchUpdateTypes": ["patch", "minor", "pinDigest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
closes #329

## 概要

Renovateの設定を充実させる。

## 変更内容

- **GHAグループ化**: `matchManagers: ["github-actions"]` でGitHub Actions依存関係を `"GitHub Actions"` グループにまとめる
- **pinDigests**: GitHub Actions向けに `pinDigests: true` を設定（コミットハッシュでの固定）
- **minimumReleaseAge**: グローバルに `"7 days"` を設定し、リリース直後の更新を避ける
- **automerge**: `patch`、`minor`、`pinDigest` 更新タイプに対して自動マージを有効化

## テスト計画

- [ ] Renovate設定のJSONスキーマが有効であることを確認
- [ ] CIが通過することを確認