### PR TITLE
docs: add Script Invocation section to worker and reviewer agents

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -16,6 +16,23 @@ Evaluates PRs created by Workers in a separate process, providing an independent
 - Uses the operator's `gh` authentication (cekernel owns no identity)
 - Communicates result to Orchestrator via `notify-complete.sh` (FIFO)
 
+## Script Invocation
+
+`.cekernel-env` adds `scripts/process/` and `scripts/shared/` to PATH. The following commands are available directly — **do not use full paths**:
+
+| Command | Description |
+|---------|-------------|
+| `worker-state-write.sh` | State write only |
+| `notify-complete.sh` | Completion notification to Orchestrator |
+
+```bash
+# Good — use bare command name
+worker-state-write.sh 123 RUNNING "phase1:reading-conventions"
+
+# Bad — do not search for full paths
+scripts/process/worker-state-write.sh 123 RUNNING "phase1:reading-conventions"
+```
+
 ## Input
 
 The Orchestrator spawns the Reviewer with the following context (via spawn prompt):

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -38,6 +38,29 @@ cekernel defines only the lifecycle skeleton for Workers:
 
 **It does not concern itself with implementation details, format, or conventions.**
 
+## Script Invocation
+
+`.cekernel-env` adds `scripts/process/` and `scripts/shared/` to PATH. The following commands are available directly — **do not use full paths**:
+
+| Command | Description |
+|---------|-------------|
+| `phase-transition.sh` | Signal check + state write (atomic) |
+| `worker-state-write.sh` | State write only |
+| `notify-complete.sh` | Completion notification to Orchestrator |
+| `check-signal.sh` | Signal check only |
+| `create-checkpoint.sh` | Write checkpoint file for SUSPEND resume |
+| `clear-resume-marker.sh` | Clear resume marker from task file |
+| `load-env.sh` | Load environment profile (sourced, not executed) |
+
+```bash
+# Good — use bare command name
+phase-transition.sh 123 RUNNING "phase0:plan"
+
+# Bad — do not search for full paths
+scripts/process/phase-transition.sh 123 RUNNING "phase0:plan"
+scripts/shared/phase-transition.sh 123 RUNNING "phase0:plan"  # wrong dir anyway
+```
+
 ## On Startup
 
 1. Confirm the current directory is within the worktree


### PR DESCRIPTION
closes #409

## Summary
- `agents/worker.md` に Script Invocation セクションを追加。PATH 経由で呼べる 7 コマンド（`phase-transition.sh`, `worker-state-write.sh`, `notify-complete.sh`, `check-signal.sh`, `create-checkpoint.sh`, `clear-resume-marker.sh`, `load-env.sh`）を一覧化し、Good/Bad の使用例を記載
- `agents/reviewer.md` に同セクションを追加。Reviewer が使う 2 コマンド（`worker-state-write.sh`, `notify-complete.sh`）を一覧化

## Background
#407 postmortem で Worker が `scripts/shared/phase-transition.sh` → `scripts/worker/phase-transition.sh` と間違ったフルパスを試行し、2 tool calls を浪費した問題への対策。`.cekernel-env` が `scripts/process/` と `scripts/shared/` を PATH に追加しているため、bare name で呼べることを明記した。

## Test Plan
- [ ] ドキュメント変更のみ。CI（run-tests.sh）がパスすること