### PR TITLE
docs: CLAUDE.md テスト規約に実行可能スクリプトがない変更の例外を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,10 @@ Test only the **behavior of executable scripts**.
 - OK: `spawn-worker.sh` returns exit 2 when the concurrency limit is exceeded
 - NG: Grep-testing `*.md` content to verify specific strings are present
 
+Exception: When a change adds no executable scripts (e.g., env profile or
+skill definition changes), content-based assertions on configuration files
+are acceptable as regression guards.
+
 ### Test File Naming
 
 ```


### PR DESCRIPTION
closes #488

## Summary
- CLAUDE.md の「What to Test」セクションの NG 例の後に例外規定を追記
- 実行可能スクリプトがない変更（env profile や skill definition など）では、content-based assertion が regression guard として許容されることを明記

## Background
- #481 の Worker が env profile / SKILL.md のみの変更に対して grep-based テストを作成し、Reviewer が NG パターンに該当すると指摘
- #477 の postmortem で Class 2 (project rules gap) として検出された問題への対応

## Test Plan
- ドキュメントのみの変更のためテスト不要