### PR TITLE
fix: replace declare -A with temp file in orchctrl gc for bash 3.2 compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,23 @@ Under `set -e` this causes immediate termination. Use `var=$((var + 1))` instead
 FAILED=$((FAILED + 1))
 ```
 
+`declare -A` (associative arrays) requires bash 4+. macOS ships bash 3.2 by default,
+so scripts using `declare -A` fail with exit code 2 on macOS. Use a temp file with
+`grep -qxF` for set-membership lookups instead:
+
+```bash
+# BAD: fails on bash 3.2
+declare -A seen
+seen["key"]=1
+[[ -n "${seen["key"]:-}" ]]
+
+# OK: bash 3.2 compatible
+seen_file=$(mktemp /tmp/cekernel-seen.XXXXXX)
+echo "key" >> "$seen_file"
+grep -qxF "key" "$seen_file"
+rm -f "$seen_file"
+```
+
 ### Environment Variables
 
 Use the `CEKERNEL_` prefix. Use `${VAR:-default}` pattern for default values. See [`envs/README.md`](./envs/README.md) for the full variable catalog.

--- a/scripts/orchestrator/orchctrl.sh
+++ b/scripts/orchestrator/orchctrl.sh
@@ -585,7 +585,9 @@ cmd_gc() {
   # Build a set of active issue numbers per session for orphan detection.
   # FIFOs are checked for staleness: if the process is dead or state is
   # TERMINATED, the FIFO is removed and not added to active_issues.
-  declare -A active_issues  # key: "session_dir:issue" value: 1
+  # Uses a temp file instead of declare -A for bash 3.2 compatibility.
+  local active_issues_file
+  active_issues_file=$(mktemp /tmp/cekernel-gc-active.XXXXXX)
 
   if [[ -d "$IPC_BASE" ]]; then
     for session_dir in "$IPC_BASE"/*/; do
@@ -608,7 +610,7 @@ cmd_gc() {
           fi
           cleaned=$((cleaned + 1))
         else
-          active_issues["${session_dir}:${issue}"]=1
+          echo "${session_dir}:${issue}" >> "$active_issues_file"
         fi
       done
     done
@@ -673,7 +675,7 @@ cmd_gc() {
       local issue="${issue_with_ext%%.*}"
 
       # Skip if there's an active FIFO
-      if [[ -n "${active_issues["${sdir}:${issue}"]:-}" ]]; then
+      if grep -qxF "${sdir}:${issue}" "$active_issues_file" 2>/dev/null; then
         continue
       fi
 
@@ -710,6 +712,9 @@ cmd_gc() {
       fi
     done
   fi
+
+  # ── Cleanup temp file ──
+  rm -f "$active_issues_file"
 
   # ── 4. Summary ──
   if [[ "$cleaned" -eq 0 ]]; then


### PR DESCRIPTION
closes #379

## Summary
- `orchctrl.sh` の `cmd_gc()` が `declare -A`（bash 4+ 連想配列）を使用しており、macOS デフォルトの bash 3.2 で exit code 2 で失敗していた
- `declare -A active_issues` を一時ファイル + `grep -qxF` によるセットメンバーシップ検索に置き換え
- CLAUDE.md の Known Pitfalls に `declare -A` の bash 3.2 非互換性の注意を追記

## Test Plan
- [x] `test-orchctrl-gc.sh` が bash 3.2 (`/bin/bash`) で全 37 テストパス
- [x] `run-tests.sh` で全テストスイートパス（リグレッションなし）