### PR TITLE
skills/orchctrl → skills/orchctl にリネーム

### DIFF
--- a/.claude/skills/orchctl
+++ b/.claude/skills/orchctl
@@ -1,0 +1,1 @@
+../../skills/orchctl

--- a/.claude/skills/orchctrl
+++ b/.claude/skills/orchctrl
@@ -1,1 +1,0 @@
-../../skills/orchctrl

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Orchestrator (agent1)             Worker (agent2, 3, 4, ...)
 | `waitpid` | `watch.sh` (triple-path: FIFO + state file + crash detection) |
 | zombie reaping | `health-check.sh` + `cleanup-worktree.sh` |
 | core dump / checkpoint | `.cekernel-checkpoint.md` (suspend/resume) |
-| `systemctl` | `orchctl.sh` / `/orchctrl` skill |
+| `systemctl` | `orchctl.sh` / `/orchctl` skill |
 | device drivers | `backend-adapter.sh` (wezterm/tmux/headless) |
 | `/etc/default/` | `load-env.sh` + env profiles |
 | PID | issue number |
@@ -150,8 +150,8 @@ skills/
     SKILL.md               # /cron skill — recurring schedule management
   dispatch/
     SKILL.md               # /dispatch skill — batch-process ready-labeled issues
-  orchctrl/
-    SKILL.md               # /orchctrl skill — Worker control interface (orchctl.sh)
+  orchctl/
+    SKILL.md               # /orchctl skill — Worker control interface (orchctl.sh)
   orchestrate/
     SKILL.md               # /orchestrate skill — issue delegation
   postmortem/
@@ -318,7 +318,7 @@ If using the WezTerm backend, see [`config/README.md`](./config/README.md) for p
 | `/setup` | Interactive runtime setup (first-time) |
 | `/orchestrate` | Issue delegation and parallel processing |
 | `/dispatch` | Batch-process ready-labeled issues |
-| `/orchctrl` | Worker inspection and control |
+| `/orchctl` | Worker inspection and control |
 | `/cron` | Recurring schedule management (launchd/crontab) |
 | `/at` | One-shot schedule management (launchd/atd) |
 | `/postmortem` | Transcript-based post-mortem analysis |

--- a/skills/orchctl/SKILL.md
+++ b/skills/orchctl/SKILL.md
@@ -4,25 +4,25 @@ argument-hint: "<command> [target] [args...]"
 allowed-tools: Bash, Read
 ---
 
-# /orchctrl
+# /orchctl
 
 Worker control interface for cekernel. Like `systemctl` / `supervisorctl`, provides commands to inspect and manage running Workers across all sessions.
 
 ## Usage
 
 ```
-/orchctrl ls
-/orchctrl ps [--session <id>]
-/orchctrl inspect <target>
-/orchctrl suspend <target>
-/orchctrl resume <target>
-/orchctrl recover <target>
-/orchctrl term <target>
-/orchctrl kill <target>
-/orchctrl nice <target> <priority>
+/orchctl ls
+/orchctl ps [--session <id>]
+/orchctl inspect <target>
+/orchctl suspend <target>
+/orchctl resume <target>
+/orchctl recover <target>
+/orchctl term <target>
+/orchctl kill <target>
+/orchctl nice <target> <priority>
 ```
 
-Note: In plugin mode, `/cekernel:orchctrl` also works.
+Note: In plugin mode, `/cekernel:orchctl` also works.
 
 ## Addressing: `<target>`
 


### PR DESCRIPTION
closes #463

## Summary
- `skills/orchctrl/` → `skills/orchctl/` にディレクトリリネーム
- `SKILL.md` 内の `/orchctrl` → `/orchctl` 参照を全更新
- `.claude/skills/orchctrl` シンボリックリンクを `orchctl` に更新
- `README.md` の skill 参照を更新（Unix mapping table, directory tree, skill table）
- RELEASE_NOTES.md / ADR / テストフィクスチャの歴史的参照はそのまま保持

## Test Plan
- [x] `run-tests.sh` 全テスト通過
- [x] `orchctrl` 参照が意図しない箇所に残っていないことを grep で確認