### PR TITLE
fix: replace hmarr/auto-approve-action with gh CLI

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -11,4 +11,7 @@ jobs:
     if: github.actor == 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
closes #351

## Summary
- `hmarr/auto-approve-action` を `gh pr review --approve` に差し替え
- 外部 action への依存を除去し、Renovate の digest lookup failure を根本解決

## Test Plan
- [ ] Renovate bot の PR が自動承認されることを確認
- [ ] Dependency Dashboard (#328) から package lookup failure が解消されることを確認