### PR TITLE
Worker/Reviewerのテスト実行を変更対象スクリプトのみに限定する

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -102,11 +102,21 @@ gh pr diff <pr-number>
 
 ### 4. Evaluate
 
+**Do not run tests locally.** Verify test results through CI using `gh pr checks`. Running test suites locally wastes Reviewer time and provides no additional value over CI.
+
+```bash
+# Good — check CI results
+gh pr checks <pr-number>
+
+# Bad — never run tests locally
+bash tests/run-tests.sh
+```
+
 Assess the changes against:
 
 - **Correctness**: Do the changes implement what the issue requires?
 - **Conventions**: Do the changes follow the target repository's CLAUDE.md and coding standards?
-- **Tests**: Are appropriate tests included (if required by the repository)?
+- **Tests**: Are appropriate tests included (if required by the repository)? Verify via CI (`gh pr checks`), not local execution.
 - **Scope**: Are the changes focused on the issue, without unrelated modifications?
 
 ### 5. Submit Review
@@ -182,6 +192,7 @@ This writes a JSON message to the FIFO, which `watch.sh` delivers to the Orchest
 - **Reviewer must not merge PRs** — merge is the Orchestrator's responsibility
 - **Reviewer must not modify files** — read-only review only
 - **Reviewer must not create commits or push** — no write operations on the repository
+- **Reviewer must not run tests locally** — verify test results via `gh pr checks` only
 - Review judgment is based on the target repository's conventions, not cekernel's internal rules
 - Keep review comments actionable and specific — the Worker must be able to address them without ambiguity
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -183,6 +183,20 @@ Implement **following the target repository's rules**.
 3. Implement following the target repository's conventions
 4. Pass tests and lint as defined by the target repository
 
+#### Test Execution Policy
+
+**Do not run the full test suite (`run-tests.sh`) locally.** Only run tests related to the scripts you changed. Full test suite execution is delegated to CI and verified via `gh pr checks` in Phase 3.
+
+Running the full suite locally wastes significant Worker time (50-60% of total execution in observed cases) due to output truncation, auto-background, and polling loops.
+
+```bash
+# Good — run only the related test file
+bash tests/shared/test-session-id.sh
+
+# Bad — never run the full suite locally
+bash tests/run-tests.sh
+```
+
 #### Development Method: TDD (Red-Green-Refactor)
 
 For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first development. Update the phase detail at each TDD step and commit:


### PR DESCRIPTION
closes #469

## Summary
- Worker: ローカルでは変更対象スクリプトに関連するテストのみ実行し、フルテストスイート (`run-tests.sh`) の実行を禁止。全体テストは CI に委任
- Reviewer: ローカルでのテスト実行を全面禁止し、`gh pr checks` で CI 結果を確認する方針を明記
- 実測で Worker 実行時間の 50-63% がフルテストスイートの再実行に浪費されていた問題を解消

## Changes
- `agents/worker.md`: Phase 1 に "Test Execution Policy" セクションを追加
- `agents/reviewer.md`: "4. Evaluate" セクションにローカルテスト禁止を追加、Constraints に制約を追加

## Test Plan
- [ ] CI テストが通ることを確認
- [ ] Worker/Reviewer エージェントが新しい方針に従うことを実運用で確認