### PR TITLE
feat: LLMがsourceする共有スクリプトをstandaloneコマンドに変換する

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -29,7 +29,7 @@ The Orchestrator spawns the Reviewer with the following context (via spawn promp
 Reviewers report their state at each workflow step using `worker_state_write`. This makes Reviewer activity visible to `process-status.sh`, `health-check.sh`, and the Orchestrator.
 
 ```bash
-source worker-state.sh && worker_state_write <issue-number> RUNNING "phase1:reading-conventions"
+worker-state-write.sh <issue-number> RUNNING "phase1:reading-conventions"
 ```
 
 Write state at the **start** of each step:
@@ -46,7 +46,7 @@ Write state at the **start** of each step:
 
 ### 1. Understand Conventions
 
-> State: `source worker-state.sh && worker_state_write <issue-number> RUNNING "phase1:reading-conventions"`
+> State: `worker-state-write.sh <issue-number> RUNNING "phase1:reading-conventions"`
 
 Read the target repository's CLAUDE.md and any referenced documents to understand:
 
@@ -64,7 +64,7 @@ If CLAUDE.md references other documents, read those as well.
 
 ### 2. Understand Intent
 
-> State: `source worker-state.sh && worker_state_write <issue-number> RUNNING "phase2:reading-issue"`
+> State: `worker-state-write.sh <issue-number> RUNNING "phase2:reading-issue"`
 
 Read the issue body to understand what the changes are meant to accomplish:
 
@@ -74,7 +74,7 @@ gh issue view <issue-number>
 
 ### 3. Review the Diff
 
-> State: `source worker-state.sh && worker_state_write <issue-number> RUNNING "phase3:reviewing-diff"`
+> State: `worker-state-write.sh <issue-number> RUNNING "phase3:reviewing-diff"`
 
 Read the PR diff and PR description:
 
@@ -94,7 +94,7 @@ Assess the changes against:
 
 ### 5. Submit Review
 
-> State: `source worker-state.sh && worker_state_write <issue-number> RUNNING "phase4:submitting-review"`
+> State: `worker-state-write.sh <issue-number> RUNNING "phase4:submitting-review"`
 
 Based on the evaluation, submit one of two verdicts:
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -47,14 +47,14 @@ cekernel defines only the lifecycle skeleton for Workers:
 3. **Determine startup mode** by checking the following in order:
    1. `.cekernel-task.md` contains `## Resume Reason: changes-requested` →
       - Read the marker content and determine the processing approach
-      - **Clear the marker from the task file** (`source task-file.sh && task_file_clear_resume_marker "$PWD"`) — this prevents stale markers from causing incorrect behavior on subsequent respawns
+      - **Clear the marker from the task file** (`clear-resume-marker.sh "$PWD"`) — this prevents stale markers from causing incorrect behavior on subsequent respawns
       - Read PR review comments (`gh pr view <pr> --comments`), fix issues, push, and wait for CI
    2. `.cekernel-checkpoint.md` exists → SUSPEND resume (read it to understand previous progress and continue from where the last Worker left off)
    3. Neither → fresh start
 4. Read issue content from `.cekernel-task.md` in the worktree (pre-extracted at spawn time)
    - If `.cekernel-task.md` does not exist, fall back to `gh issue view`
 5. Understand the issue requirements
-6. Write state: `source worker-state.sh && worker_state_write <issue-number> RUNNING "phase0:plan"`
+6. Write state: `worker-state-write.sh <issue-number> RUNNING "phase0:plan"`
 7. Post Execution Plan as a comment on the issue (or a Resume Plan if resuming)
 
 ```bash
@@ -99,11 +99,8 @@ fi
 2. Write a checkpoint file to the worktree:
 
 ```bash
-# Source the checkpoint helper (checkpoint-file.sh in scripts/shared/)
-source checkpoint-file.sh
-
 # Save current progress
-create_checkpoint_file "$WORKTREE" \
+create-checkpoint.sh "$WORKTREE" \
   "Phase 1 (Implementation)" \
   "tests written, 2/5 files implemented" \
   "implement remaining 3 files" \
@@ -135,7 +132,7 @@ Phase 4 (Notify)
 Workers report their state at each phase boundary using `worker_state_write`. This makes Worker activity visible to `process-status.sh`, `health-check.sh`, and the Orchestrator.
 
 ```bash
-source worker-state.sh && worker_state_write <issue-number> RUNNING "phase1:implement"
+worker-state-write.sh <issue-number> RUNNING "phase1:implement"
 ```
 
 Write state at the **start** of each phase:
@@ -153,7 +150,7 @@ Write state at the **start** of each phase:
 
 ### Phase 1: Implementation
 
-> State: `source worker-state.sh && worker_state_write <issue> RUNNING "phase1:implement"`
+> State: `worker-state-write.sh <issue> RUNNING "phase1:implement"`
 
 Implement **following the target repository's rules**.
 
@@ -168,7 +165,7 @@ For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first 
 
 ### Phase 2: Create PR
 
-> State: `source worker-state.sh && worker_state_write <issue> RUNNING "phase2:create-pr"`
+> State: `worker-state-write.sh <issue> RUNNING "phase2:create-pr"`
 
 ```bash
 git push -u origin HEAD
@@ -195,8 +192,8 @@ EOF
 
 ### Phase 3: CI Verification
 
-> State: `source worker-state.sh && worker_state_write <issue> WAITING "phase3:ci-waiting"` (before CI wait)
-> On CI fix: `source worker-state.sh && worker_state_write <issue> RUNNING "phase3:ci-fixing"`
+> State: `worker-state-write.sh <issue> WAITING "phase3:ci-waiting"` (before CI wait)
+> On CI fix: `worker-state-write.sh <issue> RUNNING "phase3:ci-fixing"`
 
 #### Load environment profile
 

--- a/scripts/process/clear-resume-marker.sh
+++ b/scripts/process/clear-resume-marker.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# clear-resume-marker.sh — Standalone wrapper for task_file_clear_resume_marker
+#
+# Usage: clear-resume-marker.sh <worktree>
+#
+# Removes the "## Resume Reason: ..." section from .cekernel-task.md in
+# the given worktree. This prevents stale resume markers from causing
+# incorrect behavior when a Worker is re-spawned after a previous resume cycle.
+#
+# LLM agents running in zsh can call this standalone command without
+# sourcing bash-specific scripts directly (avoids zsh "bad substitution"
+# errors from bash-specific syntax).
+#
+# Example:
+#   clear-resume-marker.sh "$PWD"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../shared/task-file.sh"
+
+WORKTREE="${1:?Usage: clear-resume-marker.sh <worktree>}"
+
+task_file_clear_resume_marker "$WORKTREE"

--- a/scripts/process/create-checkpoint.sh
+++ b/scripts/process/create-checkpoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# create-checkpoint.sh — Standalone wrapper for create_checkpoint_file
+#
+# Usage: create-checkpoint.sh <worktree> <phase> <completed> <next> <decisions>
+#
+# LLM agents running in zsh can call this standalone command without
+# sourcing bash-specific scripts directly (avoids zsh "bad substitution"
+# errors from bash-specific syntax).
+#
+# Example:
+#   create-checkpoint.sh "$PWD" "Phase 1 (Implementation)" \
+#     "tests written, 2/5 files implemented" \
+#     "implement remaining 3 files" \
+#     "chose approach X because Y"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../shared/checkpoint-file.sh"
+
+WORKTREE="${1:?Usage: create-checkpoint.sh <worktree> <phase> <completed> <next> <decisions>}"
+PHASE="${2:?Phase required}"
+COMPLETED="${3:-}"
+NEXT="${4:-}"
+DECISIONS="${5:-}"
+
+create_checkpoint_file "$WORKTREE" "$PHASE" "$COMPLETED" "$NEXT" "$DECISIONS"

--- a/scripts/process/worker-state-write.sh
+++ b/scripts/process/worker-state-write.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# worker-state-write.sh — Standalone wrapper for worker_state_write
+#
+# Usage: worker-state-write.sh <issue-number> <state> [detail]
+#   state: NEW | READY | RUNNING | WAITING | SUSPENDED | TERMINATED
+#
+# LLM agents running in zsh can call this standalone command without
+# sourcing bash-specific scripts directly (avoids zsh "bad substitution"
+# errors from bash-specific syntax).
+#
+# Example:
+#   worker-state-write.sh 42 RUNNING "phase1:implement"
+#   worker-state-write.sh 42 WAITING "phase3:ci-waiting"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../shared/session-id.sh"
+source "${SCRIPT_DIR}/../shared/worker-state.sh"
+
+ISSUE_NUMBER="${1:?Usage: worker-state-write.sh <issue-number> <state> [detail]}"
+STATE="${2:?State required: NEW|READY|RUNNING|WAITING|SUSPENDED|TERMINATED}"
+DETAIL="${3:-}"
+
+worker_state_write "$ISSUE_NUMBER" "$STATE" "$DETAIL"

--- a/tests/process/test-standalone-commands.sh
+++ b/tests/process/test-standalone-commands.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# test-standalone-commands.sh — Tests for standalone process commands
+#   worker-state-write.sh, create-checkpoint.sh, clear-resume-marker.sh
+#
+# These scripts are thin wrappers around shared library functions,
+# allowing LLM agents (running in zsh) to call them without sourcing
+# bash-specific scripts directly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "test: standalone-commands"
+
+# Test session
+export CEKERNEL_SESSION_ID="test-standalone-00000001"
+source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+
+# ── Setup ──
+TMPDIR_TEST=$(mktemp -d)
+MOCK_WORKTREE="${TMPDIR_TEST}/worktree"
+mkdir -p "$MOCK_WORKTREE"
+
+rm -rf "$CEKERNEL_IPC_DIR"
+mkdir -p "$CEKERNEL_IPC_DIR"
+
+cleanup() {
+  rm -rf "$CEKERNEL_IPC_DIR" "$TMPDIR_TEST" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+WORKER_STATE_WRITE="${CEKERNEL_DIR}/scripts/process/worker-state-write.sh"
+CREATE_CHECKPOINT="${CEKERNEL_DIR}/scripts/process/create-checkpoint.sh"
+CLEAR_RESUME_MARKER="${CEKERNEL_DIR}/scripts/process/clear-resume-marker.sh"
+
+# ── worker-state-write.sh ──
+
+# Test 1: worker-state-write.sh creates state file
+bash "$WORKER_STATE_WRITE" 50 RUNNING "phase1:implement"
+assert_file_exists "worker-state-write creates state file" "${CEKERNEL_IPC_DIR}/worker-50.state"
+
+# Test 2: State file contains correct state
+CONTENT=$(cat "${CEKERNEL_IPC_DIR}/worker-50.state")
+assert_match "State file starts with RUNNING" '^RUNNING:' "$CONTENT"
+
+# Test 3: State file contains detail
+assert_match "State file contains detail" "phase1:implement" "$CONTENT"
+
+# Test 4: worker-state-write.sh accepts all valid states
+for STATE in NEW READY RUNNING WAITING SUSPENDED TERMINATED; do
+  EXIT_CODE=0
+  bash "$WORKER_STATE_WRITE" 51 "$STATE" 2>/dev/null || EXIT_CODE=$?
+  assert_eq "worker-state-write accepts $STATE" "0" "$EXIT_CODE"
+done
+
+# Test 5: worker-state-write.sh rejects invalid state
+EXIT_CODE=0
+bash "$WORKER_STATE_WRITE" 50 INVALID 2>/dev/null || EXIT_CODE=$?
+assert_eq "worker-state-write rejects INVALID state" "1" "$EXIT_CODE"
+
+# Test 6: worker-state-write.sh missing issue number exits non-zero
+EXIT_CODE=0
+bash "$WORKER_STATE_WRITE" 2>/dev/null || EXIT_CODE=$?
+assert_eq "worker-state-write missing issue number exits non-zero" "1" "$EXIT_CODE"
+
+# Test 7: worker-state-write.sh missing state exits non-zero
+EXIT_CODE=0
+bash "$WORKER_STATE_WRITE" 50 2>/dev/null || EXIT_CODE=$?
+assert_eq "worker-state-write missing state exits non-zero" "1" "$EXIT_CODE"
+
+# ── create-checkpoint.sh ──
+
+# Test 8: create-checkpoint.sh creates checkpoint file
+bash "$CREATE_CHECKPOINT" "$MOCK_WORKTREE" "Phase 1 (Implementation)" "tests written" "implement files" "chose approach X"
+assert_file_exists "create-checkpoint creates checkpoint file" "${MOCK_WORKTREE}/.cekernel-checkpoint.md"
+
+# Test 9: Checkpoint file contains phase
+CP_CONTENT=$(cat "${MOCK_WORKTREE}/.cekernel-checkpoint.md")
+assert_match "Checkpoint file contains phase" "Phase 1" "$CP_CONTENT"
+
+# Test 10: Checkpoint file contains completed
+assert_match "Checkpoint file contains completed" "tests written" "$CP_CONTENT"
+
+# Test 11: Checkpoint file contains next steps
+assert_match "Checkpoint file contains next" "implement files" "$CP_CONTENT"
+
+# Test 12: Checkpoint file contains decisions
+assert_match "Checkpoint file contains decisions" "chose approach X" "$CP_CONTENT"
+
+# Test 13: Checkpoint file has markdown header
+assert_match "Checkpoint file has # Checkpoint header" "^# Checkpoint" "$CP_CONTENT"
+
+# Test 14: create-checkpoint.sh missing worktree exits non-zero
+EXIT_CODE=0
+bash "$CREATE_CHECKPOINT" 2>/dev/null || EXIT_CODE=$?
+assert_eq "create-checkpoint missing args exits non-zero" "1" "$EXIT_CODE"
+
+# ── clear-resume-marker.sh ──
+
+# Test 15: clear-resume-marker.sh removes ## Resume Reason section
+MARKER_WORKTREE="${TMPDIR_TEST}/marker-worktree"
+mkdir -p "$MARKER_WORKTREE"
+cat > "${MARKER_WORKTREE}/.cekernel-task.md" <<'TASK_WITH_MARKER'
+---
+issue: 100
+title: "test issue"
+labels: [enhancement]
+---
+
+Issue body content here.
+
+## Resume Reason: changes-requested
+
+Review comments are on PR #50.
+TASK_WITH_MARKER
+
+bash "$CLEAR_RESUME_MARKER" "$MARKER_WORKTREE"
+MARKER_CONTENT=$(cat "${MARKER_WORKTREE}/.cekernel-task.md")
+
+if echo "$MARKER_CONTENT" | grep -q "## Resume Reason"; then
+  echo "  FAIL: clear-resume-marker should remove ## Resume Reason section"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+else
+  echo "  PASS: clear-resume-marker removes ## Resume Reason section"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+fi
+
+# Test 16: Original content is preserved
+assert_match "clear-resume-marker preserves original content" "Issue body content here" "$MARKER_CONTENT"
+
+# Test 17: clear-resume-marker.sh is no-op when no marker
+NOMARKER_WORKTREE="${TMPDIR_TEST}/nomarker-worktree"
+mkdir -p "$NOMARKER_WORKTREE"
+cat > "${NOMARKER_WORKTREE}/.cekernel-task.md" <<'TASK_NO_MARKER'
+---
+issue: 101
+title: "test issue"
+labels: []
+---
+
+Just a normal task file.
+TASK_NO_MARKER
+
+BEFORE=$(cat "${NOMARKER_WORKTREE}/.cekernel-task.md")
+bash "$CLEAR_RESUME_MARKER" "$NOMARKER_WORKTREE"
+AFTER=$(cat "${NOMARKER_WORKTREE}/.cekernel-task.md")
+assert_eq "clear-resume-marker is no-op when no marker" "$BEFORE" "$AFTER"
+
+# Test 18: clear-resume-marker.sh exits cleanly when task file does not exist
+MISSING_WORKTREE="${TMPDIR_TEST}/missing-worktree"
+mkdir -p "$MISSING_WORKTREE"
+EXIT_CODE=0
+bash "$CLEAR_RESUME_MARKER" "$MISSING_WORKTREE" 2>/dev/null || EXIT_CODE=$?
+assert_eq "clear-resume-marker exits cleanly when no task file" "0" "$EXIT_CODE"
+
+# Test 19: clear-resume-marker.sh missing worktree arg exits non-zero
+EXIT_CODE=0
+bash "$CLEAR_RESUME_MARKER" 2>/dev/null || EXIT_CODE=$?
+assert_eq "clear-resume-marker missing worktree arg exits non-zero" "1" "$EXIT_CODE"
+
+report_results


### PR DESCRIPTION
closes #388

## Summary
- `scripts/process/worker-state-write.sh` を追加（`worker_state_write` のラッパー）
- `scripts/process/create-checkpoint.sh` を追加（`create_checkpoint_file` のラッパー）
- `scripts/process/clear-resume-marker.sh` を追加（`task_file_clear_resume_marker` のラッパー）
- `agents/worker.md` と `agents/reviewer.md` の呼び出し例を新コマンドに更新

## 背景

Claude Code の Bash tool は zsh で動作するため、bash 固有構文（`${!key:-}` 等）を含む共有スクリプトを `source` すると `bad substitution` エラーが発生する（#378）。

standalone コマンドとして shebang 経由で bash を起動することで、zsh 問題を回避する。

## 設計

- 既存の `shared/*.sh` ライブラリは変更しない（orchestrator/test が引き続き使用）
- standalone スクリプトは内部でライブラリを source し、引数を関数に渡すだけの薄いラッパー
- `scripts/process/` に配置（Worker/Reviewer 側のコマンドなので）

## Test Plan
- [ ] `tests/process/test-standalone-commands.sh` — 24 テスト全通過を確認
- [ ] `bash tests/run-tests.sh` — 全テストスイート通過を確認