### PR TITLE
chore: update .gitignore pattern from .cekernel-env to .cekernel*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .worktrees/
 .claude/settings.local.json
-.cekernel-env
+.cekernel*


### PR DESCRIPTION
closes #336

## Summary
- `.gitignore` のエントリ `.cekernel-env` を `.cekernel*` に変更
- `.cekernel-` プレフィックスのファイル（checkpoint、task、env など）をまとめて除外可能に