### PR TITLE
test: bats-core ハーネス bootstrap + CI dual-lane

### DIFF
--- a/.github/workflows/cekernel-tests.yml
+++ b/.github/workflows/cekernel-tests.yml
@@ -36,7 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Run cekernel tests
+      - name: Install bats-core (pinned)
+        run: |
+          git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git "${RUNNER_TEMP}/bats-core"
+          echo "${RUNNER_TEMP}/bats-core/bin" >> "$GITHUB_PATH"
+      - name: Run cekernel tests (dual-lane: legacy harness + bats)
         run: bash tests/run-tests.sh
 
   # Ruleset required status check (reports success even when test is skipped)

--- a/.github/workflows/cekernel-tests.yml
+++ b/.github/workflows/cekernel-tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           git clone --depth 1 --branch v1.13.0 https://github.com/bats-core/bats-core.git "${RUNNER_TEMP}/bats-core"
           echo "${RUNNER_TEMP}/bats-core/bin" >> "$GITHUB_PATH"
-      - name: Run cekernel tests (dual-lane: legacy harness + bats)
+      - name: "Run cekernel tests (dual-lane: legacy harness + bats)"
         run: bash tests/run-tests.sh
 
   # Ruleset required status check (reports success even when test is skipped)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,19 +229,49 @@ Exception: When a change adds no executable scripts (e.g., env profile or
 skill definition changes), content-based assertions on configuration files
 are acceptable as regression guards.
 
+**Assert behavior, never emitted script text** (ADR-0017). Tests verify
+executed effects and recorded argv, not the text of generated scripts.
+Grep-testing a generated runner for strings like `exec claude -p` is the
+same anti-pattern as `.md`-grep, one layer down — it breaks on mechanism
+changes even when behavior is preserved.
+
+### Test Harness (dual-lane, ADR-0017 migration)
+
+The suite is migrating from the custom harness to [bats-core](https://bats-core.readthedocs.io/).
+`tests/run-tests.sh` runs **both lanes** during migration:
+
+1. **Legacy lane**: `tests/{category}/test-*.sh` files using `helpers.sh`
+2. **bats lane**: `tests/**/*.bats` files via `bats --recursive tests/`
+
+Local setup: `brew install bats-core` (macOS). CI pins bats-core `v1.13.0`
+via git checkout in `cekernel-tests.yml`.
+
+New tests should be written as `.bats` files. Naming: one `.bats` file per
+script under test, named after the script (e.g. `tests/shared/session-id.bats`
+for `scripts/shared/session-id.sh`). Do not add new legacy-harness
+`test-*.sh` files. `run-tests.sh` is deleted when the last legacy-harness
+file is gone.
+
+In `.bats` files, use `load '../helpers/assertions'` for the ported
+`assert_*` functions (`bats-assert` is not vendored).
+
 ### Test File Naming
 
 ```
 tests/
-├── run-tests.sh             # Test runner
-├── helpers.sh               # Assertion functions
+├── run-tests.sh             # Dual-lane test runner (legacy + bats)
+├── helpers.sh               # Assertion functions (legacy harness)
+├── helpers/
+│   └── assertions.bash      # Assertion functions (bats lane)
 ├── orchestrator/
 │   ├── test-concurrency-guard.sh
-│   └── test-{feature}.sh   # Orchestrator script tests
+│   ├── test-{feature}.sh   # Orchestrator script tests (legacy)
+│   └── {script-name}.bats  # bats tests, named after the script under test
 ├── process/
 │   └── test-{feature}.sh   # Process script tests
 ├── shared/
-│   ├── test-session-id.sh   # session-id.sh tests
+│   ├── test-session-id.sh   # session-id.sh tests (legacy)
+│   ├── session-id.bats      # session-id.sh tests (bats)
 │   └── test-{feature}.sh   # Shared helper tests
 └── scheduler/
     └── test-{feature}.sh   # Scheduler script tests
@@ -249,7 +279,11 @@ tests/
 
 ### Assertion Functions
 
-Use the functions provided by `helpers.sh`:
+In `.bats` files, `load '../helpers/assertions'` provides the same
+`assert_*` API (failures return 1 and fail the surrounding `@test`;
+bats tracks pass/fail counts, so `report_results` does not exist there).
+
+In legacy-harness files, use the functions provided by `helpers.sh`:
 
 ```bash
 assert_eq <label> <expected> <actual>

--- a/README.md
+++ b/README.md
@@ -168,11 +168,14 @@ skills/
     SKILL.md               # /unix-architect skill — ADR authoring and review
 tests/
   ctl/test-*.sh            # Control script tests (orchctl, spawn-orchestrator)
-  helpers.sh               # Assertion helpers
+  helpers.sh               # Assertion helpers (legacy harness)
+  helpers/
+    assertions.bash        # Assertion helpers (bats lane)
   orchestrator/test-*.sh   # Orchestrator script tests
-  run-tests.sh             # Test runner
+  run-tests.sh             # Dual-lane test runner (legacy test-*.sh + *.bats)
   scheduler/test-*.sh      # Scheduler script tests
   shared/test-*.sh         # Shared helper tests
+  shared/*.bats            # bats-core tests (ADR-0017 migration)
   process/test-*.sh        # Process script tests
 ```
 
@@ -187,6 +190,7 @@ tests/
 | [WezTerm](https://wezfurlong.org/wezterm/) | Worker window launch/management (wezterm backend) | No* |
 | [tmux](https://github.com/tmux/tmux) | Worker pane management (tmux backend) | No* |
 | git | Worktree creation/management | Yes |
+| [bats-core](https://bats-core.readthedocs.io/) | Test framework (development only) — `brew install bats-core`; CI pins v1.13.0 | No (dev) |
 
 \* One backend is required: headless (default), WezTerm, or tmux. Set `CEKERNEL_BACKEND` env var to select. Headless requires no terminal.
 

--- a/tests/helpers/assertions.bash
+++ b/tests/helpers/assertions.bash
@@ -1,0 +1,91 @@
+# assertions.bash — bats-core assertion helpers (ADR-0017 Decision 1)
+#
+# Port of the legacy tests/helpers.sh assert_* functions for use inside
+# bats @test blocks. bats-assert is intentionally NOT vendored; these
+# helpers plus plain bash conditionals cover current needs.
+#
+# Unlike helpers.sh, these do not count pass/fail — bats tracks results
+# per @test. On failure they print a diagnostic to stderr and return 1,
+# which fails the surrounding @test immediately (bats runs under set -e
+# semantics per test).
+#
+# Usage (in a .bats file):
+#   load ../helpers/assertions   # relative to the .bats file
+#
+# API:
+#   assert_eq <label> <expected> <actual>     — exact string equality
+#   assert_match <label> <regex> <actual>     — bash [[ =~ ]] regex match
+#   assert_file_exists <label> <path>         — path is a regular file
+#   assert_fifo_exists <label> <path>         — path is a FIFO
+#   assert_dir_exists <label> <path>          — path is a directory
+#   assert_not_exists <label> <path>          — path does not exist
+#   wait_for_file <path> [max_attempts]       — poll (0.1s) until file exists
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    return 0
+  fi
+  echo "FAIL: ${label}" >&2
+  echo "  expected: ${expected}" >&2
+  echo "  actual:   ${actual}" >&2
+  return 1
+}
+
+assert_match() {
+  local label="$1" pattern="$2" actual="$3"
+  if [[ "$actual" =~ $pattern ]]; then
+    return 0
+  fi
+  echo "FAIL: ${label}" >&2
+  echo "  pattern: ${pattern}" >&2
+  echo "  actual:  ${actual}" >&2
+  return 1
+}
+
+assert_file_exists() {
+  local label="$1" path="$2"
+  if [[ -f "$path" ]]; then
+    return 0
+  fi
+  echo "FAIL: ${label} — file not found: ${path}" >&2
+  return 1
+}
+
+assert_fifo_exists() {
+  local label="$1" path="$2"
+  if [[ -p "$path" ]]; then
+    return 0
+  fi
+  echo "FAIL: ${label} — FIFO not found: ${path}" >&2
+  return 1
+}
+
+assert_dir_exists() {
+  local label="$1" path="$2"
+  if [[ -d "$path" ]]; then
+    return 0
+  fi
+  echo "FAIL: ${label} — directory not found: ${path}" >&2
+  return 1
+}
+
+assert_not_exists() {
+  local label="$1" path="$2"
+  if [[ ! -e "$path" ]]; then
+    return 0
+  fi
+  echo "FAIL: ${label} — path should not exist: ${path}" >&2
+  return 1
+}
+
+wait_for_file() {
+  local file="$1"
+  local max_attempts="${2:-30}"
+  local i
+  for i in $(seq 1 "$max_attempts"); do
+    [[ -f "$file" ]] && return 0
+    sleep 0.1
+  done
+  return 1
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# run-tests.sh — Test runner that sequentially executes tests/{shared,orchestrator,ctl,process,scheduler}/test-*.sh
+# run-tests.sh — Dual-lane test runner (ADR-0017 migration step 1):
+#   lane 1: legacy-harness tests/{shared,orchestrator,ctl,process,scheduler}/test-*.sh
+#   lane 2: bats-core *.bats files under tests/ (requires bats; brew install bats-core)
+# This runner is deleted when the last legacy-harness test-*.sh file is gone.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,6 +40,24 @@ for category in shared orchestrator ctl process scheduler; do
     echo ""
   done
 done
+
+# ── bats lane ──
+BATS_FILE_COUNT=$(find "$SCRIPT_DIR" -name '*.bats' -type f | wc -l | tr -d ' ')
+if [[ "$BATS_FILE_COUNT" -gt 0 ]]; then
+  echo "=== bats ==="
+  echo ""
+  if ! command -v bats >/dev/null 2>&1; then
+    echo "ERROR: ${BATS_FILE_COUNT} .bats file(s) found but bats is not installed." >&2
+    echo "  Install bats-core: brew install bats-core (macOS) or see https://bats-core.readthedocs.io/" >&2
+    FAILED_FILES+=("bats (bats-core not installed)")
+  elif bats --recursive "$SCRIPT_DIR"; then
+    echo "  => OK"
+  else
+    echo "  => FAILED"
+    FAILED_FILES+=("bats")
+  fi
+  echo ""
+fi
 
 # Cleanup test runtime state directory
 if [[ "${_CEKERNEL_VAR_DIR_CREATED:-}" == "1" ]]; then

--- a/tests/shared/session-id.bats
+++ b/tests/shared/session-id.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# session-id.bats — bats-core tests for scripts/shared/session-id.sh
+#
+# First .bats file of the ADR-0017 migration (step 1: harness bootstrap).
+# Runs in the bats lane of run-tests.sh alongside the legacy harness.
+
+load '../helpers/assertions'
+
+setup() {
+  CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SESSION_SCRIPT="${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+}
+
+@test "session-id.sh generates CEKERNEL_SESSION_ID when unset" {
+  run bash -c "unset CEKERNEL_SESSION_ID CEKERNEL_IPC_DIR; source '${SESSION_SCRIPT}'; echo \"\${CEKERNEL_SESSION_ID}\""
+  assert_eq "source exits 0" "0" "$status"
+  assert_match "matches {name}-{hex8}" "^[a-z0-9._-]+-[0-9a-f]{8}$" "$output"
+}
+
+@test "session-id.sh preserves an existing CEKERNEL_SESSION_ID" {
+  run bash -c "export CEKERNEL_SESSION_ID='my-custom-session-abc12345'; unset CEKERNEL_IPC_DIR; source '${SESSION_SCRIPT}'; echo \"\${CEKERNEL_SESSION_ID}\""
+  assert_eq "existing ID preserved" "my-custom-session-abc12345" "$output"
+}
+
+@test "session-id.sh derives CEKERNEL_IPC_DIR from the session ID" {
+  local expected_var_dir="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"
+  run bash -c "export CEKERNEL_SESSION_ID='test-session-aabbccdd'; unset CEKERNEL_IPC_DIR; source '${SESSION_SCRIPT}'; echo \"\${CEKERNEL_IPC_DIR}\""
+  assert_eq "IPC dir derived" "${expected_var_dir}/ipc/test-session-aabbccdd" "$output"
+}

--- a/tests/shared/test-run-tests-dual-lane.sh
+++ b/tests/shared/test-run-tests-dual-lane.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test-run-tests-dual-lane.sh — Tests that run-tests.sh runs both lanes:
+# legacy-harness test-*.sh and bats *.bats (ADR-0017 migration step 1)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+RUN_TESTS="${SCRIPT_DIR}/../run-tests.sh"
+
+echo "test: run-tests.sh dual-lane"
+
+# ── Setup: copy run-tests.sh into a sandbox with synthetic test dirs ──
+# bats is mocked via PATH shim so the test does not require bats-core installed.
+setup_sandbox() {
+  SANDBOX="$(mktemp -d)"
+  cp "$RUN_TESTS" "${SANDBOX}/run-tests.sh"
+  mkdir -p "${SANDBOX}/shared"
+
+  # PATH shim for bats: records argv, exit code controlled by BATS_SHIM_EXIT
+  SHIM_DIR="${SANDBOX}/shim-bin"
+  mkdir -p "$SHIM_DIR"
+  cat > "${SHIM_DIR}/bats" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "${SANDBOX}/bats-argv.log"
+exit "\${BATS_SHIM_EXIT:-0}"
+EOF
+  chmod +x "${SHIM_DIR}/bats"
+}
+
+# ── Test 1: legacy lane and bats lane both run in one invocation ──
+setup_sandbox
+echo 'echo "legacy ran" > "$(dirname "$0")/../legacy-ran.txt"' > "${SANDBOX}/shared/test-legacy.sh"
+echo '@test "sample" { true; }' > "${SANDBOX}/shared/sample.bats"
+
+EXIT=0
+(
+  export PATH="${SHIM_DIR}:${PATH}"
+  bash "${SANDBOX}/run-tests.sh"
+) >/dev/null 2>&1 || EXIT=$?
+
+assert_eq "dual-lane run exits 0 when both lanes pass" "0" "$EXIT"
+assert_file_exists "legacy lane executed test-*.sh" "${SANDBOX}/legacy-ran.txt"
+assert_file_exists "bats lane invoked bats" "${SANDBOX}/bats-argv.log"
+assert_match "bats invoked against tests dir or .bats files" "(${SANDBOX}|sample\.bats)" "$(cat "${SANDBOX}/bats-argv.log" 2>/dev/null || echo '')"
+rm -rf "$SANDBOX"
+
+# ── Test 2: bats lane failure makes run-tests.sh exit non-zero ──
+setup_sandbox
+echo '@test "failing" { false; }' > "${SANDBOX}/shared/failing.bats"
+
+EXIT=0
+(
+  export PATH="${SHIM_DIR}:${PATH}"
+  export BATS_SHIM_EXIT=1
+  bash "${SANDBOX}/run-tests.sh"
+) >/dev/null 2>&1 || EXIT=$?
+
+assert_eq "bats lane failure propagates to exit code" "1" "$([[ "$EXIT" -ne 0 ]] && echo 1 || echo 0)"
+rm -rf "$SANDBOX"
+
+# ── Test 3: no .bats files → bats lane skipped, exit 0 ──
+setup_sandbox
+echo 'true' > "${SANDBOX}/shared/test-noop.sh"
+
+EXIT=0
+(
+  export PATH="${SHIM_DIR}:${PATH}"
+  bash "${SANDBOX}/run-tests.sh"
+) >/dev/null 2>&1 || EXIT=$?
+
+assert_eq "runner exits 0 with no .bats files" "0" "$EXIT"
+assert_not_exists "bats not invoked when no .bats files exist" "${SANDBOX}/bats-argv.log"
+rm -rf "$SANDBOX"
+
+# ── Test 4: .bats files exist but bats not installed → fail noisily ──
+setup_sandbox
+rm -rf "$SHIM_DIR"  # no bats shim on PATH
+echo '@test "sample" { true; }' > "${SANDBOX}/shared/sample.bats"
+
+EXIT=0
+OUTPUT=$(
+  # Hide any real bats by restricting PATH to a dir with only required tools
+  TOOLS_DIR="${SANDBOX}/tools-bin"
+  mkdir -p "$TOOLS_DIR"
+  for tool in bash mktemp rm find sort dirname basename cat echo; do
+    tool_path="$(command -v "$tool" 2>/dev/null)" || continue
+    ln -s "$tool_path" "${TOOLS_DIR}/${tool}" 2>/dev/null || true
+  done
+  export PATH="$TOOLS_DIR"
+  bash "${SANDBOX}/run-tests.sh" 2>&1
+) || EXIT=$?
+
+assert_eq "runner fails when .bats exist but bats missing" "1" "$([[ "$EXIT" -ne 0 ]] && echo 1 || echo 0)"
+assert_match "error message mentions bats-core install" "bats-core" "$OUTPUT"
+rm -rf "$SANDBOX"
+
+report_results

--- a/tests/shared/test-run-tests-dual-lane.sh
+++ b/tests/shared/test-run-tests-dual-lane.sh
@@ -83,7 +83,7 @@ OUTPUT=$(
   # Hide any real bats by restricting PATH to a dir with only required tools
   TOOLS_DIR="${SANDBOX}/tools-bin"
   mkdir -p "$TOOLS_DIR"
-  for tool in bash mktemp rm find sort dirname basename cat echo; do
+  for tool in bash mktemp rm find sort dirname basename cat echo wc tr; do
     tool_path="$(command -v "$tool" 2>/dev/null)" || continue
     ln -s "$tool_path" "${TOOLS_DIR}/${tool}" 2>/dev/null || true
   done


### PR DESCRIPTION
closes #543

## Summary
ADR-0017 (Accepted) Decision 1 / Migration order 1 の実装。bats-core ハーネスを bootstrap し、既存 `run-tests.sh` と併走(dual-lane)させる。**テスト意味論の変更なし** — 既存テストは無変更。

- `tests/run-tests.sh` を dual-lane 化: legacy `test-*.sh` レーン実行後に `bats --recursive tests/` で `*.bats` レーンを実行。`.bats` が存在するのに bats 未インストールの場合は install ヒント付きで noisy に失敗(Rule of Repair)。`.bats` ゼロ件ならレーンをスキップ
- `tests/helpers/assertions.bash`: 既存 `helpers.sh` の `assert_*` を bats 用に移植(fail 時 return 1、カウンタなし)。ADR の決定通り bats-assert は vendoring しない
- サンプル `.bats`: `tests/shared/session-id.bats`(session-id.sh の挙動検証、bats レーンで実行)
- CI (`cekernel-tests.yml`): bats-core **v1.13.0** を pinned git checkout で導入し、dual-lane runner を実行
- CLAUDE.md Testing 節: dual-lane ハーネス、`.bats` 命名規則(script under test と同名)、「assert behavior, never emitted script text」ルール、`brew install bats-core` を追記。README に dev dependency 追加

TDD: dual-lane 動作は `tests/shared/test-run-tests-dual-lane.sh` で RED → GREEN → REFACTOR で実装。

## Test Plan
- [x] `bash tests/shared/test-run-tests-dual-lane.sh` — dual-lane 動作(bats 起動、失敗伝播、スキップ、bats 欠如時の noisy fail)
- [x] `bash tests/shared/test-run-tests-isolation.sh` — 既存 runner テスト回帰なし
- [x] `bash tests/shared/test-session-id.sh` / `bats tests/shared/session-id.bats` — ローカル macOS で両レーン通過(bats 1.13.0)
- [ ] CI (ubuntu) で dual-lane 通過