### PR TITLE
reviewer.md の checkpoint warning 抑制と postmortem 誤検出防止

### DIFF
--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -208,11 +208,15 @@ if [[ "$RESUME" -eq 1 ]]; then
   # it as self-cleanup. Clearing here would race with the Orchestrator's
   # marker write and prevent the Worker from entering the correct mode.
 
-  # Verify checkpoint exists for resume
-  if checkpoint_file_exists "$WORKTREE"; then
-    echo "checkpoint: $(checkpoint_file_path "$WORKTREE")" >&2
-  else
-    echo "Warning: no checkpoint file found. Process will start fresh." >&2
+  # Verify checkpoint exists for resume (Worker only)
+  # Checkpoints are written only on SUSPEND signal, which is a Worker-only concept.
+  # Reviewer resumes always lack a checkpoint — this is expected, not a warning.
+  if [[ "$AGENT_TYPE" == "worker" ]]; then
+    if checkpoint_file_exists "$WORKTREE"; then
+      echo "checkpoint: $(checkpoint_file_path "$WORKTREE")" >&2
+    else
+      echo "Warning: no checkpoint file found. Process will start fresh." >&2
+    fi
   fi
 else
   # Normal mode: create new worktree

--- a/skills/references/postmortem-patterns.md
+++ b/skills/references/postmortem-patterns.md
@@ -116,6 +116,7 @@ Patterns are organized by category. Each has:
 - **Severity**: warning
 - **Class**: 1
 - **Example**: [#340], [#335] — Neither initial Worker session wrote a checkpoint, forcing resumed Workers to reconstruct context from PR comments and git log
+- **Exclusion**: The `no checkpoint file found` message during Reviewer startup is expected behavior. Checkpoints are only written when a Worker receives a SUSPEND signal, so a Worker that completed normally will not have a checkpoint file. This message during Reviewer spawn (via `spawn-reviewer.sh --resume`) should be excluded from detection.
 
 ### Reviewer not following linked documents
 - **Detect**: Reviewer reading CLAUDE.md but not following `Read` instructions for linked documents (unix-philosophy.md, tdd.md, etc.)

--- a/tests/orchestrator/test-spawn-checkpoint-warning.sh
+++ b/tests/orchestrator/test-spawn-checkpoint-warning.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# test-spawn-checkpoint-warning.sh — Tests for checkpoint warning suppression in spawn.sh
+#
+# Verifies that spawn.sh only shows the checkpoint warning when resuming Workers,
+# not when resuming Reviewers (checkpoints are a Worker-only concept, written on SUSPEND).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "test: spawn-checkpoint-warning"
+
+SPAWN_SH="${CEKERNEL_DIR}/scripts/orchestrator/spawn.sh"
+SPAWN_CONTENT=$(cat "$SPAWN_SH")
+
+# ── Test 1: spawn.sh checkpoint warning is conditional on agent type ──
+# The checkpoint existence check in resume mode should only warn for Workers.
+# Reviewer resumes should NOT produce a "Warning: no checkpoint file found" message
+# because checkpoints are a Worker-only concept (written on SUSPEND signal).
+if echo "$SPAWN_CONTENT" | grep -q 'AGENT_TYPE.*worker.*checkpoint\|checkpoint.*AGENT_TYPE.*worker'; then
+  echo "  PASS: Checkpoint warning is conditional on AGENT_TYPE"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: Checkpoint warning should be conditional on AGENT_TYPE (worker only)"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 2: spawn.sh does not unconditionally warn about missing checkpoint ──
+# The old pattern was: if checkpoint_file_exists; then ... else Warning ...
+# The new pattern should gate the entire checkpoint check behind an agent type check.
+# Count occurrences of the checkpoint warning to ensure it's inside a conditional.
+WARNING_LINES=$(echo "$SPAWN_CONTENT" | grep -c 'Warning.*no checkpoint file found' || true)
+CONDITIONAL_LINES=$(echo "$SPAWN_CONTENT" | grep -c 'AGENT_TYPE.*worker' || true)
+if [[ "$WARNING_LINES" -gt 0 && "$CONDITIONAL_LINES" -gt 0 ]]; then
+  echo "  PASS: Warning exists with agent type guard"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+elif [[ "$WARNING_LINES" -eq 0 ]]; then
+  # Warning removed entirely — also acceptable (Reviewer never sees it)
+  echo "  PASS: Checkpoint warning removed (acceptable)"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: Checkpoint warning exists without agent type guard"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+report_results

--- a/tests/orchestrator/test-spawn-checkpoint-warning.sh
+++ b/tests/orchestrator/test-spawn-checkpoint-warning.sh
@@ -19,8 +19,12 @@ SPAWN_CONTENT=$(cat "$SPAWN_SH")
 # The checkpoint existence check in resume mode should only warn for Workers.
 # Reviewer resumes should NOT produce a "Warning: no checkpoint file found" message
 # because checkpoints are a Worker-only concept (written on SUSPEND signal).
-if echo "$SPAWN_CONTENT" | grep -q 'AGENT_TYPE.*worker.*checkpoint\|checkpoint.*AGENT_TYPE.*worker'; then
-  echo "  PASS: Checkpoint warning is conditional on AGENT_TYPE"
+# Extract the resume-mode block (between "Resume mode:" and "else" / "Normal mode:").
+# Verify that within this block, the checkpoint check is guarded by AGENT_TYPE == worker.
+RESUME_BLOCK=$(echo "$SPAWN_CONTENT" | sed -n '/Resume mode:/,/Normal mode:/p')
+HAS_AGENT_GUARD=$(echo "$RESUME_BLOCK" | grep -c 'AGENT_TYPE.*worker' || true)
+if [[ "$HAS_AGENT_GUARD" -gt 0 ]]; then
+  echo "  PASS: Checkpoint warning is conditional on AGENT_TYPE in resume block"
   TESTS_PASSED=$((TESTS_PASSED + 1))
 else
   echo "  FAIL: Checkpoint warning should be conditional on AGENT_TYPE (worker only)"


### PR DESCRIPTION
closes #519

## Summary
- `spawn.sh` の checkpoint 存在チェックを `AGENT_TYPE == worker` の場合のみに限定。Reviewer は `--resume` で起動するが SUSPEND/checkpoint は Worker 専用概念のため、warning は不要
- `postmortem-patterns.md` の「Missing checkpoint file」パターンに Exclusion を追加。Reviewer spawn 時の checkpoint 不在は正常動作として除外対象に

## Test Plan
- [x] `test-spawn-checkpoint-warning.sh` — checkpoint warning が AGENT_TYPE で制御されることを検証
- [x] `test-spawn-resume.sh` — 既存の resume テストがパスすることを確認
- [x] `test-spawn-reviewer.sh` — 既存の reviewer テストがパスすることを確認