### PR TITLE
refactor: remove headless backend stdout redirect

### DIFF
--- a/scripts/orchestrator/orchctrl.sh
+++ b/scripts/orchestrator/orchctrl.sh
@@ -5,7 +5,6 @@
 #
 # Commands:
 #   ls                          List all workers across all sessions
-#   log <target>                Tail worker log
 #   inspect <target>            Detailed worker view
 #   suspend <target>            Suspend a worker (send SUSPEND signal)
 #   resume <target>             Resume a suspended worker
@@ -40,7 +39,6 @@ Usage: orchctrl.sh <command> [args...]
 
 Commands:
   ls                          List all workers
-  log <target>                Tail worker log
   inspect <target>            Detailed worker view
   suspend <target>            Suspend a worker
   resume <target>             Resume a suspended worker
@@ -196,18 +194,6 @@ detect_backend() {
   fi
 }
 
-# ── Helper: find best log file ──
-find_log_file() {
-  local ipc_dir="$1" issue="$2"
-
-  # Prefer stdout.log (headless backend output)
-  if [[ -f "${ipc_dir}/logs/worker-${issue}.stdout.log" ]]; then
-    echo "${ipc_dir}/logs/worker-${issue}.stdout.log"
-  elif [[ -f "${ipc_dir}/logs/worker-${issue}.log" ]]; then
-    echo "${ipc_dir}/logs/worker-${issue}.log"
-  fi
-}
-
 # ══════════════════════════════════════════════
 # Commands
 # ══════════════════════════════════════════════
@@ -263,10 +249,6 @@ cmd_ls() {
       local backend
       backend=$(detect_backend "$session_dir" "$issue")
 
-      # Log path
-      local log_path
-      log_path=$(find_log_file "$session_dir" "$issue")
-
       jq -cn \
         --arg session "$sid" \
         --arg repo "$sid_repo" \
@@ -278,32 +260,13 @@ cmd_ls() {
         --arg priority_name "$priority_name" \
         --arg elapsed "${elapsed:-}" \
         --arg backend "$backend" \
-        --arg log "${log_path:-}" \
-        '{session: $session, repo: $repo, issue: $issue, type: $type, state: $state, detail: $detail, priority: $priority, priority_name: $priority_name, elapsed: $elapsed, backend: $backend, log: $log}'
+        '{session: $session, repo: $repo, issue: $issue, type: $type, state: $state, detail: $detail, priority: $priority, priority_name: $priority_name, elapsed: $elapsed, backend: $backend}'
     done
   done
 
   if [[ "$found" -eq 0 ]]; then
     echo "no workers."
   fi
-}
-
-# ── log: Tail worker log ──
-cmd_log() {
-  resolve_target "$@" || return 1
-  set_ipc_context
-
-  local log_file
-  log_file=$(find_log_file "$CEKERNEL_IPC_DIR" "$RESOLVED_ISSUE")
-
-  if [[ -z "$log_file" ]]; then
-    echo "Error: no log file found for worker #${RESOLVED_ISSUE}" >&2
-    return 1
-  fi
-
-  echo "=== Log: worker #${RESOLVED_ISSUE} (session: ${RESOLVED_SESSION}) ===" >&2
-  echo "=== File: ${log_file} ===" >&2
-  tail -100 "$log_file"
 }
 
 # ── inspect: Detailed worker view ──
@@ -360,19 +323,6 @@ cmd_inspect() {
     checkpoint_json=$(read_checkpoint_file "$worktree")
   fi
 
-  # Log files
-  local log_files="[]"
-  local logs=()
-  if [[ -f "${CEKERNEL_IPC_DIR}/logs/worker-${RESOLVED_ISSUE}.stdout.log" ]]; then
-    logs+=("${CEKERNEL_IPC_DIR}/logs/worker-${RESOLVED_ISSUE}.stdout.log")
-  fi
-  if [[ -f "${CEKERNEL_IPC_DIR}/logs/worker-${RESOLVED_ISSUE}.log" ]]; then
-    logs+=("${CEKERNEL_IPC_DIR}/logs/worker-${RESOLVED_ISSUE}.log")
-  fi
-  if [[ ${#logs[@]} -gt 0 ]]; then
-    log_files=$(printf '%s\n' "${logs[@]}" | jq -Rsc 'split("\n") | map(select(. != ""))')
-  fi
-
   jq -cn \
     --arg session "$RESOLVED_SESSION" \
     --argjson issue "$RESOLVED_ISSUE" \
@@ -385,8 +335,7 @@ cmd_inspect() {
     --arg backend "$backend" \
     --arg worktree "${worktree:-}" \
     --argjson checkpoint "$checkpoint_json" \
-    --argjson logs "$log_files" \
-    '{session: $session, issue: $issue, type: $type, state: $state, detail: $detail, timestamp: $timestamp, priority: $priority, elapsed: $elapsed, backend: $backend, worktree: $worktree, checkpoint: $checkpoint, logs: $logs}'
+    '{session: $session, issue: $issue, type: $type, state: $state, detail: $detail, timestamp: $timestamp, priority: $priority, elapsed: $elapsed, backend: $backend, worktree: $worktree, checkpoint: $checkpoint}'
 }
 
 # ── suspend: Send SUSPEND signal ──
@@ -446,24 +395,30 @@ cmd_kill() {
   resolve_target "$@" || return 1
   set_ipc_context
 
+  # Detect backend once for all handles
+  local backend
+  backend=$(detect_backend "$CEKERNEL_IPC_DIR" "$RESOLVED_ISSUE")
+
   # Kill all handle files for this issue (Worker + Reviewer)
   for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${RESOLVED_ISSUE}".*; do
     [[ -f "$handle_file" ]] || continue
     local handle_content
     handle_content=$(tr -d '[:space:]' < "$handle_file")
 
-    if [[ "$handle_content" == *:*.* ]]; then
-      # tmux pane target — kill the window
-      local window_target
-      window_target=$(echo "$handle_content" | sed 's/\.[0-9]*$//')
-      tmux kill-window -t "$window_target" 2>/dev/null || true
-    elif [[ -f "${CEKERNEL_IPC_DIR}/logs/worker-${RESOLVED_ISSUE}.stdout.log" ]]; then
-      # headless — handle is PID, kill process group
-      kill -- -"$handle_content" 2>/dev/null || kill "$handle_content" 2>/dev/null || true
-    else
-      # wezterm — handle is pane ID
-      wezterm cli kill-pane --pane-id "$handle_content" 2>/dev/null || true
-    fi
+    case "$backend" in
+      tmux)
+        local window_target
+        window_target=$(echo "$handle_content" | sed 's/\.[0-9]*$//')
+        tmux kill-window -t "$window_target" 2>/dev/null || true
+        ;;
+      headless)
+        kill -- -"$handle_content" 2>/dev/null || kill "$handle_content" 2>/dev/null || true
+        ;;
+      *)
+        # wezterm or unknown — try wezterm pane kill
+        wezterm cli kill-pane --pane-id "$handle_content" 2>/dev/null || true
+        ;;
+    esac
   done
 
   # Mark as terminated
@@ -777,7 +732,6 @@ shift || true
 
 case "$COMMAND" in
   ls)      cmd_ls "$@" ;;
-  log)     cmd_log "$@" ;;
   inspect) cmd_inspect "$@" ;;
   suspend) cmd_suspend "$@" ;;
   resume)  cmd_resume "$@" ;;

--- a/scripts/shared/backends/headless.sh
+++ b/scripts/shared/backends/headless.sh
@@ -3,7 +3,7 @@
 #
 # Implements 5 external API functions using background processes.
 # No terminal multiplexer required — Workers run as background processes
-# with stdout/stderr redirected to log files.
+# with stdout/stderr discarded (analysis uses transcripts, not log files).
 #
 # Sourced by backend-adapter.sh when CEKERNEL_BACKEND=headless.
 #
@@ -27,11 +27,6 @@ backend_spawn_worker() {
   local prompt="$4"
   local agent_name="$5"
 
-  # Ensure log directory exists
-  local log_dir="${CEKERNEL_IPC_DIR}/logs"
-  mkdir -p "$log_dir"
-  local log_file="${log_dir}/worker-${issue}.stdout.log"
-
   # Launch Worker as a background process.
   # Bash creates a new process group for background jobs automatically,
   # so kill -- -$PID can terminate the entire group.
@@ -39,12 +34,13 @@ backend_spawn_worker() {
   # Unset Claude Code session markers to avoid nested-session detection.
   # Use -p (print mode) for non-TTY execution.
   # NOTE: -p may hang without TTY due to upstream bug (claude-code#9026).
+  # stdout/stderr discarded — analysis uses transcripts (ADR-0005, #347).
   (
     cd "$worktree" && \
     unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
     CEKERNEL_SESSION_ID="${CEKERNEL_SESSION_ID:-}" \
     exec claude -p --agent "$agent_name" "$prompt"
-  ) >> "$log_file" 2>&1 &
+  ) >/dev/null 2>&1 &
   local pid=$!
 
   # Save handle (PID)

--- a/skills/orchctrl/SKILL.md
+++ b/skills/orchctrl/SKILL.md
@@ -12,7 +12,6 @@ Worker control interface for cekernel. Like `systemctl` / `supervisorctl`, provi
 
 ```
 /orchctrl ls
-/orchctrl log <target>
 /orchctrl inspect <target>
 /orchctrl suspend <target>
 /orchctrl resume <target>
@@ -59,22 +58,14 @@ Run `orchctrl.sh` via Bash with the user's command.
 bash "$ORCHCTRL" ls
 ```
 
-Output: JSON Lines (one per Worker). Fields: `session`, `repo`, `issue`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`, `log`.
+Output: JSON Lines (one per Worker). Fields: `session`, `repo`, `issue`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`.
 
 If no workers are found, outputs `no workers.`
 
 Format the output as a readable table for the user:
 
-| Session | Repo | Issue | State | Priority | Elapsed | Backend | Log |
-|---------|------|-------|-------|----------|---------|---------|-----|
-
-#### log — Tail Worker log
-
-```bash
-bash "$ORCHCTRL" log <target>
-```
-
-Shows the last 100 lines of the Worker's log file. Saves the user from searching for log file locations in `$CEKERNEL_VAR_DIR/ipc/`.
+| Session | Repo | Issue | State | Priority | Elapsed | Backend |
+|---------|------|-------|-------|----------|---------|---------|
 
 #### inspect — Detailed Worker view
 
@@ -82,7 +73,7 @@ Shows the last 100 lines of the Worker's log file. Saves the user from searching
 bash "$ORCHCTRL" inspect <target>
 ```
 
-Output: JSON with `session`, `issue`, `state`, `priority`, `elapsed`, `backend`, `worktree`, `checkpoint`, `logs`.
+Output: JSON with `session`, `issue`, `state`, `priority`, `elapsed`, `backend`, `worktree`, `checkpoint`.
 
 Present the output in a human-readable format, especially the checkpoint data (current phase, completed work, next steps, key decisions).
 
@@ -136,6 +127,5 @@ Changes the Worker's priority. Priority values: `critical` (0), `high` (5), `nor
 
 - For `ls`: Format as a table
 - For `inspect`: Format as a structured summary
-- For `log`: Show the log content directly
 - For action commands (`suspend`, `resume`, `term`, `kill`, `nice`): Confirm the action was taken
 - For `resume`: Also show the follow-up `spawn-worker.sh --resume` command for the user to execute

--- a/tests/orchestrator/test-orchctrl.sh
+++ b/tests/orchestrator/test-orchctrl.sh
@@ -207,29 +207,6 @@ assert_match "kill marks worker as TERMINATED" "^TERMINATED:" "$STATE_CONTENT"
 assert_match "kill detail says killed" ":killed$" "$STATE_CONTENT"
 
 # ══════════════════════════════════════════════
-# log command
-# ══════════════════════════════════════════════
-
-# ── Test 24: log shows log content ──
-mkdir -p "${IPC_A}/logs"
-echo "test log line 1" > "${IPC_A}/logs/worker-10.log"
-echo "test log line 2" >> "${IPC_A}/logs/worker-10.log"
-OUTPUT=$(bash "$ORCHCTRL" log 10 --session "$SESSION_A" 2>/dev/null)
-assert_match "log shows content" "test log line 1" "$OUTPUT"
-
-# ── Test 25: log prefers stdout.log for headless ──
-echo "headless output" > "${IPC_A}/logs/worker-10.stdout.log"
-OUTPUT=$(bash "$ORCHCTRL" log 10 --session "$SESSION_A" 2>/dev/null)
-assert_match "log prefers stdout.log" "headless output" "$OUTPUT"
-rm -f "${IPC_A}/logs/worker-10.stdout.log"
-
-# ── Test 26: log missing → error ──
-rm -rf "${IPC_A}/logs"
-EXIT_CODE=0
-bash "$ORCHCTRL" log 10 --session "$SESSION_A" 2>/dev/null || EXIT_CODE=$?
-assert_eq "log missing: error" "1" "$EXIT_CODE"
-
-# ══════════════════════════════════════════════
 # inspect command
 # ══════════════════════════════════════════════
 

--- a/tests/shared/test-backend-headless.sh
+++ b/tests/shared/test-backend-headless.sh
@@ -17,7 +17,6 @@ export CEKERNEL_SESSION_ID="test-headless-backend-001"
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
 rm -rf "$CEKERNEL_IPC_DIR"
 mkdir -p "$CEKERNEL_IPC_DIR"
-mkdir -p "${CEKERNEL_IPC_DIR}/logs"
 
 # ── Load headless backend ──
 export CEKERNEL_BACKEND=headless
@@ -116,56 +115,18 @@ EXIT_CODE=0
 backend_kill_worker "99999" 2>/dev/null || EXIT_CODE=$?
 assert_eq "kill_worker for non-existent handle exits cleanly" "0" "$EXIT_CODE"
 
-# ── Test 9: Log file is created for spawned worker ──
+# ── Test 9: Second worker spawn creates handle file ──
 ISSUE2="501"
 backend_spawn_worker "$ISSUE2" "worker" "$WORKTREE" "test prompt 2" "worker"
 sleep 0.2
 
-LOG_FILE="${CEKERNEL_IPC_DIR}/logs/worker-${ISSUE2}.stdout.log"
-assert_file_exists "Log file created for spawned worker" "$LOG_FILE"
+# Verify handle file exists
+HANDLE_FILE2="${CEKERNEL_IPC_DIR}/handle-${ISSUE2}.worker"
+assert_file_exists "Handle file created for second worker" "$HANDLE_FILE2"
 
 # Clean up process
 backend_kill_worker "$ISSUE2" 2>/dev/null || true
 sleep 0.2
-
-# ── Test 10: SESSION_ID is propagated to worker process ──
-# We can't easily check this with a mock, but verify the handle exists
-HANDLE_FILE2="${CEKERNEL_IPC_DIR}/handle-${ISSUE2}.worker"
-assert_file_exists "Handle file created for second worker" "$HANDLE_FILE2"
-
-# ── Test 11: Log file uses append mode — Worker → Reviewer switch preserves logs ──
-# Replace mock claude with one that outputs a line and exits immediately
-cat > "${MOCK_BIN}/claude" <<'MOCK_SCRIPT'
-#!/usr/bin/env bash
-# Mock claude that outputs a marker line and exits
-echo "output: $*"
-MOCK_SCRIPT
-chmod +x "${MOCK_BIN}/claude"
-
-ISSUE3="502"
-LOG_FILE3="${CEKERNEL_IPC_DIR}/logs/worker-${ISSUE3}.stdout.log"
-
-# Spawn first process (simulates Worker)
-backend_spawn_worker "$ISSUE3" "worker" "$WORKTREE" "worker-prompt" "worker"
-sleep 0.3
-wait 2>/dev/null || true
-
-# Spawn second process (simulates Reviewer replacing Worker on same issue)
-backend_spawn_worker "$ISSUE3" "reviewer" "$WORKTREE" "reviewer-prompt" "reviewer"
-sleep 0.3
-wait 2>/dev/null || true
-
-# Both outputs must be present — log must not have been truncated
-WORKER_LINE=$(grep -c "worker-prompt" "$LOG_FILE3" 2>/dev/null || echo "0")
-REVIEWER_LINE=$(grep -c "reviewer-prompt" "$LOG_FILE3" 2>/dev/null || echo "0")
-
-if [[ "$WORKER_LINE" -ge 1 && "$REVIEWER_LINE" -ge 1 ]]; then
-  echo "  PASS: Log file preserved both Worker and Reviewer output (append mode)"
-  TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-  echo "  FAIL: Log file truncated (worker_lines=${WORKER_LINE}, reviewer_lines=${REVIEWER_LINE})"
-  TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
 
 # ── Restore PATH ──
 PATH="$OLD_PATH"


### PR DESCRIPTION
closes #349

## Summary
- `headless.sh`: stdout/stderr リダイレクト（ログファイル書き出し）を `>/dev/null 2>&1` に変更、`log_dir` 作成を除去
- `orchctrl.sh`: `log` サブコマンド、`find_log_file` ヘルパー、`ls`/`inspect` の `log`/`logs` フィールドを除去
- `orchctrl.sh`: `cmd_kill` のインライン `stdout.log` ヒューリスティックを `detect_backend()` に置き換え（新しい headless Worker で kill が失敗する問題を防止）
- `SKILL.md`: `log` コマンドのドキュメント除去
- テスト: log ファイル作成/append テスト、log コマンドテストを除去

## Test Plan
- [x] `test-orchctrl.sh`: 47 passed, 0 failed
- [x] `test-backend-headless.sh`: 10 passed, 0 failed
- [x] 全テスト (pre-existing `test-orchctrl-gc.sh` の bash 3.x 互換性問題を除き pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)