### PR TITLE
docs: add ADR-0014 for two-tier concurrency env vars

### DIFF
--- a/docs/adr/0014-two-tier-concurrency-env-vars.md
+++ b/docs/adr/0014-two-tier-concurrency-env-vars.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

- `CEKERNEL_MAX_PROCESSES` → `CEKERNEL_MAX_ORCH_CHILDREN` にリネーム（orchestrator当たりの子プロセス上限を明示）
- `CEKERNEL_MAX_ORCHESTRATORS` を新設（orchestratorの同時起動数を制御）
- `CEKERNEL_MAX_WORKERS` の後方互換を廃止

ref #477

## Test plan

- [ ] ADRの内容を確認
- [ ] 実装タスクはissue分割後に別PRで対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)