### PR TITLE
docs: translate Japanese descriptions to English in envs/README.md

### DIFF
--- a/envs/README.md
+++ b/envs/README.md
@@ -15,8 +15,8 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Any filename | `checkpoint-file.sh` | Checkpoint file name in worktree |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Any filename | `task-file.sh` | Task file name in worktree |
 | `CEKERNEL_CI_MAX_RETRIES` | `3` | Positive integer | `worker.md` (Phase 3) | Maximum CI retry attempts before Worker reports failure |
-| `CEKERNEL_AUTO_MERGE` | `false` | `true`, `false` | Orchestrator | `true`: Reviewer 承認後に Orchestrator が自動マージ。`false`: desktop 通知のみ、人間がマージ |
-| `CEKERNEL_REVIEW_MAX_RETRIES` | `2` | Positive integer | Orchestrator | Reviewer の reject → Worker re-implement サイクルの上限。超過時は人間にエスカレーション |
+| `CEKERNEL_AUTO_MERGE` | `false` | `true`, `false` | Orchestrator | `true`: Orchestrator auto-merges after Reviewer approval. `false`: desktop notification only, human merges manually |
+| `CEKERNEL_REVIEW_MAX_RETRIES` | `2` | Positive integer | Orchestrator | Max cycles of Reviewer reject → Worker re-implement. Escalates to human when exceeded |
 | `CEKERNEL_VAR_DIR` | `/usr/local/var/cekernel` | Directory path | `registry.sh`, `wrapper.sh` | Runtime state directory (locks, logs, runners, registry) |
 
 ## Internal Variables


### PR DESCRIPTION
closes #333

## Summary
- `envs/README.md` の `CEKERNEL_AUTO_MERGE` と `CEKERNEL_REVIEW_MAX_RETRIES` の Purpose 列を日本語から英語に翻訳
- 他のドキュメントとの一貫性を維持

## Test Plan
- [ ] ドキュメントのみの変更のため、テスト不要
- [ ] 翻訳内容が正確であることを確認