### PR TITLE
fix: correct alerter install command to vjeantet/tap/alerter

### DIFF
--- a/scripts/shared/desktop-notify-backend/macos.sh
+++ b/scripts/shared/desktop-notify-backend/macos.sh
@@ -4,7 +4,7 @@
 # Implements desktop_notify for macOS using alerter (preferred) or osascript (fallback).
 #
 # Tool priority:
-#   1. alerter   — if available (e.g. brew install alerter)
+#   1. alerter   — if available (e.g. brew install vjeantet/tap/alerter)
 #   2. osascript — fallback (always available on macOS)
 #
 # URL handling:

--- a/scripts/shared/desktop-notify.sh
+++ b/scripts/shared/desktop-notify.sh
@@ -5,7 +5,7 @@
 # Detects the platform and delegates to the appropriate backend adapter.
 #
 # Backends:
-#   macos.sh  — alerter (preferred, brew install alerter) or osascript (fallback)
+#   macos.sh  — alerter (preferred, brew install vjeantet/tap/alerter) or osascript (fallback)
 #   linux.sh  — notify-send + canberra-gtk-play
 #   wsl.sh    — powershell.exe toast notification
 #


### PR DESCRIPTION
## Summary
- alerter の Homebrew インストールコマンドを `brew install alerter` → `brew install vjeantet/tap/alerter` に修正（2箇所）

## Test plan
- [x] コメントのみの変更、動作への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)