### PR TITLE
postmortem SKILL.md / CLAUDE.md の細かな修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ Claude Code stores per-project data under `~/.claude/projects/`, using the workt
 
 ```
 Worktree:  /Users/alice/git/repo/.worktrees/issue/42-add-widget-support/
-Project:   ~/.claude/projects/-Users-alice-git-repo-.worktrees-issue-42-add-widget-support/
+Project:   ~/.claude/projects/-Users-alice-git-repo--worktrees-issue-42-add-widget-support/
 ```
 
 `transcript-locator.sh` uses this mapping to discover transcripts. The glob pattern `*-issue-{N}-*` matches project directories for a given issue number, regardless of host path or slug content.

--- a/scripts/shared/transcript-locator.sh
+++ b/scripts/shared/transcript-locator.sh
@@ -54,7 +54,7 @@ transcript_locate_worker() {
   local found=0
 
   # Glob: *-issue-{number}-* matches worktree project directories
-  # e.g., -Users-alice-git-repo-.worktrees-issue-42-feat-add-widget
+  # e.g., -Users-alice-git-repo--worktrees-issue-42-feat-add-widget
   local pattern="${projects_dir}/*-issue-${issue_number}-*/*.jsonl"
 
   # Use nullglob behavior via find to avoid literal glob in output

--- a/skills/postmortem/SKILL.md
+++ b/skills/postmortem/SKILL.md
@@ -37,15 +37,28 @@ Use `transcript-locator.sh` to find all transcripts associated with the issues. 
 ```bash
 source "${CEKERNEL_SCRIPTS}/shared/transcript-locator.sh"
 
-# For each issue number:
+ALL_TRANSCRIPTS=""
 for ISSUE in <issue-numbers...>; do
-  # Discover Worker/Reviewer transcripts (always available by issue number)
-  WORKER_TRANSCRIPTS=$(transcript_locate_worker "$ISSUE" 2>/dev/null) || true
+  FOUND=$(transcript_locate_worker "$ISSUE" 2>/dev/null) || true
+  ALL_TRANSCRIPTS="${ALL_TRANSCRIPTS:+${ALL_TRANSCRIPTS}$'\n'}${FOUND}"
 
-  # Discover Orchestrator transcripts (via .spawned file session reverse lookup)
-  ORCH_TRANSCRIPTS=$(transcript_locate_orchestrator_by_issue "$ISSUE" 2>/dev/null) || true
+  FOUND=$(transcript_locate_orchestrator_by_issue "$ISSUE" 2>/dev/null) || true
+  ALL_TRANSCRIPTS="${ALL_TRANSCRIPTS:+${ALL_TRANSCRIPTS}$'\n'}${FOUND}"
 done
 ```
+
+#### Worker/Reviewer Identification
+
+`transcript_locate_worker` returns both Worker and Reviewer transcripts (they share the same worktree). File names alone cannot distinguish them. Use the first line's `agentSetting` field in the JSONL to identify the type:
+
+```json
+{"type":"agent-setting","agentSetting":"reviewer","sessionId":"6fe286bd-..."}
+{"type":"agent-setting","agentSetting":"worker","sessionId":"82bbd747-..."}
+```
+
+- `agentSetting` contains `worker` → Worker (matches both `worker` and `cekernel:worker`)
+- `agentSetting` contains `reviewer` → Reviewer (matches both `reviewer` and `cekernel:reviewer`)
+- `agentSetting` line missing or no match → Other (still analyze; pass as "unknown type transcript" to subagent)
 
 Report what was found:
 
@@ -68,7 +81,7 @@ If no transcripts are found at all, report the failure to the user and stop.
 Read the detection patterns checklist:
 
 ```
-$(git rev-parse --show-toplevel)/skills/references/postmortem-patterns.md
+${CEKERNEL_SCRIPTS}/../skills/references/postmortem-patterns.md
 ```
 
 This file defines all detection categories, heuristics, and severities. The full content of this file will be included in each analysis subagent's prompt.


### PR DESCRIPTION
closes #422

## Summary
- CLAUDE.md: Worktree Naming の Claude Code プロジェクトディレクトリ例を修正（`-.worktrees` → `--worktrees`）
- `transcript-locator.sh`: L57 コメントの同様のパス例を修正
- `skills/postmortem/SKILL.md` Step 1: for ループ内の変数上書きを蓄積形に修正
- `skills/postmortem/SKILL.md` Step 1: Worker/Reviewer 区別ルール（`agentSetting` フィールド）を追記
- `skills/postmortem/SKILL.md` Step 2: reference パスを `git rev-parse` から `CEKERNEL_SCRIPTS` ベースに修正（plugin mode 対応）

## Test Plan
- [ ] ドキュメント・コメントのみの変更のため、CI テストの通過を確認