### PR TITLE
Worker agent 定義に TDD コミットルールを直接記載する

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -161,7 +161,11 @@ Implement **following the target repository's rules**.
 
 #### Development Method: TDD (Red-Green-Refactor)
 
-For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first development.
+For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first development. Commit at each step:
+
+1. **RED**: Write a failing test, verify it fails, commit with `(RED)` suffix
+2. **GREEN**: Write minimum code to pass, verify it passes, commit with `(GREEN)` suffix
+3. **REFACTOR**: Improve design with tests passing, commit with `(REFACTOR)` suffix
 
 ### Phase 2: Create PR
 


### PR DESCRIPTION
closes #394

## Summary
- `agents/worker.md` Phase 1 セクションに TDD コミットルール（`(RED)`, `(GREEN)`, `(REFACTOR)` サフィックス）を直接記載
- `docs/tdd.md` へのリンクは残しつつ、Worker がリンク先を読まなくても要点が伝わるように inline 化

## Test Plan
- [ ] ドキュメントのみの変更のため、CI（run-tests.sh）がパスすることを確認