### PR TITLE
feat: add phase-transition.sh to combine signal check and state write

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -54,7 +54,7 @@ cekernel defines only the lifecycle skeleton for Workers:
 4. Read issue content from `.cekernel-task.md` in the worktree (pre-extracted at spawn time)
    - If `.cekernel-task.md` does not exist, fall back to `gh issue view`
 5. Understand the issue requirements
-6. Write state: `worker-state-write.sh <issue-number> RUNNING "phase0:plan"`
+6. Transition to Phase 0: `phase-transition.sh <issue-number> RUNNING "phase0:plan"`
 7. Post Execution Plan as a comment on the issue (or a Resume Plan if resuming)
 
 ```bash
@@ -73,18 +73,23 @@ EOF
 
 The Plan must be posted before starting implementation, so the Orchestrator or humans can review the approach in advance.
 
-## Signal Handling
+## Phase Transition
 
-Workers check for signals at **phase boundaries** — between each lifecycle phase. This enables cooperative cancellation by the Orchestrator or user.
+Workers use `phase-transition.sh` at **phase boundaries** to atomically check for signals and write state. This ensures signal checks are never forgotten, since the script combines both operations into a single call.
 
-### How to check
+### How to use
 
 ```bash
-SIGNAL=$(check-signal.sh <issue-number>) || true
-if [[ -n "$SIGNAL" ]]; then
-  # Handle signal
+SIGNAL=$(phase-transition.sh <issue-number> <state> <detail>) || EXIT=$?
+if [[ "${EXIT:-0}" -eq 3 ]]; then
+  # Handle signal (TERM or SUSPEND)
 fi
 ```
+
+`phase-transition.sh` performs:
+1. `check-signal.sh` — check for pending signal
+2. If signal found → output signal name to stdout, **exit 3**
+3. If no signal → `worker-state-write.sh` to write state, **exit 0**
 
 ### On receiving `TERM`
 
@@ -113,29 +118,19 @@ create-checkpoint.sh "$WORKTREE" \
 
 ### When to check
 
-Check for signals at the boundary **before** each phase:
+Call `phase-transition.sh` at the **start** of each phase:
 
 ```
-Phase 0 (Plan)
-  ← CHECK SIGNAL
-Phase 1 (Implement)
-  ← CHECK SIGNAL
-Phase 2 (Create PR)
-  ← CHECK SIGNAL
-Phase 3 (CI verify)
-  ← CHECK SIGNAL
-Phase 4 (Notify)
+phase-transition.sh <issue> RUNNING "phase0:plan"
+  Phase 0 (Plan)
+phase-transition.sh <issue> RUNNING "phase1:implement"
+  Phase 1 (Implement)
+phase-transition.sh <issue> RUNNING "phase2:create-pr"
+  Phase 2 (Create PR)
+phase-transition.sh <issue> WAITING "phase3:ci-waiting"
+  Phase 3 (CI verify)
+  Phase 4 (Notify)
 ```
-
-## State Reporting
-
-Workers report their state at each phase boundary using `worker_state_write`. This makes Worker activity visible to `process-status.sh`, `health-check.sh`, and the Orchestrator.
-
-```bash
-worker-state-write.sh <issue-number> RUNNING "phase1:implement"
-```
-
-Write state at the **start** of each phase:
 
 | Phase | State | Detail | When |
 |---|---|---|---|
@@ -150,7 +145,7 @@ Write state at the **start** of each phase:
 
 ### Phase 1: Implementation
 
-> State: `worker-state-write.sh <issue> RUNNING "phase1:implement"`
+> Transition: `phase-transition.sh <issue> RUNNING "phase1:implement"`
 
 Implement **following the target repository's rules**.
 
@@ -165,7 +160,7 @@ For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first 
 
 ### Phase 2: Create PR
 
-> State: `worker-state-write.sh <issue> RUNNING "phase2:create-pr"`
+> Transition: `phase-transition.sh <issue> RUNNING "phase2:create-pr"`
 
 ```bash
 git push -u origin HEAD
@@ -192,8 +187,8 @@ EOF
 
 ### Phase 3: CI Verification
 
-> State: `worker-state-write.sh <issue> WAITING "phase3:ci-waiting"` (before CI wait)
-> On CI fix: `worker-state-write.sh <issue> RUNNING "phase3:ci-fixing"`
+> Transition: `phase-transition.sh <issue> WAITING "phase3:ci-waiting"` (before CI wait)
+> On CI fix: `phase-transition.sh <issue> RUNNING "phase3:ci-fixing"`
 
 #### Load environment profile
 

--- a/scripts/process/phase-transition.sh
+++ b/scripts/process/phase-transition.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# phase-transition.sh — Atomic phase boundary: signal check + state write
+#
+# Usage: phase-transition.sh <issue-number> <state> [detail]
+#
+# Combines check-signal.sh and worker-state-write.sh into a single call
+# for use at phase boundaries. This ensures signal checks are never
+# forgotten, since Workers reliably call state-write at each boundary.
+#
+# Flow:
+#   1. Check for pending signal (check-signal.sh)
+#   2. If signal found → output signal name to stdout, exit 3
+#   3. If no signal   → write state (worker-state-write.sh), exit 0
+#
+# Exit codes:
+#   0 — No signal; state written successfully
+#   1 — Usage error (missing arguments, invalid state)
+#   3 — Signal received (signal name on stdout)
+#
+# Example:
+#   phase-transition.sh 42 RUNNING "phase1:implement"
+#   # → checks signal, then writes RUNNING state
+#
+#   SIGNAL=$(phase-transition.sh 42 RUNNING "phase1:implement") || EXIT=$?
+#   if [[ "${EXIT:-0}" -eq 3 ]]; then
+#     echo "Signal received: $SIGNAL"
+#   fi
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ISSUE_NUMBER="${1:?Usage: phase-transition.sh <issue-number> <state> [detail]}"
+STATE="${2:?State required: NEW|READY|RUNNING|WAITING|SUSPENDED|TERMINATED}"
+DETAIL="${3:-}"
+
+# ── Step 1: Check for pending signal ──
+SIGNAL=$("${SCRIPT_DIR}/check-signal.sh" "$ISSUE_NUMBER") || true
+
+if [[ -n "$SIGNAL" ]]; then
+  echo "$SIGNAL"
+  exit 3
+fi
+
+# ── Step 2: Write state ──
+"${SCRIPT_DIR}/worker-state-write.sh" "$ISSUE_NUMBER" "$STATE" "$DETAIL"

--- a/tests/process/test-phase-transition.sh
+++ b/tests/process/test-phase-transition.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# test-phase-transition.sh — Tests for phase-transition.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "test: phase-transition"
+
+# Test session
+export CEKERNEL_SESSION_ID="test-phase-transition-00000001"
+source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+
+# ── Setup: Ensure clean state ──
+rm -rf "$CEKERNEL_IPC_DIR"
+mkdir -p "$CEKERNEL_IPC_DIR"
+
+PHASE_TRANSITION="${CEKERNEL_DIR}/scripts/process/phase-transition.sh"
+
+# ── Test 1: No signal → writes state and exits 0 ──
+EXIT_CODE=0
+bash "$PHASE_TRANSITION" 100 RUNNING "phase1:implement" || EXIT_CODE=$?
+assert_eq "No signal exits 0" "0" "$EXIT_CODE"
+
+# Verify state was written
+STATE_FILE="${CEKERNEL_IPC_DIR}/worker-100.state"
+assert_file_exists "State file created" "$STATE_FILE"
+STATE_CONTENT=$(cat "$STATE_FILE")
+assert_match "State contains RUNNING" "^RUNNING:" "$STATE_CONTENT"
+assert_match "State contains detail" "phase1:implement" "$STATE_CONTENT"
+
+# ── Test 2: TERM signal → outputs signal and exits 3 ──
+echo "TERM" > "${CEKERNEL_IPC_DIR}/worker-101.signal"
+EXIT_CODE=0
+OUTPUT=$(bash "$PHASE_TRANSITION" 101 RUNNING "phase1:implement" 2>/dev/null) || EXIT_CODE=$?
+assert_eq "TERM signal exits 3" "3" "$EXIT_CODE"
+assert_eq "Output is TERM" "TERM" "$OUTPUT"
+assert_not_exists "Signal file consumed" "${CEKERNEL_IPC_DIR}/worker-101.signal"
+
+# Verify state was NOT written (signal takes precedence)
+STATE_FILE_101="${CEKERNEL_IPC_DIR}/worker-101.state"
+assert_not_exists "State file not created when signal found" "$STATE_FILE_101"
+
+# ── Test 3: SUSPEND signal → outputs signal and exits 3 ──
+echo "SUSPEND" > "${CEKERNEL_IPC_DIR}/worker-102.signal"
+EXIT_CODE=0
+OUTPUT=$(bash "$PHASE_TRANSITION" 102 WAITING "phase3:ci-waiting" 2>/dev/null) || EXIT_CODE=$?
+assert_eq "SUSPEND signal exits 3" "3" "$EXIT_CODE"
+assert_eq "Output is SUSPEND" "SUSPEND" "$OUTPUT"
+assert_not_exists "SUSPEND signal file consumed" "${CEKERNEL_IPC_DIR}/worker-102.signal"
+
+# ── Test 4: Missing issue number exits with error ──
+EXIT_CODE=0
+bash "$PHASE_TRANSITION" 2>/dev/null || EXIT_CODE=$?
+assert_eq "Missing issue number exits non-zero" "1" "$EXIT_CODE"
+
+# ── Test 5: Missing state exits with error ──
+EXIT_CODE=0
+bash "$PHASE_TRANSITION" 200 2>/dev/null || EXIT_CODE=$?
+assert_eq "Missing state exits non-zero" "1" "$EXIT_CODE"
+
+# ── Test 6: Detail is optional ──
+EXIT_CODE=0
+bash "$PHASE_TRANSITION" 103 RUNNING || EXIT_CODE=$?
+assert_eq "No detail exits 0" "0" "$EXIT_CODE"
+STATE_FILE_103="${CEKERNEL_IPC_DIR}/worker-103.state"
+assert_file_exists "State file created without detail" "$STATE_FILE_103"
+
+# ── Test 7: WAITING state works ──
+EXIT_CODE=0
+bash "$PHASE_TRANSITION" 104 WAITING "phase3:ci-waiting" || EXIT_CODE=$?
+assert_eq "WAITING state exits 0" "0" "$EXIT_CODE"
+STATE_FILE_104="${CEKERNEL_IPC_DIR}/worker-104.state"
+STATE_CONTENT_104=$(cat "$STATE_FILE_104")
+assert_match "State contains WAITING" "^WAITING:" "$STATE_CONTENT_104"
+
+# ── Cleanup ──
+rm -rf "$CEKERNEL_IPC_DIR"
+
+report_results


### PR DESCRIPTION
closes #393

## Summary
- `scripts/process/phase-transition.sh` を新規作成: `check-signal.sh` + `worker-state-write.sh` を1つの呼び出しにまとめる薄いラッパー
- シグナルがあれば stdout に出力して exit 3、なければ state write して exit 0
- `agents/worker.md` のフェーズ境界呼び出しを `phase-transition.sh` に統一
- テスト 17 件追加（`tests/process/test-phase-transition.sh`）

## Background
Worker が `check-signal.sh` を呼び忘れる問題（#387, #388 の postmortem で確認）を仕組みで解決。Worker が確実に呼ぶ `worker-state-write.sh` に signal check を相乗りさせることで、シグナルチェックを構造的に保証する。

## Test Plan
- [x] `test-phase-transition.sh`: シグナルなし → state 書き込み (exit 0)
- [x] `test-phase-transition.sh`: TERM シグナル → 出力して exit 3、state 未書き込み
- [x] `test-phase-transition.sh`: SUSPEND シグナル → 出力して exit 3
- [x] `test-phase-transition.sh`: 引数不足 → exit 1
- [x] `test-phase-transition.sh`: detail 省略可
- [x] `test-phase-transition.sh`: WAITING state 対応
- [x] 全テストスイート通過