### PR TITLE
feat: bare-mode helper for future-proofing -p (headless backend, opt-in)

### DIFF
--- a/envs/README.md
+++ b/envs/README.md
@@ -19,6 +19,7 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_REVIEW_MAX_RETRIES` | `2` | Positive integer | Orchestrator | Max cycles of Reviewer reject → Worker re-implement. Escalates to human when exceeded |
 | `CEKERNEL_NOTIFY_MACOS_ACTION` | `none` | `none`, `open`, `pbcopy` | `desktop-notify-backend/macos.sh` | macOS notification URL action: `none` = notify only, `open` = open URL in browser, `pbcopy` = copy URL to clipboard |
 | `CEKERNEL_VAR_DIR` | `~/.local/var/cekernel` | Directory path | `registry.sh`, `wrapper.sh` | Runtime state directory (locks, logs, runners, registry) |
+| `CEKERNEL_USE_BARE` | `0` | `0`, `1` | `bare-mode.sh` (Worker spawn) | `1`: spawn Workers with `claude --bare --plugin-dir <root> --add-dir <worktree>` for future-proofing against the planned default change of `-p`. **Requires `ANTHROPIC_API_KEY` (OAuth/keychain are not read under `--bare`).** If unset, the helper emits a stderr warning and falls back to the standard `-p` mode. Currently only the headless backend honors this flag |
 
 ## Internal Variables
 

--- a/scripts/shared/backends/headless.sh
+++ b/scripts/shared/backends/headless.sh
@@ -10,6 +10,10 @@
 # Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains PID (numeric).
 # Process group: setsid creates a new process group for clean termination.
 
+# ── Dependencies ──
+_HEADLESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
+source "${_HEADLESS_DIR}/../bare-mode.sh"
+
 # ── External API ──
 
 backend_available() {
@@ -33,13 +37,16 @@ backend_spawn_worker() {
   # Source .cekernel-env to propagate PATH and env vars (SESSION_ID, IPC_DIR, ENV).
   # Unset Claude Code session markers to avoid nested-session detection.
   # Use -p (print mode) for non-TTY execution.
+  # When CEKERNEL_USE_BARE=1, prepend --bare + --plugin-dir + --add-dir
+  # so plugin agents/skills and worktree CLAUDE.md remain discoverable.
   # NOTE: -p may hang without TTY due to upstream bug (claude-code#9026).
   # stdout/stderr discarded — analysis uses transcripts (ADR-0005, #347).
   (
     cd "$worktree" && \
     unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
     source .cekernel-env && \
-    exec claude -p --agent "$agent_name" "$prompt"
+    cekernel_bare_prepare "$worktree" && \
+    exec claude ${CEKERNEL_BARE_FLAGS[@]+"${CEKERNEL_BARE_FLAGS[@]}"} -p --agent "$agent_name" "$prompt"
   ) >/dev/null 2>&1 &
   local pid=$!
 

--- a/scripts/shared/bare-mode.sh
+++ b/scripts/shared/bare-mode.sh
@@ -14,6 +14,9 @@
 # Output:
 #   CEKERNEL_BARE_FLAGS (array) — flags to inject before the prompt.
 #                                 Empty when CEKERNEL_USE_BARE is unset/0.
+#                                 Consumers must expand with the bash 3.2-safe
+#                                 form: ${CEKERNEL_BARE_FLAGS[@]+"${CEKERNEL_BARE_FLAGS[@]}"}
+#                                 (plain "${arr[@]}" fails under `set -u` when empty).
 #
 # Environment:
 #   CEKERNEL_USE_BARE — "1" to enable; anything else (or unset) keeps the
@@ -21,16 +24,34 @@
 #
 # Auth note:
 #   --bare does not read OAuth/keychain. ANTHROPIC_API_KEY or apiKeyHelper
-#   (via --settings) is required when CEKERNEL_USE_BARE=1.
+#   (via --settings) is required when CEKERNEL_USE_BARE=1. cekernel_bare_prepare
+#   auto-disables bare mode (with a stderr warning) when neither is configured,
+#   so the caller falls back to the existing `claude -p` behavior instead of
+#   spawning a Worker that immediately dies on auth failure.
 
 cekernel_use_bare() {
   [[ "${CEKERNEL_USE_BARE:-0}" == "1" ]]
+}
+
+# cekernel_bare_preflight — exit 0 if --bare is safe to use, exit 1 otherwise.
+# Currently checks only for ANTHROPIC_API_KEY (apiKeyHelper detection would
+# require parsing --settings, which the helper does not own).
+cekernel_bare_preflight() {
+  if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    return 0
+  fi
+  return 1
 }
 
 cekernel_bare_prepare() {
   CEKERNEL_BARE_FLAGS=()
 
   cekernel_use_bare || return 0
+
+  if ! cekernel_bare_preflight; then
+    echo "cekernel: CEKERNEL_USE_BARE=1 but ANTHROPIC_API_KEY is unset; falling back to standard -p mode" >&2
+    return 0
+  fi
 
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"

--- a/scripts/shared/bare-mode.sh
+++ b/scripts/shared/bare-mode.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# bare-mode.sh — Build `claude --bare` flag set for spawn paths
+#
+# Usage:
+#   source bare-mode.sh
+#   cekernel_bare_prepare [worktree_root]
+#   exec claude "${CEKERNEL_BARE_FLAGS[@]}" -p --agent "$name" "$prompt"
+#
+# Functions:
+#   cekernel_use_bare        — exit 0 if CEKERNEL_USE_BARE=1, else exit 1
+#   cekernel_bare_prepare    — populate global CEKERNEL_BARE_FLAGS array
+#                              with the flags required when --bare is enabled
+#
+# Output:
+#   CEKERNEL_BARE_FLAGS (array) — flags to inject before the prompt.
+#                                 Empty when CEKERNEL_USE_BARE is unset/0.
+#
+# Environment:
+#   CEKERNEL_USE_BARE — "1" to enable; anything else (or unset) keeps the
+#                       existing `claude -p` behavior (default: 0).
+#
+# Auth note:
+#   --bare does not read OAuth/keychain. ANTHROPIC_API_KEY or apiKeyHelper
+#   (via --settings) is required when CEKERNEL_USE_BARE=1.
+
+cekernel_use_bare() {
+  [[ "${CEKERNEL_USE_BARE:-0}" == "1" ]]
+}
+
+cekernel_bare_prepare() {
+  CEKERNEL_BARE_FLAGS=()
+
+  cekernel_use_bare || return 0
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
+  local plugin_root
+  plugin_root="$(cd "${script_dir}/../.." && pwd)"
+
+  CEKERNEL_BARE_FLAGS=(--bare --plugin-dir "$plugin_root")
+
+  local worktree="${1:-}"
+  if [[ -n "$worktree" ]]; then
+    CEKERNEL_BARE_FLAGS+=(--add-dir "$worktree")
+  fi
+}

--- a/tests/shared/test-bare-mode.sh
+++ b/tests/shared/test-bare-mode.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# test-bare-mode.sh — Tests for bare-mode.sh
+#
+# Verifies that cekernel_bare_prepare populates CEKERNEL_BARE_FLAGS with
+# the correct flag set based on CEKERNEL_USE_BARE.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BARE_SCRIPT="${CEKERNEL_DIR}/scripts/shared/bare-mode.sh"
+
+echo "test: bare-mode.sh"
+
+# ── Test 1: file exists ──
+assert_file_exists "bare-mode.sh exists" "$BARE_SCRIPT"
+
+# ── Test 2: disabled by default (env unset) → no flags ──
+RESULT=$(
+  unset CEKERNEL_USE_BARE
+  CEKERNEL_BARE_FLAGS=("initial")
+  source "$BARE_SCRIPT"
+  cekernel_bare_prepare
+  echo "${#CEKERNEL_BARE_FLAGS[@]}"
+)
+assert_eq "CEKERNEL_USE_BARE unset → empty flags" "0" "$RESULT"
+
+# ── Test 3: CEKERNEL_USE_BARE=0 → no flags ──
+RESULT=$(
+  export CEKERNEL_USE_BARE=0
+  CEKERNEL_BARE_FLAGS=("initial")
+  source "$BARE_SCRIPT"
+  cekernel_bare_prepare
+  echo "${#CEKERNEL_BARE_FLAGS[@]}"
+)
+assert_eq "CEKERNEL_USE_BARE=0 → empty flags" "0" "$RESULT"
+
+# ── Test 4: CEKERNEL_USE_BARE=1 (no worktree arg) → --bare --plugin-dir <root> ──
+RESULT=$(
+  export CEKERNEL_USE_BARE=1
+  source "$BARE_SCRIPT"
+  cekernel_bare_prepare
+  printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
+)
+EXPECTED="--bare
+--plugin-dir
+${CEKERNEL_DIR}"
+assert_eq "CEKERNEL_USE_BARE=1 → bare + plugin-dir" "$EXPECTED" "$RESULT"
+
+# ── Test 5: CEKERNEL_USE_BARE=1 with worktree arg → adds --add-dir ──
+TMP_WORKTREE="$(mktemp -d)"
+RESULT=$(
+  export CEKERNEL_USE_BARE=1
+  source "$BARE_SCRIPT"
+  cekernel_bare_prepare "$TMP_WORKTREE"
+  printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
+)
+EXPECTED="--bare
+--plugin-dir
+${CEKERNEL_DIR}
+--add-dir
+${TMP_WORKTREE}"
+assert_eq "worktree arg → adds --add-dir" "$EXPECTED" "$RESULT"
+rm -rf "$TMP_WORKTREE"
+
+# ── Test 6: cekernel_use_bare exit code ──
+EXIT=$(
+  unset CEKERNEL_USE_BARE
+  source "$BARE_SCRIPT"
+  cekernel_use_bare && echo enabled || echo disabled
+)
+assert_eq "cekernel_use_bare returns disabled when unset" "disabled" "$EXIT"
+
+EXIT=$(
+  export CEKERNEL_USE_BARE=1
+  source "$BARE_SCRIPT"
+  cekernel_use_bare && echo enabled || echo disabled
+)
+assert_eq "cekernel_use_bare returns enabled when set to 1" "enabled" "$EXIT"
+
+report_results

--- a/tests/shared/test-bare-mode.sh
+++ b/tests/shared/test-bare-mode.sh
@@ -39,6 +39,7 @@ assert_eq "CEKERNEL_USE_BARE=0 → empty flags" "0" "$RESULT"
 # ── Test 4: CEKERNEL_USE_BARE=1 (no worktree arg) → --bare --plugin-dir <root> ──
 RESULT=$(
   export CEKERNEL_USE_BARE=1
+  export ANTHROPIC_API_KEY=test-key
   source "$BARE_SCRIPT"
   cekernel_bare_prepare
   printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
@@ -52,6 +53,7 @@ assert_eq "CEKERNEL_USE_BARE=1 → bare + plugin-dir" "$EXPECTED" "$RESULT"
 TMP_WORKTREE="$(mktemp -d)"
 RESULT=$(
   export CEKERNEL_USE_BARE=1
+  export ANTHROPIC_API_KEY=test-key
   source "$BARE_SCRIPT"
   cekernel_bare_prepare "$TMP_WORKTREE"
   printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
@@ -78,5 +80,46 @@ EXIT=$(
   cekernel_use_bare && echo enabled || echo disabled
 )
 assert_eq "cekernel_use_bare returns enabled when set to 1" "enabled" "$EXIT"
+
+# ── Test 8: bash 3.2 + set -u safe expansion (empty case) ──
+# Plain "${arr[@]}" fails on bash 3.2 under set -u when the array is empty.
+# Verify the documented workaround form expands cleanly.
+RESULT=$(
+  unset CEKERNEL_USE_BARE
+  source "$BARE_SCRIPT"
+  cekernel_bare_prepare
+  set -u
+  printf '[%s]' ${CEKERNEL_BARE_FLAGS[@]+"${CEKERNEL_BARE_FLAGS[@]}"}
+  echo "ok"
+)
+assert_eq "empty CEKERNEL_BARE_FLAGS expands safely under set -u" "[]ok" "$RESULT"
+
+# ── Test 9: preflight passes with ANTHROPIC_API_KEY ──
+EXIT=$(
+  export ANTHROPIC_API_KEY=test-key
+  source "$BARE_SCRIPT"
+  cekernel_bare_preflight && echo ok || echo blocked
+)
+assert_eq "preflight ok when ANTHROPIC_API_KEY is set" "ok" "$EXIT"
+
+# ── Test 10: preflight blocks without ANTHROPIC_API_KEY ──
+EXIT=$(
+  unset ANTHROPIC_API_KEY
+  source "$BARE_SCRIPT"
+  cekernel_bare_preflight && echo ok || echo blocked
+)
+assert_eq "preflight blocks when ANTHROPIC_API_KEY is unset" "blocked" "$EXIT"
+
+# ── Test 11: USE_BARE=1 but no API key → auto-disable with stderr warning ──
+RESULT=$(
+  export CEKERNEL_USE_BARE=1
+  unset ANTHROPIC_API_KEY
+  source "$BARE_SCRIPT"
+  cekernel_bare_prepare 2>/tmp/cekernel-bare-warn.$$
+  echo "flags=${#CEKERNEL_BARE_FLAGS[@]}"
+)
+assert_eq "auto-disable when no API key (empty flags)" "flags=0" "$RESULT"
+WARN=$(cat /tmp/cekernel-bare-warn.$$ 2>/dev/null; rm -f /tmp/cekernel-bare-warn.$$)
+assert_match "auto-disable emits stderr warning" "ANTHROPIC_API_KEY" "$WARN"
 
 report_results


### PR DESCRIPTION
## Summary

- `scripts/shared/bare-mode.sh` を追加：`CEKERNEL_USE_BARE=1` を opt-in switch として、Worker spawn に `claude --bare --plugin-dir <root> --add-dir <worktree>` を注入する仕組み。
- `scripts/shared/backends/headless.sh` を更新し、新 helper を経由して `claude` を起動。bash 3.2 + `set -u` で空配列が安全に展開されるよう `${arr[@]+"${arr[@]}"}` 形式を使用。
- preflight チェック：`CEKERNEL_USE_BARE=1` だが `ANTHROPIC_API_KEY` 未設定の場合は stderr に警告を出して **auto-disable**（フラグなしの現状 `-p` 経路に fallback）。

`--bare` は OAuth/keychain を読まないため、現在の OAuth login user に強制すると Worker が auth エラーで即死します。本 PR は **opt-in + auto-disable** で安全側に倒し、`/cron` のような Programmatic 利用 (ANTHROPIC_API_KEY 環境) でのみ実効化される設計です。

`-p` の future default 化 (`--bare is the recommended mode for scripted and SDK calls, and will become the default for -p in a future release` — official docs) に備える Phase 0 の足場。

## 適用範囲

- ✅ `scripts/shared/backends/headless.sh`
- ⏳ `scripts/shared/runner.sh` (wezterm/tmux backend)
- ⏳ `scripts/ctl/spawn-orchestrator.sh`
- ⏳ `scripts/scheduler/wrapper.sh` (cron/at)

`runner.sh` / `spawn-orchestrator.sh` / `wrapper.sh` への展開は follow-up PR で。

## Auth について

`--bare` は OAuth/keychain を読まないため、有効化には `ANTHROPIC_API_KEY` か `apiKeyHelper`（`--settings` 経由）が必須。詳細は #532 のコメントを参照。

## Test plan

- [x] `bash tests/shared/test-bare-mode.sh` — 12/12 PASS（RED → GREEN → REFACTOR の TDD サイクル）
- [x] `bash tests/shared/test-backend-headless.sh` — 11/11 PASS（regression）
- [x] `bash tests/shared/test-backend-dispatch.sh` — 9/9 PASS（regression）
- [x] `bash tests/shared/test-backend-adapter-zsh-compat.sh` — 5/5 PASS（regression）
- [x] CI で全テストが通ること
- [x] `CEKERNEL_USE_BARE=1` + `ANTHROPIC_API_KEY=...` 環境で実 Worker spawn を行い、target repo の Worker 動作を確認（reviewer 確認時）

## 関連

- closes #532 (Phase 0/1 部分。残りの spawn 経路は follow-up issue で追跡)
- 上流 #534 (cekernel v2 / `claude --bg` 路線) との両立を意識
- #526 (Programmatic vs Interactive 課金分離) の Programmatic レーン整理に資する

🤖 Generated with [Claude Code](https://claude.com/claude-code)