### PR TITLE
feat: add transcript-locator.sh for post-mortem transcript discovery

### DIFF
--- a/scripts/shared/transcript-locator.sh
+++ b/scripts/shared/transcript-locator.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# transcript-locator.sh — Locate Claude Code conversation transcripts for post-mortem analysis
+#
+# Implements the Transcript Discovery Algorithm from ADR-0013.
+# Centralizes path resolution so that changes to Claude Code's storage
+# format can be absorbed in one place.
+#
+# Usage: source transcript-locator.sh
+#
+# Functions:
+#   transcript_locate_worker <issue-number> [claude-home]
+#     — Find Worker/Reviewer transcripts by issue number
+#     — Outputs one path per line to stdout
+#     — Returns 1 if no transcripts found (error on stderr)
+#
+#   transcript_locate_orchestrator <session-id> [claude-home] [project-slug]
+#     — Find Orchestrator subagent transcripts by session ID
+#     — Outputs one path per line to stdout
+#     — Returns 1 if no transcripts found (error on stderr)
+#
+#   transcript_locate_all <issue-number> [session-id] [claude-home] [project-slug]
+#     — Combine worker + orchestrator transcript discovery
+#     — Outputs one path per line to stdout
+#     — Returns partial results when only some transcripts are found
+#
+# Claude Code transcript locations (as of ADR-0013):
+#   Worker/Reviewer: ~/.claude/projects/*-issue-{number}-*/*.jsonl
+#   Orchestrator:    ~/.claude/projects/<project>/<session-id>/subagents/*.jsonl
+
+# transcript_locate_worker <issue-number> [claude-home]
+# Finds Worker/Reviewer transcripts matching the issue number.
+# Workers and Reviewers run in worktrees whose directory names contain
+# the issue number, so the glob pattern matches directly.
+transcript_locate_worker() {
+  local issue_number="${1:?Usage: transcript_locate_worker <issue-number> [claude-home]}"
+  local claude_home="${2:-${HOME}/.claude}"
+
+  # Validate issue number is numeric
+  if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+    echo "transcript_locate_worker: issue number must be numeric: ${issue_number}" >&2
+    return 1
+  fi
+
+  local projects_dir="${claude_home}/projects"
+  local found=0
+
+  # Glob: *-issue-{number}-* matches worktree project directories
+  # e.g., -Users-alice-git-repo-.worktrees-issue-42-feat-add-widget
+  local pattern="${projects_dir}/*-issue-${issue_number}-*/*.jsonl"
+
+  # Use nullglob behavior via find to avoid literal glob in output
+  while IFS= read -r -d '' file; do
+    echo "$file"
+    found=$((found + 1))
+  done < <(find "${projects_dir}" -path "*-issue-${issue_number}-*/*.jsonl" -not -path "*/subagents/*" -print0 2>/dev/null | sort -z)
+
+  if [[ "$found" -eq 0 ]]; then
+    echo "No Worker/Reviewer transcripts found for issue #${issue_number}" >&2
+    return 1
+  fi
+}
+
+# transcript_locate_orchestrator <session-id> [claude-home] [project-slug]
+# Finds Orchestrator subagent transcripts for a given session.
+# The Orchestrator runs as a subagent of the interactive session.
+# Transcripts are at: ~/.claude/projects/<project>/<session-id>/subagents/*.jsonl
+transcript_locate_orchestrator() {
+  local session_id="${1:?Usage: transcript_locate_orchestrator <session-id> [claude-home] [project-slug]}"
+  local claude_home="${2:-${HOME}/.claude}"
+  local project_slug="${3:-}"
+
+  local projects_dir="${claude_home}/projects"
+  local found=0
+
+  local search_base
+  if [[ -n "$project_slug" ]]; then
+    search_base="${projects_dir}/${project_slug}"
+  else
+    search_base="${projects_dir}"
+  fi
+
+  # Look for subagent transcripts under the session directory
+  while IFS= read -r -d '' file; do
+    echo "$file"
+    found=$((found + 1))
+  done < <(find "$search_base" -path "*/${session_id}/subagents/*.jsonl" -print0 2>/dev/null | sort -z)
+
+  if [[ "$found" -eq 0 ]]; then
+    echo "No Orchestrator transcripts found for session ${session_id}" >&2
+    return 1
+  fi
+}
+
+# transcript_locate_all <issue-number> [session-id] [claude-home] [project-slug]
+# Combines worker + orchestrator transcript discovery.
+# Partial success is allowed: returns whatever is found, warns about missing.
+transcript_locate_all() {
+  local issue_number="${1:?Usage: transcript_locate_all <issue-number> [session-id] [claude-home] [project-slug]}"
+  local session_id="${2:-}"
+  local claude_home="${3:-${HOME}/.claude}"
+  local project_slug="${4:-}"
+
+  local any_found=0
+
+  # Worker/Reviewer transcripts
+  if transcript_locate_worker "$issue_number" "$claude_home" 2>/dev/null; then
+    any_found=1
+  else
+    echo "Warning: No Worker/Reviewer transcripts found for issue #${issue_number}" >&2
+  fi
+
+  # Orchestrator transcripts (optional — requires session ID)
+  if [[ -n "$session_id" ]]; then
+    if transcript_locate_orchestrator "$session_id" "$claude_home" "$project_slug" 2>/dev/null; then
+      any_found=1
+    else
+      echo "Warning: No Orchestrator transcripts found for session ${session_id}" >&2
+    fi
+  fi
+
+  if [[ "$any_found" -eq 0 ]]; then
+    echo "No transcripts found for issue #${issue_number}" >&2
+    return 1
+  fi
+}

--- a/tests/shared/test-transcript-locator.sh
+++ b/tests/shared/test-transcript-locator.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test-transcript-locator.sh — Tests for transcript-locator.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "test: transcript-locator"
+
+# Test session
+export CEKERNEL_SESSION_ID="test-transcript-locator-00000001"
+source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+
+# ── Setup ──
+TMPDIR_TEST=$(mktemp -d)
+MOCK_CLAUDE_HOME="${TMPDIR_TEST}/claude-home"
+
+cleanup() {
+  rm -rf "$TMPDIR_TEST" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Source the transcript-locator helper (override CLAUDE_PROJECTS_DIR)
+source "${CEKERNEL_DIR}/scripts/shared/transcript-locator.sh"
+
+# ── Test 1: Worker transcript discovery — single file ──
+WORKER_PROJECT="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo-.worktrees-issue-42-feat-add-widget"
+mkdir -p "$WORKER_PROJECT"
+touch "${WORKER_PROJECT}/session-abc123.jsonl"
+
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME")
+assert_eq "Worker transcript found for issue 42" "${WORKER_PROJECT}/session-abc123.jsonl" "$RESULT"
+
+# ── Test 2: Worker transcript discovery — multiple files (resume) ──
+touch "${WORKER_PROJECT}/session-def456.jsonl"
+
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | sort)
+EXPECTED=$(printf '%s\n%s' "${WORKER_PROJECT}/session-abc123.jsonl" "${WORKER_PROJECT}/session-def456.jsonl" | sort)
+assert_eq "Multiple worker transcripts found (resume)" "$EXPECTED" "$RESULT"
+
+# ── Test 3: Worker transcript discovery — no match ──
+EXIT_CODE=0
+RESULT=$(transcript_locate_worker 999 "$MOCK_CLAUDE_HOME" 2>/dev/null) || EXIT_CODE=$?
+assert_eq "Worker transcript not found returns empty" "" "$RESULT"
+assert_eq "Worker transcript not found exit code 1" "1" "$EXIT_CODE"
+
+# ── Test 4: Reviewer transcript shares same pattern as Worker ──
+REVIEWER_PROJECT="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo-.worktrees-issue-42-feat-add-widget-reviewer"
+mkdir -p "$REVIEWER_PROJECT"
+touch "${REVIEWER_PROJECT}/session-review1.jsonl"
+
+# Worker locate should also find reviewer transcripts (both contain issue number)
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | wc -l | tr -d ' ')
+assert_eq "Finds transcripts from both worker and reviewer worktrees" "3" "$RESULT"
+
+# ── Test 5: Orchestrator transcript discovery ──
+ORCH_SESSION_DIR="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo/session-orch1/subagents"
+mkdir -p "$ORCH_SESSION_DIR"
+touch "${ORCH_SESSION_DIR}/agent-orch-001.jsonl"
+touch "${ORCH_SESSION_DIR}/agent-orch-002.jsonl"
+
+RESULT=$(transcript_locate_orchestrator "session-orch1" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | sort)
+EXPECTED=$(printf '%s\n%s' "${ORCH_SESSION_DIR}/agent-orch-001.jsonl" "${ORCH_SESSION_DIR}/agent-orch-002.jsonl" | sort)
+assert_eq "Orchestrator transcripts found via session ID" "$EXPECTED" "$RESULT"
+
+# ── Test 6: Orchestrator transcript — session not found ──
+EXIT_CODE=0
+RESULT=$(transcript_locate_orchestrator "nonexistent-session" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null) || EXIT_CODE=$?
+assert_eq "Orchestrator transcript not found returns empty" "" "$RESULT"
+assert_eq "Orchestrator transcript not found exit code 1" "1" "$EXIT_CODE"
+
+# ── Test 7: transcript_locate_all combines worker + orchestrator ──
+RESULT=$(transcript_locate_all 42 "session-orch1" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ')
+assert_eq "transcript_locate_all returns all transcripts" "5" "$RESULT"
+
+# ── Test 8: transcript_locate_all without orchestrator session ──
+RESULT=$(transcript_locate_all 42 "" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "transcript_locate_all works without orchestrator session" "3" "$RESULT"
+
+# ── Test 9: Non-.jsonl files are excluded ──
+touch "${WORKER_PROJECT}/not-a-transcript.txt"
+touch "${WORKER_PROJECT}/session.json"
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | wc -l | tr -d ' ')
+assert_eq "Non-.jsonl files excluded" "3" "$RESULT"
+
+# ── Test 10: Error message on stderr for absent transcripts ──
+ERR_OUTPUT=$(transcript_locate_worker 888 "$MOCK_CLAUDE_HOME" 2>&1 1>/dev/null || true)
+assert_match "Error message on stderr for missing transcripts" "No.*transcript" "$ERR_OUTPUT"
+
+# ── Test 11: Issue number must be numeric ──
+EXIT_CODE=0
+ERR_OUTPUT=$(transcript_locate_worker "abc" "$MOCK_CLAUDE_HOME" 2>&1 1>/dev/null) || EXIT_CODE=$?
+assert_match "Non-numeric issue number produces error" "numeric" "$ERR_OUTPUT"
+assert_eq "Non-numeric issue number returns exit code 1" "1" "$EXIT_CODE"
+
+report_results


### PR DESCRIPTION
closes #354

## Summary
- ADR-0013 の Transcript Discovery Algorithm を `scripts/shared/transcript-locator.sh` として実装
- Worker/Reviewer の transcript を issue 番号で glob 検出する `transcript_locate_worker` 関数
- Orchestrator の subagent transcript をセッション ID で検出する `transcript_locate_orchestrator` 関数
- 両者を統合し部分的成功を許容する `transcript_locate_all` 関数
- Claude Code の transcript パス解決を一箇所に集約し、ストレージ形式変更時の影響を局所化

## Test Plan
- [x] Worker transcript の単一ファイル検出
- [x] 複数 transcript（resume）の全件返却
- [x] transcript 不在時の exit code 1 とエラーメッセージ
- [x] Reviewer transcript の同時検出
- [x] Orchestrator transcript のセッション ID 検出
- [x] `transcript_locate_all` の統合動作
- [x] 非 `.jsonl` ファイルの除外
- [x] 非数値 issue 番号のバリデーション
- [x] 全 14 テスト通過