### PR TITLE
docs: fix post-refactoring documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,14 @@ it distributes, monitors, and reaps issues via independent Workers.
 
 ## Concept
 
-```
-Orchestrator (agent1)             Worker (agent2, 3, 4, ...)
-  main working tree                 git worktree per issue
-  +---------------+               +---------------+
-  | receive issue |               | implement     |
-  | create wktree |--spawn------->| test          |
-  | monitor FIFO  |               | create PR     |
-  |   ...waiting  |               | CI verify     |
-  |   <--signal---|<--notify------| notify done   |
-  | review (agent)|               +---------------+
-  | merge / human |
-  | cleanup       |
-  +---------------+
+```mermaid
+graph LR
+    H[Human / Scheduler] -->|/orchestrate<br/>/dispatch| O[Orchestrator<br/>main working tree]
+    O -->|spawn-worker.sh| W[Worker<br/>git worktree]
+    W -->|notify ci-passed| O
+    O -->|spawn-reviewer.sh| R[Reviewer<br/>same worktree]
+    R -->|notify approved| O
+    O -->|cleanup + notify| H
 ```
 
 ### OS Analogy

--- a/docs/adr/0009-file-based-namespace-detection.md
+++ b/docs/adr/0009-file-based-namespace-detection.md
@@ -76,7 +76,7 @@ For file-based detection to work in local mode, Claude Code must be able to reso
 └── worker.md@       -> ../../agents/worker.md
 
 .claude/skills/
-├── orchctrl@       -> ../../skills/orchctrl
+├── orchctl@        -> ../../skills/orchctl
 ├── orchestrate@    -> ../../skills/orchestrate
 ├── probe@          -> ../../skills/probe
 └── unix-architect@ -> ../../skills/unix-architect


### PR DESCRIPTION
closes #475

## Summary
- README.md の Concept セクションを ASCII art から mermaid diagram に変換
- ADR-0009 の symlink 例を `orchctrl@` → `orchctl@` に修正（#463 リネーム後の残存不整合）

## Test Plan
- [ ] mermaid diagram が GitHub 上で正しくレンダリングされること
- [ ] ADR-0009 の symlink 例が実際のディレクトリ構造と一致すること