### PR TITLE
fix: use cd -P for CEKERNEL_SCRIPTS resolution via symlinks

### DIFF
--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -51,7 +51,7 @@ Store these values for use in subsequent steps.
 Also resolve the cekernel scripts path for lock checking and Orchestrator propagation:
 
 ```bash
-CEKERNEL_SCRIPTS="$(cd "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
+CEKERNEL_SCRIPTS="$(cd -P "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
 ```
 
 ### Step 1: Discover Issues

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -43,7 +43,7 @@ Store these values for use in subsequent steps.
 Also resolve the cekernel scripts path for lock checking and Orchestrator propagation:
 
 ```bash
-CEKERNEL_SCRIPTS="$(cd "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
+CEKERNEL_SCRIPTS="$(cd -P "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
 ```
 
 ### Step 1: Lock Filter and Triage

--- a/skills/references/namespace-detection.md
+++ b/skills/references/namespace-detection.md
@@ -33,7 +33,7 @@ Based on the detection result, set agent names:
 Skills resolve the cekernel scripts absolute path using `${CLAUDE_SKILL_DIR}`:
 
 ```bash
-CEKERNEL_SCRIPTS="$(cd "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
+CEKERNEL_SCRIPTS="$(cd -P "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
 ```
 
 - local: `.claude/skills/<skill>/../../scripts` → `<repo>/scripts`


### PR DESCRIPTION
closes #397

## Summary
- `cd` → `cd -P` に変更し、`.claude/skills/` のシンボリックリンク経由で `CEKERNEL_SCRIPTS` を解決する際に物理パスを使用するように修正
- canonical source の `namespace-detection.md` に加え、インラインコピーを持つ `orchestrate/SKILL.md` と `dispatch/SKILL.md` にも同じ修正を適用

## Test Plan
- [x] 既存テスト全パス (`run-tests.sh`)
- [ ] CI green