### PR TITLE
fix: テストの set -e 耐性 — 非ゼロ返却を期待する関数呼び出しの保護

### DIFF
--- a/tests/process/test-check-signal.sh
+++ b/tests/process/test-check-signal.sh
@@ -26,16 +26,16 @@ assert_eq "No signal file exits 1" "1" "$EXIT_CODE"
 
 # ── Test 2: TERM signal file exists → exit 0, outputs signal name, consumes file ──
 echo "TERM" > "${CEKERNEL_IPC_DIR}/worker-42.signal"
-OUTPUT=$(bash "$CHECK_SIGNAL" 42)
-EXIT_CODE=$?
+EXIT_CODE=0
+OUTPUT=$(bash "$CHECK_SIGNAL" 42) || EXIT_CODE=$?
 assert_eq "TERM signal detected exits 0" "0" "$EXIT_CODE"
 assert_eq "Output is TERM" "TERM" "$OUTPUT"
 assert_not_exists "Signal file consumed after check" "${CEKERNEL_IPC_DIR}/worker-42.signal"
 
 # ── Test 3: SUSPEND signal file exists → exit 0, outputs SUSPEND, consumes file ──
 echo "SUSPEND" > "${CEKERNEL_IPC_DIR}/worker-43.signal"
-OUTPUT=$(bash "$CHECK_SIGNAL" 43)
-EXIT_CODE=$?
+EXIT_CODE=0
+OUTPUT=$(bash "$CHECK_SIGNAL" 43) || EXIT_CODE=$?
 assert_eq "SUSPEND signal detected exits 0" "0" "$EXIT_CODE"
 assert_eq "Output is SUSPEND" "SUSPEND" "$OUTPUT"
 assert_not_exists "SUSPEND signal file consumed after check" "${CEKERNEL_IPC_DIR}/worker-43.signal"
@@ -47,7 +47,7 @@ assert_eq "Missing issue number exits non-zero" "1" "$EXIT_CODE"
 
 # ── Test 5: Signal file with trailing whitespace is trimmed ──
 printf "TERM\n" > "${CEKERNEL_IPC_DIR}/worker-55.signal"
-OUTPUT=$(bash "$CHECK_SIGNAL" 55)
+OUTPUT=$(bash "$CHECK_SIGNAL" 55) || true
 assert_eq "Trailing newline trimmed" "TERM" "$OUTPUT"
 assert_not_exists "Signal file consumed" "${CEKERNEL_IPC_DIR}/worker-55.signal"
 
@@ -55,7 +55,7 @@ assert_not_exists "Signal file consumed" "${CEKERNEL_IPC_DIR}/worker-55.signal"
 mkdir -p "${CEKERNEL_IPC_DIR}/logs"
 LOG_FILE="${CEKERNEL_IPC_DIR}/logs/worker-60.log"
 echo "TERM" > "${CEKERNEL_IPC_DIR}/worker-60.signal"
-bash "$CHECK_SIGNAL" 60 >/dev/null
+bash "$CHECK_SIGNAL" 60 >/dev/null || true
 assert_file_exists "Log file created" "$LOG_FILE"
 LOG_CONTENT=$(cat "$LOG_FILE")
 assert_match "Log contains SIGNAL_RECEIVED" "SIGNAL_RECEIVED" "$LOG_CONTENT"

--- a/tests/shared/test-claude-session-id.sh
+++ b/tests/shared/test-claude-session-id.sh
@@ -39,14 +39,14 @@ sleep 0.1
 # Create newer session (this should be discovered)
 touch "${PROJECT_DIR}/11111111-2222-3333-4444-555555555555.jsonl"
 
-RESULT=$(claude_session_id_discover "/Users/test/git/repo" "$MOCK_CLAUDE_HOME")
+RESULT=$(claude_session_id_discover "/Users/test/git/repo" "$MOCK_CLAUDE_HOME") || true
 assert_eq "Discovers most recent session ID" "11111111-2222-3333-4444-555555555555" "$RESULT"
 
 # ── Test 2: Discover session ID — excludes subagent directories ──
 mkdir -p "${PROJECT_DIR}/11111111-2222-3333-4444-555555555555/subagents"
 touch "${PROJECT_DIR}/11111111-2222-3333-4444-555555555555/subagents/agent-001.jsonl"
 
-RESULT=$(claude_session_id_discover "/Users/test/git/repo" "$MOCK_CLAUDE_HOME")
+RESULT=$(claude_session_id_discover "/Users/test/git/repo" "$MOCK_CLAUDE_HOME") || true
 assert_eq "Discover excludes subagent .jsonl files" "11111111-2222-3333-4444-555555555555" "$RESULT"
 
 # ── Test 3: Discover session ID — no project directory ──
@@ -74,7 +74,7 @@ EXIT_CODE=0
 assert_eq "Persist fails without CEKERNEL_IPC_DIR" "1" "$EXIT_CODE"
 
 # ── Test 7: Read session ID ──
-RESULT=$(claude_session_id_read)
+RESULT=$(claude_session_id_read) || true
 assert_eq "Read returns persisted session ID" "abcd1234-5678-90ab-cdef-1234567890ab" "$RESULT"
 
 # ── Test 8: Read session ID — file does not exist ──
@@ -89,13 +89,13 @@ EXIT_CODE=0
 assert_eq "Read fails without CEKERNEL_IPC_DIR" "1" "$EXIT_CODE"
 
 # ── Test 10: Project slug derivation ──
-RESULT=$(claude_session_id_project_slug "/Users/alice/git/myrepo")
+RESULT=$(claude_session_id_project_slug "/Users/alice/git/myrepo") || true
 assert_eq "Project slug from path" "-Users-alice-git-myrepo" "$RESULT"
 
 # ── Test 11: Persist overwrites existing value ──
 claude_session_id_persist "first-value"
 claude_session_id_persist "second-value"
-RESULT=$(claude_session_id_read)
+RESULT=$(claude_session_id_read) || true
 assert_eq "Persist overwrites existing value" "second-value" "$RESULT"
 
 report_results

--- a/tests/shared/test-transcript-locator.sh
+++ b/tests/shared/test-transcript-locator.sh
@@ -31,13 +31,13 @@ WORKER_PROJECT="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo--worktrees-iss
 mkdir -p "$WORKER_PROJECT"
 touch "${WORKER_PROJECT}/session-abc123.jsonl"
 
-RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME")
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME") || true
 assert_eq "Worker transcript found for issue 42" "${WORKER_PROJECT}/session-abc123.jsonl" "$RESULT"
 
 # ── Test 2: Worker transcript discovery — multiple files (resume) ──
 touch "${WORKER_PROJECT}/session-def456.jsonl"
 
-RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | sort)
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | sort) || true
 EXPECTED=$(printf '%s\n%s' "${WORKER_PROJECT}/session-abc123.jsonl" "${WORKER_PROJECT}/session-def456.jsonl" | sort)
 assert_eq "Multiple worker transcripts found (resume)" "$EXPECTED" "$RESULT"
 
@@ -53,7 +53,7 @@ mkdir -p "$REVIEWER_PROJECT"
 touch "${REVIEWER_PROJECT}/session-review1.jsonl"
 
 # Worker locate should also find reviewer transcripts (both contain issue number)
-RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | wc -l | tr -d ' ') || true
 assert_eq "Finds transcripts from both worker and reviewer worktrees" "3" "$RESULT"
 
 # ── Test 5: Orchestrator transcript discovery ──
@@ -62,7 +62,7 @@ mkdir -p "$ORCH_SESSION_DIR"
 touch "${ORCH_SESSION_DIR}/agent-orch-001.jsonl"
 touch "${ORCH_SESSION_DIR}/agent-orch-002.jsonl"
 
-RESULT=$(transcript_locate_orchestrator "session-orch1" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | sort)
+RESULT=$(transcript_locate_orchestrator "session-orch1" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | sort) || true
 EXPECTED=$(printf '%s\n%s' "${ORCH_SESSION_DIR}/agent-orch-001.jsonl" "${ORCH_SESSION_DIR}/agent-orch-002.jsonl" | sort)
 assert_eq "Orchestrator transcripts found via session ID" "$EXPECTED" "$RESULT"
 
@@ -73,17 +73,17 @@ assert_eq "Orchestrator transcript not found returns empty" "" "$RESULT"
 assert_eq "Orchestrator transcript not found exit code 1" "1" "$EXIT_CODE"
 
 # ── Test 7: transcript_locate_all combines worker + orchestrator ──
-RESULT=$(transcript_locate_all 42 "session-orch1" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_all 42 "session-orch1" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ') || true
 assert_eq "transcript_locate_all returns all transcripts" "5" "$RESULT"
 
 # ── Test 8: transcript_locate_all without orchestrator session ──
-RESULT=$(transcript_locate_all 42 "" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_all 42 "" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ') || true
 assert_eq "transcript_locate_all works without orchestrator session" "3" "$RESULT"
 
 # ── Test 9: Non-.jsonl files are excluded ──
 touch "${WORKER_PROJECT}/not-a-transcript.txt"
 touch "${WORKER_PROJECT}/session.json"
-RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_worker 42 "$MOCK_CLAUDE_HOME" | wc -l | tr -d ' ') || true
 assert_eq "Non-.jsonl files excluded" "3" "$RESULT"
 
 # ── Test 10: Error message on stderr for absent transcripts ──
@@ -108,7 +108,7 @@ ORCH_SESSION_DIR2="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo/${MOCK_SESS
 mkdir -p "$ORCH_SESSION_DIR2"
 touch "${ORCH_SESSION_DIR2}/agent-orch-010.jsonl"
 
-RESULT=$(transcript_locate_orchestrator_by_issue 42 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo")
+RESULT=$(transcript_locate_orchestrator_by_issue 42 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo") || true
 assert_eq "Orchestrator found via .spawned file reverse lookup" "${ORCH_SESSION_DIR2}/agent-orch-010.jsonl" "$RESULT"
 
 # ── Test 13: _by_issue — reviewer .spawned file also matches ──
@@ -122,7 +122,7 @@ mkdir -p "$ORCH_SESSION_DIR3"
 touch "${ORCH_SESSION_DIR3}/agent-orch-020.jsonl"
 
 # Should find transcripts from both sessions
-RESULT=$(transcript_locate_orchestrator_by_issue 42 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_orchestrator_by_issue 42 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ') || true
 assert_eq "Finds orchestrator transcripts from multiple sessions via .spawned" "2" "$RESULT"
 
 # ── Test 14: _by_issue — no .spawned files for issue ──
@@ -141,7 +141,7 @@ RESULT=$(transcript_locate_orchestrator_by_issue 99 "$MOCK_VAR_DIR" "$MOCK_CLAUD
 assert_eq "Returns exit 1 when .spawned exists but no orchestrator transcripts" "1" "$EXIT_CODE"
 
 # ── Test 16: transcript_locate_all uses _by_issue for orchestrator discovery ──
-RESULT=$(transcript_locate_all 42 "" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" "$MOCK_VAR_DIR" 2>/dev/null | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_all 42 "" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" "$MOCK_VAR_DIR" 2>/dev/null | wc -l | tr -d ' ') || true
 assert_eq "transcript_locate_all uses _by_issue as fallback" "5" "$RESULT"
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -153,7 +153,7 @@ DIRECT_SESSION="direct-orch-uuid-1"
 DIRECT_JSONL="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo/${DIRECT_SESSION}.jsonl"
 echo '{"type":"agent-setting","agentSetting":"orchestrator","sessionId":"direct-orch-uuid-1"}' > "$DIRECT_JSONL"
 
-RESULT=$(transcript_locate_orchestrator "$DIRECT_SESSION" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo")
+RESULT=$(transcript_locate_orchestrator "$DIRECT_SESSION" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo") || true
 assert_eq "Direct JSONL found for orchestrator (claude -p)" "$DIRECT_JSONL" "$RESULT"
 
 # ── Test 18: transcript_locate_orchestrator finds both direct and subagent ──
@@ -163,7 +163,7 @@ mkdir -p "$BOTH_SUBDIR"
 touch "${BOTH_SUBDIR}/agent-both-001.jsonl"
 touch "${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo/${BOTH_SESSION}.jsonl"
 
-RESULT=$(transcript_locate_orchestrator "$BOTH_SESSION" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_orchestrator "$BOTH_SESSION" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" | wc -l | tr -d ' ') || true
 assert_eq "Finds both direct and subagent transcripts for same session" "2" "$RESULT"
 
 # ── Test 19: _by_issue with orchestrator.spawned + agentSetting scan ──
@@ -182,7 +182,7 @@ echo '{"type":"agent-setting","agentSetting":"orchestrator","sessionId":"orch-cl
 WORKER_100="${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo--worktrees-issue-100-test-feature"
 mkdir -p "$WORKER_100"
 
-RESULT=$(transcript_locate_orchestrator_by_issue 100 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null)
+RESULT=$(transcript_locate_orchestrator_by_issue 100 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null) || true
 assert_match "Finds orchestrator JSONL via agentSetting scan" "orch-claude-p-uuid" "$RESULT"
 
 # ── Test 20: agentSetting scan excludes non-orchestrator JSONL ──
@@ -190,17 +190,17 @@ assert_match "Finds orchestrator JSONL via agentSetting scan" "orch-claude-p-uui
 # direct-orch-uuid-1.jsonl (test 17) + orch-claude-p-uuid.jsonl (test 19) = 2
 echo '{"type":"agent-setting","agentSetting":"worker","sessionId":"worker-session-1"}' > "${MOCK_CLAUDE_HOME}/projects/-Users-test-git-repo/worker-session-1.jsonl"
 
-RESULT=$(transcript_locate_orchestrator_by_issue 100 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_orchestrator_by_issue 100 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ') || true
 assert_eq "agentSetting scan excludes non-orchestrator JSONL" "2" "$RESULT"
 
 # ── Test 21: _by_issue without project_slug derives main slug from worker dirs ──
-RESULT=$(transcript_locate_orchestrator_by_issue 100 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "" 2>/dev/null)
+RESULT=$(transcript_locate_orchestrator_by_issue 100 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "" 2>/dev/null) || true
 assert_match "Derives main project slug and finds orchestrator" "orch-claude-p-uuid" "$RESULT"
 
 # ── Test 22: _by_issue prefers subagent path (backward compat) ──
 # For issue 42, sessions mock-session-orch1 and mock-session-orch2 have subagent transcripts
 # The function should find those via subagent path, not fall through to agentSetting scan
-RESULT=$(transcript_locate_orchestrator_by_issue 42 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ')
+RESULT=$(transcript_locate_orchestrator_by_issue 42 "$MOCK_VAR_DIR" "$MOCK_CLAUDE_HOME" "-Users-test-git-repo" 2>/dev/null | wc -l | tr -d ' ') || true
 assert_eq "Backward compat: subagent path still works for issue 42" "2" "$RESULT"
 
 # ── Test 23: orchestrator.spawned absent — only subagent path used ──


### PR DESCRIPTION
closes #491

## Summary
- `set -euo pipefail` 環境下で、`transcript_locate_*`・`check-signal.sh`・`claude_session_id_*` 関数の command substitution が非ゼロを返すとテストスクリプトが即終了する問題を修正
- `|| true` / `|| EXIT_CODE=$?` パターンを 25 箇所に追加し、テストが `FAIL:` 行で報告するようにした
- 対象ファイル: `test-transcript-locator.sh` (16), `test-check-signal.sh` (4), `test-claude-session-id.sh` (5)

## Test Plan
- [x] `bash tests/shared/test-transcript-locator.sh` — 26 passed, 0 failed
- [x] `bash tests/process/test-check-signal.sh` — 14 passed, 0 failed
- [x] `bash tests/shared/test-claude-session-id.sh` — 12 passed, 0 failed
- [ ] CI passes