### PR TITLE
fix: source load-env.sh before session-id.sh in /orchestrate skill

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -67,6 +67,7 @@ If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name
 **Persist Claude Code Session ID** — Before launching the Orchestrator, discover and save the current Claude Code session ID so that `/postmortem` can later locate Orchestrator transcripts:
 
 ```bash
+source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
 source "${CEKERNEL_SCRIPTS}/shared/session-id.sh"
 source "${CEKERNEL_SCRIPTS}/shared/claude-session-id.sh"
 mkdir -p "$CEKERNEL_IPC_DIR"


### PR DESCRIPTION
closes #366

## Summary
- `/orchestrate` スキルの Step 2 で `session-id.sh` を source する前に `load-env.sh` を source するように修正
- これにより、ユーザープロファイルで設定された `CEKERNEL_VAR_DIR` が `session-id.sh` で正しく参照されるようになる

## Test Plan
- [x] 既存テストが全てパス（`test-orchctrl-gc.sh` の失敗は main でも再現する既存の問題）
- [x] `load-env.sh` → `session-id.sh` の順序で source されることを SKILL.md 上で確認