### PR TITLE
Conventions: skill reference ファイルの commit prefix を明確化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,9 @@ The skill analyzes git log and recommends a bump level. After confirmation:
   - `test:` Tests only
   - `refactor:` Refactoring
   - `release:` Version bump (CI auto-generated)
+- Skill reference files (`skills/references/*.md`) and skill definitions (`skills/*/SKILL.md`)
+  are executable instructions, not documentation. Use `feat:` / `fix:` accordingly.
+  `docs:` is reserved for purely informational files (README, architecture docs, ADRs).
 
 ### Worktree Naming
 


### PR DESCRIPTION
closes #454

## Summary
- CLAUDE.md の Conventions セクションに、skill reference / skill definition ファイルの commit prefix ルールを追記
- `skills/references/*.md` と `skills/*/SKILL.md` はエージェントの実行時動作を制御する実行可能な命令であり、ドキュメントではないため `feat:` / `fix:` を使用する
- `docs:` は純粋な情報提供ファイル（README、ADR 等）に限定する

## Test Plan
- [ ] CLAUDE.md の Conventions セクションに新しいルールが正しく追記されていることを確認
- [ ] 既存の conventional commits リストとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)