### PR TITLE
fix: cleanup-worktree.sh の .backend/.priority 削除漏れを修正

### DIFF
--- a/scripts/orchestrator/cleanup-worktree.sh
+++ b/scripts/orchestrator/cleanup-worktree.sh
@@ -70,6 +70,10 @@ rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.type"
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.signal"
 # Handle file cleanup (in case not already removed)
 rm -f "${CEKERNEL_IPC_DIR}"/handle-"${ISSUE_NUMBER}".*
+# Backend file cleanup
+rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.backend"
+# Priority file cleanup
+rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.priority"
 # Payload file cleanup (wezterm backend: avoids send-text 1024-byte limit)
 rm -f "${CEKERNEL_IPC_DIR}/payload-${ISSUE_NUMBER}.b64"
 

--- a/tests/orchestrator/test-cleanup-session.sh
+++ b/tests/orchestrator/test-cleanup-session.sh
@@ -54,12 +54,14 @@ echo '{"state":"RUNNING"}' > "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.state"
 echo "wezterm" > "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.backend"
 echo '{"priority":50}' > "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.priority"
 
-# Simulate the IPC cleanup portion of cleanup-worktree.sh (lines 64-79)
+# Simulate the IPC cleanup portion of cleanup-worktree.sh (lines 64-81)
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE}"
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.state"
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.type"
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.signal"
 rm -f "${CEKERNEL_IPC_DIR}"/handle-"${ISSUE}".*
+rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.backend"
+rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.priority"
 rm -f "${CEKERNEL_IPC_DIR}/payload-${ISSUE}.b64"
 
 assert_not_exists ".backend file removed" "${CEKERNEL_IPC_DIR}/worker-${ISSUE}.backend"


### PR DESCRIPTION
closes #415

## Summary
- `cleanup-worktree.sh` が `worker-{N}.backend` と `worker-{N}.priority` を削除していなかった問題を修正
- `spawn.sh` の `rollback()` では削除していたが、正常系の cleanup パスでは漏れていた
- `test-cleanup-session.sh` に `.backend` / `.priority` の削除検証テストを追加

## Test Plan
- [x] RED: テスト追加 → `.backend` / `.priority` が残存し FAIL を確認
- [x] GREEN: `cleanup-worktree.sh` に `rm -f` 2行追加 → 全テスト PASS
- [x] `run-tests.sh` 全テスト PASS 確認