### PR TITLE
fix: desktop-notify.sh テスト中に実通知が飛ぶ問題を修正

### DIFF
--- a/tests/shared/test-desktop-notify.sh
+++ b/tests/shared/test-desktop-notify.sh
@@ -181,7 +181,7 @@ chmod +x "${MOCK_BIN_EMPTY}/uname"
 unset -f desktop_notify 2>/dev/null || true
 unset _DESKTOP_NOTIFY_PLATFORM 2>/dev/null || true
 PATH="${MOCK_BIN_EMPTY}:${ORIG_PATH}" source "${CEKERNEL_DIR}/scripts/shared/desktop-notify.sh"
-PATH="${MOCK_BIN_EMPTY}:${ORIG_PATH}"
+PATH="${MOCK_BIN_EMPTY}"
 
 if desktop_notify "Title" "Message"; then
   echo "  PASS: desktop_notify does not fail when notification tool is missing"
@@ -190,6 +190,7 @@ else
   echo "  FAIL: desktop_notify should not fail when notification tool is missing"
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
+PATH="$ORIG_PATH"
 rm -rf "$MOCK_BIN_EMPTY"
 
 # ── Test 12: URL is optional — no error when omitted ──


### PR DESCRIPTION
closes #399

## Summary
- Test 11（通知ツール欠損時のbest-effort動作テスト）で `PATH` に `ORIG_PATH` を含めていたため、本物の `osascript` が呼ばれ実際の macOS デスクトップ通知が飛んでいた
- `desktop_notify` 呼び出し時の PATH を `MOCK_BIN_EMPTY` のみに制限し、`osascript` を本当に不在にすることで修正
- テスト後に `PATH="$ORIG_PATH"` で復元し、後続の `rm` やクリーンアップが正常に動作するようにした

## Test Plan
- [x] `test-desktop-notify.sh` — 24 tests passed, 0 failed
- [x] `run-tests.sh` — All tests passed