### PR TITLE
feat: add auto-approve workflow for Renovate PRs

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,0 +1,14 @@
+name: Auto-approve Renovate PRs
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
+  "platformAutomerge": true,
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {


### PR DESCRIPTION
closes #344

## Summary
- Renovate PR を自動 approve する GitHub Actions workflow を追加
- `renovate.json` に `platformAutomerge: true` を追加し、GitHub ネイティブの auto-merge を有効化
- Branch protection の review approval 要件を満たし、Renovate の automerge を完全自動化

## 変更ファイル
- `.github/workflows/auto-approve-renovate.yml` — 新規作成（`hmarr/auto-approve-action@v4` を digest pin で使用）
- `renovate.json` — `platformAutomerge: true` 追加

## フロー
1. Renovate が PR を作成（`automerge: true` の対象）
2. `platformAutomerge: true` により GitHub の auto-merge が有効化
3. `auto-approve-renovate.yml` が `renovate[bot]` の PR を自動 approve
4. CI パス + approve が揃った時点で GitHub が自動マージ

## Test Plan
- [ ] YAML / JSON の構文確認 ✅
- [ ] Workflow が `renovate[bot]` の PR のみに限定されていることを確認 ✅
- [ ] Action の digest pin が既存の規約に一致していることを確認 ✅