### PR TITLE
fix: add helpers:pinGitHubActionDigests preset to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "minimumReleaseAge": "7 days",
   "packageRules": [


### PR DESCRIPTION
## Summary

- #329 の対応漏れ。`packageRules` の `pinDigests: true` だけでは既存GHAのdigest pinning PRが作成されないため、`helpers:pinGitHubActionDigests` プリセットを追加

closes #329

## Test plan

- [x] Renovate がGHAのdigest pinning PRを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)