### PR TITLE
docs: envs/README.md に CEKERNEL_USE_BARE auth 制約解説セクションを追加

### DIFF
--- a/envs/README.md
+++ b/envs/README.md
@@ -38,6 +38,33 @@ Auto-generated or derived. Not intended for user configuration.
 |----------|---------|---------|---------|
 | `CEKERNEL_ENV` | `default` | `load-env.sh` | Select which env profile to load |
 
+## Notes on bare mode auth
+
+`CEKERNEL_USE_BARE=true` opts the headless backend into Claude Code's `--bare`
+mode. `--bare` strips Claude Code of all interactive amenities, which has
+important authentication consequences worth calling out separately from the
+variable table.
+
+- **`--bare` does not read OAuth / keychain credentials.** Per the
+  [Claude Code CLI reference](https://docs.claude.com/en/docs/claude-code/cli-reference),
+  `--bare` runs without the interactive session that owns the OAuth token and
+  the OS keychain entries, so any auth state established by `claude login`
+  is invisible to a `--bare` invocation.
+- **An explicit API key source is mandatory.** Either set `ANTHROPIC_API_KEY`
+  in the environment, or supply a settings file with an `apiKeyHelper` via
+  `--settings <path>`. Without one of these, `--bare` will fail to
+  authenticate.
+- **Preflight auto-disables when no key is available.** cekernel's headless
+  preflight checks for a usable `ANTHROPIC_API_KEY` / `apiKeyHelper` before
+  launching. When neither is configured, it emits a warning on stderr,
+  disables `--bare` for that invocation, and falls back to the standard
+  `claude -p` path so the run still proceeds.
+- **Recommended use cases.** Enable `CEKERNEL_USE_BARE=true` from
+  programmatic-batch contexts where `ANTHROPIC_API_KEY` can be supplied
+  explicitly — typically the `/cron` and `/at` scheduled jobs, CI pipelines,
+  and other non-interactive automation. Leave it off for ordinary
+  developer-driven sessions that rely on the OAuth login.
+
 ## Profiles
 
 Env profiles are `.env` files containing coherent sets of variable assignments.


### PR DESCRIPTION
## Summary

- `envs/README.md` に "Notes on bare mode auth" セクションを追加。`CEKERNEL_USE_BARE=true` を有効化した時の認証要件を専用セクションとしてまとめた。
- 含めた 4 点:
  - `--bare` は OAuth / keychain を読まない仕様 (Claude Code 公式 docs へのリンク付き)
  - 有効化には `ANTHROPIC_API_KEY` または `apiKeyHelper` (via `--settings`) が必須
  - 未設定時は headless preflight が stderr 警告 + auto-disable して `claude -p` に fallback
  - 推奨利用シーン: `/cron`, `/at` などの programmatic batch 用途
- セクションは "Meta Variable" と "Profiles" の間に挿入し、既存テーブルとの導線を維持。

## Test plan

- [x] `envs/README.md` の差分を目視確認 (見出し / 4 項目すべて含まれる)
- [ ] CI green

closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)