### PR TITLE
fix: claude_session_id_persist を Orchestrator 起動後に移動

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -44,6 +44,25 @@ If requirements are ambiguous or insufficient, FAIL immediately and return the r
 
 ## Workflow
 
+### Claude Code Session ID Persistence
+
+On startup, the Orchestrator must discover and persist its own Claude Code session ID (UUID). This is separate from `CEKERNEL_SESSION_ID` and is used by `/postmortem` to locate Orchestrator transcripts.
+
+The dispatch/orchestrate skill does **not** persist the Claude Code session ID because the skill runs in a different Claude Code session than the Orchestrator. The Orchestrator runs as an independent `claude -p --agent` process with its own UUID, so it must persist the ID itself.
+
+Run this **once** at startup, before processing any issues:
+
+```bash
+export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && \
+source ${CEKERNEL_SCRIPTS}/shared/session-id.sh && \
+source ${CEKERNEL_SCRIPTS}/shared/claude-session-id.sh && \
+_PROJECT_ROOT="$(git rev-parse --show-toplevel)" && \
+_CLAUDE_SID=$(claude_session_id_discover "$_PROJECT_ROOT") && \
+claude_session_id_persist "$_CLAUDE_SID" || echo "warn: Claude session ID discovery failed (non-fatal)" >&2
+```
+
+If discovery fails (e.g., no `.jsonl` files found yet), continue — it is optional for Orchestrator operation.
+
 ### CEKERNEL_SESSION_ID Management
 
 Each Bash tool call runs in an independent shell, so `CEKERNEL_SESSION_ID` is not automatically shared.

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -129,7 +129,7 @@ If `CURRENT_ORCH < MAX_ORCH`, proceed to Step 4.
 
 If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
 
-**Initialize cekernel session and persist Claude Code session ID** — Run the following in a **single** Bash tool call. This generates `CEKERNEL_SESSION_ID` (format: `{repo}-{hex8}`), writes repo metadata for `orchctl ls`, and separately persists the Claude Code session UUID for `/postmortem`:
+**Initialize cekernel session** — Run the following in a **single** Bash tool call. This generates `CEKERNEL_SESSION_ID` (format: `{repo}-{hex8}`) and writes repo metadata for `orchctl ls`:
 
 ```bash
 # 1. Generate CEKERNEL_SESSION_ID ({repo}-{hex8} format)
@@ -143,22 +143,13 @@ _path="${_url#*:}"; _path="${_path#*//}"; _path="${_path%.git}"
 _REPO_SLUG="${_path#*/}"
 echo "$_REPO_SLUG" > "${CEKERNEL_IPC_DIR}/repo"
 
-# 3. Persist Claude Code session ID (UUID — separate from CEKERNEL_SESSION_ID)
-source "${CEKERNEL_SCRIPTS}/shared/claude-session-id.sh"
-_PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-_CLAUDE_SID=$(claude_session_id_discover "$_PROJECT_ROOT") && claude_session_id_persist "$_CLAUDE_SID" || echo "warn: Claude session ID discovery failed (non-fatal)" >&2
-
-# 4. Output CEKERNEL_SESSION_ID for prompt construction
+# 3. Output CEKERNEL_SESSION_ID for prompt construction
 echo "CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}"
 ```
 
-**IMPORTANT**: `CEKERNEL_SESSION_ID` and `CLAUDE_SESSION_ID` are distinct values with different purposes:
-- `CEKERNEL_SESSION_ID` — cekernel's session identifier (`{repo}-{hex8}`), used for IPC directory and script coordination
-- `CLAUDE_SESSION_ID` — Claude Code's internal UUID, used only for `/postmortem` transcript lookup
+Capture `CEKERNEL_SESSION_ID` from the Bash output (the line `CEKERNEL_SESSION_ID=...`) and use it in the Orchestrator prompt.
 
-Capture `CEKERNEL_SESSION_ID` from the Bash output (the line `CEKERNEL_SESSION_ID=...`) and use it in the Orchestrator prompt. Do **NOT** use the Claude Code session UUID as `CEKERNEL_SESSION_ID`.
-
-If Claude Code session ID discovery fails (e.g., no `.jsonl` files found), continue — it is optional for Orchestrator operation.
+Note: Claude Code session ID (`claude-session-id`) persistence is handled by the Orchestrator itself after startup. The dispatch skill does not persist it because the skill's UUID differs from the Orchestrator's UUID (the Orchestrator runs as a separate `claude -p --agent` process).
 
 **Construct the Orchestrator prompt** from the following template. Replace `<placeholders>` with actual values determined in previous steps:
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -100,7 +100,7 @@ If `CURRENT_ORCH < MAX_ORCH`, proceed to Step 2 directly.
 
 If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
 
-**Initialize cekernel session and persist Claude Code session ID** — Run the following in a **single** Bash tool call. This generates `CEKERNEL_SESSION_ID` (format: `{repo}-{hex8}`), writes repo metadata for `orchctl ls`, and separately persists the Claude Code session UUID for `/postmortem`:
+**Initialize cekernel session** — Run the following in a **single** Bash tool call. This generates `CEKERNEL_SESSION_ID` (format: `{repo}-{hex8}`) and writes repo metadata for `orchctl ls`:
 
 ```bash
 # 1. Generate CEKERNEL_SESSION_ID ({repo}-{hex8} format)
@@ -114,22 +114,13 @@ _path="${_url#*:}"; _path="${_path#*//}"; _path="${_path%.git}"
 _REPO_SLUG="${_path#*/}"
 echo "$_REPO_SLUG" > "${CEKERNEL_IPC_DIR}/repo"
 
-# 3. Persist Claude Code session ID (UUID — separate from CEKERNEL_SESSION_ID)
-source "${CEKERNEL_SCRIPTS}/shared/claude-session-id.sh"
-_PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-_CLAUDE_SID=$(claude_session_id_discover "$_PROJECT_ROOT") && claude_session_id_persist "$_CLAUDE_SID" || echo "warn: Claude session ID discovery failed (non-fatal)" >&2
-
-# 4. Output CEKERNEL_SESSION_ID for prompt construction
+# 3. Output CEKERNEL_SESSION_ID for prompt construction
 echo "CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}"
 ```
 
-**IMPORTANT**: `CEKERNEL_SESSION_ID` and `CLAUDE_SESSION_ID` are distinct values with different purposes:
-- `CEKERNEL_SESSION_ID` — cekernel's session identifier (`{repo}-{hex8}`), used for IPC directory and script coordination
-- `CLAUDE_SESSION_ID` — Claude Code's internal UUID, used only for `/postmortem` transcript lookup
+Capture `CEKERNEL_SESSION_ID` from the Bash output (the line `CEKERNEL_SESSION_ID=...`) and use it in the Orchestrator prompt.
 
-Capture `CEKERNEL_SESSION_ID` from the Bash output (the line `CEKERNEL_SESSION_ID=...`) and use it in the Orchestrator prompt. Do **NOT** use the Claude Code session UUID as `CEKERNEL_SESSION_ID`.
-
-If Claude Code session ID discovery fails (e.g., no `.jsonl` files found), continue — it is optional for Orchestrator operation.
+Note: Claude Code session ID (`claude-session-id`) persistence is handled by the Orchestrator itself after startup. The orchestrate skill does not persist it because the skill's UUID differs from the Orchestrator's UUID (the Orchestrator runs as a separate `claude -p --agent` process).
 
 **Construct the Orchestrator prompt** from the following template. Replace `<placeholders>` with actual values determined in previous steps:
 


### PR DESCRIPTION
closes #492

## 概要
- dispatch/orchestrate skill から `claude_session_id_persist` 呼び出しを削除
- Orchestrator agent (`agents/orchestrator.md`) の起動直後に `claude_session_id_discover` + `claude_session_id_persist` を実行するステップを追加
- これにより Orchestrator 自身の UUID が `claude-session-id` に保存され、transcript locator の Strategy 1 が正常動作する

## 背景
dispatch/orchestrate skill が `claude_session_id_persist` を呼び出していたが、保存されるのは skill 自身の Claude Code UUID であり、Orchestrator の UUID ではなかった。Orchestrator は独立プロセス (`claude -p --agent`) として起動されるため別の UUID を持つ。

## テスト計画
- [ ] 実行可能スクリプトの変更なし（.md ファイルのみ）— 既存テストで回帰確認
- [ ] `/orchestrate` 実行後、`claude-session-id` ファイルに Orchestrator の UUID が保存されることを確認