### PR TITLE
docs: reviewer.md に self-review 時の --comment フォールバック手順を追加

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -135,25 +135,30 @@ The review body must clearly describe what needs to be fixed so that the Worker 
 
 #### Self-Review Fallback
 
-GitHub does not allow approving or requesting changes on your own PR (`"Can not approve your own pull request"`). When this error occurs, fall back to `--comment` to preserve the review body:
+GitHub does not allow approving or requesting changes on your own PR (HTTP 422: `"Can not approve your own pull request"`). Use `gh api` (not `gh pr review`) to avoid duplicate postings — `gh pr review --approve` posts the body as COMMENTED even on failure, while `gh api` with event=APPROVE returns 422 without posting anything.
 
 ```bash
-# 1. First attempt --approve (or --request-changes)
-if ! gh pr review <pr-number> --approve --body "..."; then
-  # 2. On self-review error, fall back to --comment
-  gh pr review <pr-number> --comment --body "..."
+OWNER_REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+# 1. Attempt APPROVE via REST API (422 = nothing posted)
+if ! gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
+  -f event=APPROVE -f body="..." 2>/dev/null; then
+  # 2. Self-review error → COMMENT fallback (single posting)
+  gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
+    -f event=COMMENT -f body="..."
 fi
 
 # 3. notify-complete.sh uses the actual review verdict, not the GitHub submission method
-#    --comment fallback is a GitHub constraint; the review judgment itself is unchanged
 notify-complete.sh <issue-number> approved <pr-number>
 ```
 
-The same fallback applies for `--request-changes`:
+The same fallback applies for `REQUEST_CHANGES`:
 
 ```bash
-if ! gh pr review <pr-number> --request-changes --body "..."; then
-  gh pr review <pr-number> --comment --body "..."
+if ! gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
+  -f event=REQUEST_CHANGES -f body="..." 2>/dev/null; then
+  gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
+    -f event=COMMENT -f body="..."
 fi
 notify-complete.sh <issue-number> changes-requested <pr-number>
 ```

--- a/skills/references/postmortem-patterns.md
+++ b/skills/references/postmortem-patterns.md
@@ -55,9 +55,9 @@ Patterns are organized by category. Each has:
 - **Note**: This is an infrastructure constraint, not a bug. Track frequency but do not create issues unless the fallback also fails.
 
 ### Reviewer self-review fallback missing
-- **Detect**: `gh pr review --approve` or `gh pr review --request-changes` failing with self-review error, followed by `notify-complete.sh failed` without a `--comment` fallback attempt
+- **Detect**: `gh pr review --approve` or `gh pr review --request-changes` failing with self-review error, followed by `notify-complete.sh failed` without a `--comment` fallback attempt; OR duplicate COMMENTED reviews (same body posted twice within seconds) caused by `gh pr review` CLI posting body even on failure
 - **Severity**: warning
-- **Example**: #428 — Reviewer exited with `failed` without posting the review body to the PR; review content was lost and had to be manually salvaged from the transcript
+- **Example**: #428 — Reviewer exited with `failed` without posting the review body; #430 — `gh pr review --approve` posted body as COMMENTED on failure, then `--comment` fallback posted it again (duplicate). Fix: use `gh api` with `event=APPROVE` which returns 422 without posting on self-review error
 
 ### Agent definition mismatch
 - **Detect**: Reviewer transcript showing Worker-like behavior (implementation, commits), or Worker showing review-only behavior


### PR DESCRIPTION
closes #430

## Summary
- `agents/reviewer.md` の「5. Submit Review」に Self-Review Fallback セクションを追加
  - GitHub self-review 制約（`--approve`/`--request-changes` 不可）時に `--comment` にフォールバックする手順を明示
  - `notify-complete.sh` には実際のレビュー判断（approved/changes-requested）を渡すことを明記
- `skills/references/postmortem-patterns.md` に「Reviewer self-review fallback missing」パターンを追加
  - self-review エラー後に `--comment` フォールバックなしで `notify-complete.sh failed` が実行されるケースを検出

## Test Plan
- [ ] ドキュメントのみの変更のため、テストは不要
- [ ] `agents/reviewer.md` の Self-Review Fallback セクションが正確に記載されていることを確認
- [ ] `postmortem-patterns.md` の新パターンが既存フォーマットに沿っていることを確認