### PR TITLE
Orchestrator 完了時に orchestrator.pid を削除する

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -596,3 +596,11 @@ If `watch.sh` returns `merged` (legacy Worker behavior), proceed with cleanup di
   # 4. If still alive, force-kill
   export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh --force <issue>
   ```
+
+## Completion
+
+When all issues have been processed (all Workers completed and cleaned up), the Orchestrator must remove its PID file before exiting. Without this cleanup, `orchctl ps` continues to show the completed Orchestrator as `not-running`.
+
+```bash
+rm -f "${CEKERNEL_IPC_DIR}/orchestrator.pid"
+```


### PR DESCRIPTION
closes #471

## Summary
- `agents/orchestrator.md` に Completion セクションを追加し、Orchestrator が全 issue 処理完了後に `orchestrator.pid` を削除するよう指示
- `spawn-orchestrator.sh` は起動後即 exit するため cleanup hook を仕込めず、Orchestrator エージェント自身が削除するのが唯一の方法

## Test Plan
- [ ] `orchctl ps` で完了済み Orchestrator が `not-running` として残らないことを確認