### PR TITLE
fix: run-tests.sh deletes production IPC directory when CEKERNEL_VAR_DIR is inherited

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -7,8 +7,9 @@ TOTAL_PASS=0
 TOTAL_FAIL=0
 FAILED_FILES=()
 
-# Use a temporary directory for runtime state so tests don't depend on system paths
-export CEKERNEL_VAR_DIR="${CEKERNEL_VAR_DIR:-$(mktemp -d)}"
+# Always use a fresh temporary directory for runtime state so tests never affect
+# production IPC directories (even when CEKERNEL_VAR_DIR is inherited from the environment)
+export CEKERNEL_VAR_DIR="$(mktemp -d)"
 _CEKERNEL_VAR_DIR_CREATED=1
 
 echo "=== cekernel test runner ==="

--- a/tests/shared/test-run-tests-isolation.sh
+++ b/tests/shared/test-run-tests-isolation.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# test-run-tests-isolation.sh — Tests that run-tests.sh does not delete inherited CEKERNEL_VAR_DIR
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+RUN_TESTS="${SCRIPT_DIR}/../run-tests.sh"
+
+echo "test: run-tests.sh isolation"
+
+# ── Test 1: Pre-existing CEKERNEL_VAR_DIR survives run-tests.sh execution ──
+# Copy run-tests.sh to an empty directory (no category dirs → no tests to run)
+# so the script finishes instantly, but CEKERNEL_VAR_DIR setup/cleanup still executes.
+EMPTY_TEST_DIR="$(mktemp -d)"
+cp "$RUN_TESTS" "$EMPTY_TEST_DIR/run-tests.sh"
+
+FAKE_PRODUCTION_DIR="$(mktemp -d)"
+touch "${FAKE_PRODUCTION_DIR}/sentinel"
+
+(
+  export CEKERNEL_VAR_DIR="$FAKE_PRODUCTION_DIR"
+  bash "$EMPTY_TEST_DIR/run-tests.sh"
+) >/dev/null 2>&1 || true
+
+assert_dir_exists "inherited CEKERNEL_VAR_DIR survives after run-tests.sh" "$FAKE_PRODUCTION_DIR"
+assert_file_exists "files inside inherited dir survive" "${FAKE_PRODUCTION_DIR}/sentinel"
+
+# Cleanup
+rm -rf "$FAKE_PRODUCTION_DIR" "$EMPTY_TEST_DIR"
+
+report_results


### PR DESCRIPTION
closes #339

## Summary
- `run-tests.sh` が環境変数 `CEKERNEL_VAR_DIR` を継承した場合、本番 IPC ディレクトリを `rm -rf` してしまうバグを修正
- `${CEKERNEL_VAR_DIR:-$(mktemp -d)}` → `$(mktemp -d)` に変更し、常に新規 temp ディレクトリを使用
- 回帰テスト `test-run-tests-isolation.sh` を追加

## Test Plan
- [x] RED: 修正前に `test-run-tests-isolation.sh` が FAIL することを確認
- [x] GREEN: 修正後に `test-run-tests-isolation.sh` が PASS することを確認
- [x] 全テストスイート実行（既存テストに回帰なし、`test-orchctrl-gc.sh` は main でも失敗する既知の問題）