### PR TITLE
feat: default all spawn paths to --bare explicit context (ADR-0016 Phase 0)

### DIFF
--- a/envs/README.md
+++ b/envs/README.md
@@ -19,6 +19,7 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_REVIEW_MAX_RETRIES` | `2` | Positive integer | Orchestrator | Max cycles of Reviewer reject → Worker re-implement. Escalates to human when exceeded |
 | `CEKERNEL_NOTIFY_MACOS_ACTION` | `none` | `none`, `open`, `pbcopy` | `desktop-notify-backend/macos.sh` | macOS notification URL action: `none` = notify only, `open` = open URL in browser, `pbcopy` = copy URL to clipboard |
 | `CEKERNEL_VAR_DIR` | `~/.local/var/cekernel` | Directory path | `registry.sh`, `wrapper.sh` | Runtime state directory (locks, logs, runners, registry) |
+| `CEKERNEL_CLAUDE_SETTINGS` | (unset) | Path to a Claude settings JSON | `bare-mode.sh` (all spawn paths) | Passed to `claude` via `--settings`. All spawns run in `--bare` mode (ADR-0016 Phase 0), which never reads OAuth/keychain — auth is strictly `ANTHROPIC_API_KEY` or `apiKeyHelper` via this settings file. **Required for cron/at scheduled jobs**, where exported env vars do not reach the generated runner (the path is captured at schedule time). Spawn fails fast when neither auth source is available |
 
 ## Internal Variables
 

--- a/scripts/ctl/spawn-orchestrator.sh
+++ b/scripts/ctl/spawn-orchestrator.sh
@@ -23,9 +23,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
 source "${SCRIPT_DIR}/../shared/load-env.sh"
 source "${SCRIPT_DIR}/../shared/session-id.sh"
 source "${SCRIPT_DIR}/../shared/resolve-repo-root.sh"
+source "${SCRIPT_DIR}/../shared/bare-mode.sh"
 
 PROMPT="${1:?Usage: spawn-orchestrator.sh <prompt>}"
 REPO_ROOT="$(resolve_repo_root)"
+
+# --bare requires an explicit auth path — fail before spawning an
+# Orchestrator that would die on auth (Rule of Repair, ADR-0016 Phase 0).
+bare_mode_preflight
+bare_mode_prepare "$REPO_ROOT"
 
 # ── Resolve agent name ──
 AGENT_NAME="${CEKERNEL_AGENT_ORCHESTRATOR:-orchestrator}"
@@ -38,6 +44,8 @@ CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
 # ── Launch Orchestrator as background process ──
 # Unset Claude Code session markers to avoid nested-session detection.
 # Export cekernel env vars so the Orchestrator's Bash tool calls inherit them.
+# --bare with explicit context: --plugin-dir (agents/skills) +
+# --add-dir (repo-root CLAUDE.md). ADR-0016 Phase 0.
 # stdout/stderr discarded — analysis uses transcripts.
 (
   cd "$REPO_ROOT" && \
@@ -46,7 +54,7 @@ CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
   export CEKERNEL_IPC_DIR="${CEKERNEL_IPC_DIR}" && \
   export CEKERNEL_ENV="${CEKERNEL_ENV}" && \
   export PATH="${CEKERNEL_ORCHESTRATOR_SCRIPTS}:${CEKERNEL_PROCESS_SCRIPTS}:${CEKERNEL_SHARED_SCRIPTS}:${PATH}" && \
-  exec claude -p --agent "$AGENT_NAME" "$PROMPT"
+  exec claude -p "${CEKERNEL_BARE_FLAGS[@]}" --agent "$AGENT_NAME" "$PROMPT"
 ) >/dev/null 2>&1 &
 PID=$!
 

--- a/scripts/scheduler/wrapper.sh
+++ b/scripts/scheduler/wrapper.sh
@@ -11,6 +11,7 @@
 
 _WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_WRAPPER_DIR}/../shared/load-env.sh"
+source "${_WRAPPER_DIR}/../shared/bare-mode.sh"
 
 CEKERNEL_VAR_DIR="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"
 
@@ -27,6 +28,15 @@ schedule_generate_wrapper() {
   local runner_file="${runner_dir}/${id}.sh"
   local syslog_file="${CEKERNEL_VAR_DIR}/logs/schedule.log"
   local run_log="${CEKERNEL_VAR_DIR}/logs/${id}.run.log"
+
+  # --bare requires an explicit auth path — fail at schedule time instead of
+  # generating a runner doomed to die on auth (Rule of Repair, ADR-0016
+  # Phase 0). Exported env vars do NOT reach the cron/at runtime, so use
+  # CEKERNEL_CLAUDE_SETTINGS (captured below as a --settings path with
+  # apiKeyHelper) for scheduled jobs.
+  bare_mode_preflight || return 1
+  local bare_flags
+  bare_flags="$(bare_mode_flags "$repo")"
 
   cat > "$runner_file" <<RUNNER_EOF
 #!/usr/bin/env bash
@@ -49,7 +59,7 @@ source "\${CEKERNEL_DIR}/scripts/shared/desktop-notify.sh"
 echo "\$(date '+%Y-%m-%dT%H:%M:%S%z') cekernel[\$ID]: START prompt=\"${prompt}\" repo=\"${repo}\"" >> "\$SYSLOG_FILE"
 SECONDS=0
 
-if cd "${repo}" && claude -p \\
+if cd "${repo}" && claude -p ${bare_flags} \\
   "${prompt}" >> "\$RUN_LOG" 2>&1; then
   STATUS=0
 else

--- a/scripts/shared/backends/headless.sh
+++ b/scripts/shared/backends/headless.sh
@@ -10,6 +10,10 @@
 # Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains PID (numeric).
 # Process group: setsid creates a new process group for clean termination.
 
+# ── Dependencies ──
+_HEADLESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
+source "${_HEADLESS_DIR}/../bare-mode.sh"
+
 # ── External API ──
 
 backend_available() {
@@ -27,19 +31,25 @@ backend_spawn_worker() {
   local prompt="$4"
   local agent_name="$5"
 
+  # --bare requires an explicit auth path — fail before spawning a Worker
+  # that would die on auth (Rule of Repair, ADR-0016 Phase 0).
+  bare_mode_preflight || return 1
+  bare_mode_prepare "$worktree"
+
   # Launch Worker as a background process.
   # Bash creates a new process group for background jobs automatically,
   # so kill -- -$PID can terminate the entire group.
   # Source .cekernel-env to propagate PATH and env vars (SESSION_ID, IPC_DIR, ENV).
   # Unset Claude Code session markers to avoid nested-session detection.
-  # Use -p (print mode) for non-TTY execution.
+  # Use -p (print mode) for non-TTY execution, in --bare mode with explicit
+  # context: --plugin-dir (agents/skills) + --add-dir (worktree CLAUDE.md).
   # NOTE: -p may hang without TTY due to upstream bug (claude-code#9026).
   # stdout/stderr discarded — analysis uses transcripts (ADR-0005, #347).
   (
     cd "$worktree" && \
     unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
     source .cekernel-env && \
-    exec claude -p --agent "$agent_name" "$prompt"
+    exec claude -p "${CEKERNEL_BARE_FLAGS[@]}" --agent "$agent_name" "$prompt"
   ) >/dev/null 2>&1 &
   local pid=$!
 

--- a/scripts/shared/bare-mode.sh
+++ b/scripts/shared/bare-mode.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# bare-mode.sh — Explicit-context flag builder for `claude -p --bare` spawns
+#
+# cekernel 2.0 spawns every `claude -p` process in --bare mode (ADR-0016
+# Phase 0, #532). --bare skips hooks, plugin sync, auto-memory, keychain
+# reads, and CLAUDE.md auto-discovery, so all required context is injected
+# explicitly:
+#
+#   --bare                       minimal mode (future default for -p)
+#   --plugin-dir <cekernel-root> plugin agents/skills resolution
+#   --add-dir <context-dir>      CLAUDE.md discovery for worktree/repo root
+#   --settings <path>            only when CEKERNEL_CLAUDE_SETTINGS is set
+#                                (auth via apiKeyHelper, extra settings)
+#
+# Usage:
+#   source bare-mode.sh
+#   bare_mode_preflight || return 1
+#   bare_mode_prepare "$worktree"
+#   exec claude -p "${CEKERNEL_BARE_FLAGS[@]}" --agent "$name" "$prompt"
+#
+# Functions:
+#   bare_mode_prepare [context-dir]
+#     Populates the global CEKERNEL_BARE_FLAGS array (never empty).
+#   bare_mode_flags [context-dir]
+#     Echoes the flags as a single shell-quoted string, safe to embed in
+#     generated runner scripts (runner.sh, wrapper.sh heredocs).
+#   bare_mode_preflight
+#     Returns 1 with an actionable stderr message when no --bare-compatible
+#     auth path exists. --bare never reads OAuth/keychain — auth is strictly
+#     ANTHROPIC_API_KEY or apiKeyHelper via --settings. Fail at spawn time
+#     instead of launching a process that dies on auth (Rule of Repair).
+#
+# Environment:
+#   CEKERNEL_CLAUDE_SETTINGS — optional path to a Claude settings JSON,
+#                              passed via --settings. Required for auth in
+#                              environments without ANTHROPIC_API_KEY
+#                              (e.g. cron/at, where exported vars don't reach
+#                              the generated runner).
+
+# Resolve plugin root at source time (zsh fallback: sourced by backends).
+_BARE_MODE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
+_BARE_MODE_PLUGIN_ROOT="$(cd "${_BARE_MODE_DIR}/../.." && pwd)"
+
+# bare_mode_prepare [context-dir]
+# Populates CEKERNEL_BARE_FLAGS (global array).
+bare_mode_prepare() {
+  local context_dir="${1:-}"
+
+  CEKERNEL_BARE_FLAGS=(--bare --plugin-dir "$_BARE_MODE_PLUGIN_ROOT")
+
+  if [[ -n "$context_dir" ]]; then
+    CEKERNEL_BARE_FLAGS+=(--add-dir "$context_dir")
+  fi
+
+  if [[ -n "${CEKERNEL_CLAUDE_SETTINGS:-}" ]]; then
+    CEKERNEL_BARE_FLAGS+=(--settings "$CEKERNEL_CLAUDE_SETTINGS")
+  fi
+}
+
+# bare_mode_flags [context-dir]
+# Echoes the flag set as one shell-quoted line for heredoc embedding.
+bare_mode_flags() {
+  bare_mode_prepare "${1:-}"
+
+  local out="" flag
+  for flag in "${CEKERNEL_BARE_FLAGS[@]}"; do
+    out+="$(printf '%q' "$flag") "
+  done
+  printf '%s' "${out% }"
+}
+
+# bare_mode_preflight
+# exit 0 when a --bare-compatible auth path exists, exit 1 otherwise.
+bare_mode_preflight() {
+  if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${CEKERNEL_CLAUDE_SETTINGS:-}" ]]; then
+    if [[ ! -f "$CEKERNEL_CLAUDE_SETTINGS" ]]; then
+      echo "Error: CEKERNEL_CLAUDE_SETTINGS points to a missing file: ${CEKERNEL_CLAUDE_SETTINGS}" >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  cat >&2 <<'EOF'
+Error: no --bare-compatible auth available.
+claude --bare never reads OAuth/keychain. Set one of:
+  - ANTHROPIC_API_KEY  (exported in the spawning environment)
+  - CEKERNEL_CLAUDE_SETTINGS  (path to a settings JSON with apiKeyHelper,
+    passed to claude via --settings; required for cron/at scheduled jobs)
+EOF
+  return 1
+}

--- a/scripts/shared/runner.sh
+++ b/scripts/shared/runner.sh
@@ -10,6 +10,10 @@
 #     Prompt is passed via file — no shell escaping needed.
 #     stdout: path to the generated runner script
 
+# ── Dependencies ──
+_RUNNER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
+source "${_RUNNER_DIR}/bare-mode.sh"
+
 # write_runner_script <issue> <worktree> <session_id> <agent_name> <prompt>
 write_runner_script() {
   local issue="${1:?Usage: write_runner_script <issue> <worktree> <session_id> <agent_name> <prompt>}"
@@ -21,11 +25,18 @@ write_runner_script() {
   local runner="${CEKERNEL_IPC_DIR}/run-${issue}.sh"
   local prompt_file="${CEKERNEL_IPC_DIR}/prompt-${issue}.txt"
 
+  # --bare requires an explicit auth path — fail before generating a runner
+  # that would die on auth (Rule of Repair, ADR-0016 Phase 0).
+  bare_mode_preflight || return 1
+  local bare_flags
+  bare_flags="$(bare_mode_flags "$worktree")"
+
   # Write prompt to file — no escaping needed
   printf '%s' "$prompt" > "$prompt_file"
 
   # Generate runner script
-  # Variables expanded at generation time: worktree, session_id, agent_name, prompt_file
+  # Variables expanded at generation time: worktree, session_id, agent_name,
+  # prompt_file, bare_flags (--bare + explicit context, ADR-0016 Phase 0)
   # Variables expanded at runtime: PROMPT (read from file)
   cat > "$runner" <<RUNNER
 #!/usr/bin/env bash
@@ -35,7 +46,7 @@ source .cekernel-env
 
 PROMPT=\$(cat '${prompt_file}')
 
-exec claude -p --agent ${agent_name} "\$PROMPT"
+exec claude -p ${bare_flags} --agent ${agent_name} "\$PROMPT"
 RUNNER
   chmod +x "$runner"
 

--- a/tests/ctl/test-spawn-orchestrator.sh
+++ b/tests/ctl/test-spawn-orchestrator.sh
@@ -35,12 +35,21 @@ else
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-# ── Test 3: launches claude -p --agent ──
-if echo "$CONTENT" | grep -q 'claude -p --agent'; then
-  echo "  PASS: launches claude -p --agent"
+# ── Test 3: launches claude -p with explicit --bare context (ADR-0016 Phase 0) ──
+if echo "$CONTENT" | grep -q 'claude -p' && echo "$CONTENT" | grep -q 'CEKERNEL_BARE_FLAGS'; then
+  echo "  PASS: launches claude -p with CEKERNEL_BARE_FLAGS"
   TESTS_PASSED=$((TESTS_PASSED + 1))
 else
-  echo "  FAIL: should launch claude -p --agent"
+  echo "  FAIL: should launch claude -p with CEKERNEL_BARE_FLAGS"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── Test 3b: sources bare-mode.sh and runs auth preflight ──
+if echo "$CONTENT" | grep -q 'bare-mode\.sh' && echo "$CONTENT" | grep -q 'bare_mode_preflight'; then
+  echo "  PASS: sources bare-mode.sh and runs bare_mode_preflight"
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+  echo "  FAIL: should source bare-mode.sh and run bare_mode_preflight"
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 

--- a/tests/orchestrator/test-agent-name-resolution.sh
+++ b/tests/orchestrator/test-agent-name-resolution.sh
@@ -14,6 +14,9 @@ echo "test: agent-name-resolution"
 
 # ── Test session ──
 export CEKERNEL_SESSION_ID="test-agent-name-001"
+# --bare preflight requires an auth path (never reads OAuth/keychain)
+export ANTHROPIC_API_KEY="test-key-bare"
+unset CEKERNEL_CLAUDE_SETTINGS
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
 rm -rf "$CEKERNEL_IPC_DIR"
 mkdir -p "$CEKERNEL_IPC_DIR"

--- a/tests/scheduler/test-at-launchd.sh
+++ b/tests/scheduler/test-at-launchd.sh
@@ -15,6 +15,9 @@ setup() {
   export CEKERNEL_LAUNCHD_DIR="$(mktemp -d)"
   mkdir -p "${CEKERNEL_VAR_DIR}/runners" "${CEKERNEL_VAR_DIR}/logs"
   echo '[]' > "${CEKERNEL_VAR_DIR}/schedules.json"
+  # --bare preflight requires an auth path (never reads OAuth/keychain)
+  export ANTHROPIC_API_KEY="test-key-bare"
+  unset CEKERNEL_CLAUDE_SETTINGS
 
   source "${CEKERNEL_DIR}/scripts/scheduler/at-backends/launchd.sh"
   source "${CEKERNEL_DIR}/scripts/scheduler/wrapper.sh"

--- a/tests/scheduler/test-at.sh
+++ b/tests/scheduler/test-at.sh
@@ -13,6 +13,9 @@ echo "test: scheduler/at.sh"
 # ── Setup: isolated environment ──
 setup() {
   export CEKERNEL_VAR_DIR="$(mktemp -d)"
+  # --bare preflight requires an auth path (never reads OAuth/keychain)
+  export ANTHROPIC_API_KEY="test-key-bare"
+  unset CEKERNEL_CLAUDE_SETTINGS
   mkdir -p "${CEKERNEL_VAR_DIR}/runners" "${CEKERNEL_VAR_DIR}/logs"
   echo '[]' > "${CEKERNEL_VAR_DIR}/schedules.json"
 

--- a/tests/scheduler/test-cron.sh
+++ b/tests/scheduler/test-cron.sh
@@ -13,6 +13,9 @@ echo "test: scheduler/cron.sh"
 # ── Setup: isolated environment ──
 setup() {
   export CEKERNEL_VAR_DIR="$(mktemp -d)"
+  # --bare preflight requires an auth path (never reads OAuth/keychain)
+  export ANTHROPIC_API_KEY="test-key-bare"
+  unset CEKERNEL_CLAUDE_SETTINGS
   mkdir -p "${CEKERNEL_VAR_DIR}/runners" "${CEKERNEL_VAR_DIR}/logs"
   echo '[]' > "${CEKERNEL_VAR_DIR}/schedules.json"
 

--- a/tests/scheduler/test-wrapper.sh
+++ b/tests/scheduler/test-wrapper.sh
@@ -15,6 +15,9 @@ setup() {
   export CEKERNEL_VAR_DIR="$(mktemp -d)"
   mkdir -p "${CEKERNEL_VAR_DIR}/runners"
   echo '[]' > "${CEKERNEL_VAR_DIR}/schedules.json"
+  # --bare preflight requires an auth path (never reads OAuth/keychain)
+  export ANTHROPIC_API_KEY="test-key-bare"
+  unset CEKERNEL_CLAUDE_SETTINGS
   source "$WRAPPER_SCRIPT"
 }
 
@@ -167,6 +170,40 @@ schedule_generate_wrapper "$TEST_ID" "$TEST_REPO" "$TEST_PATH" "$TEST_PROMPT"
 RUNNER="${CEKERNEL_VAR_DIR}/runners/${TEST_ID}.sh"
 CONTENT=$(cat "$RUNNER")
 assert_match "calls schedule_registry_update_status" "schedule_registry_update_status" "$CONTENT"
+teardown
+
+# ── Test 17: claude is invoked with explicit --bare context (ADR-0016 Phase 0) ──
+setup
+schedule_generate_wrapper "$TEST_ID" "$TEST_REPO" "$TEST_PATH" "$TEST_PROMPT"
+RUNNER="${CEKERNEL_VAR_DIR}/runners/${TEST_ID}.sh"
+CONTENT=$(cat "$RUNNER")
+assert_match "claude invoked with --bare" "claude -p --bare" "$CONTENT"
+assert_match "plugin dir embedded" "--plugin-dir ${CEKERNEL_DIR}" "$CONTENT"
+assert_match "repo embedded as --add-dir" "--add-dir ${TEST_REPO}" "$CONTENT"
+teardown
+
+# ── Test 18: CEKERNEL_CLAUDE_SETTINGS at generation time → --settings embedded ──
+# Required for cron/at: exported env vars don't reach the generated runner,
+# so auth must travel as a captured --settings path (apiKeyHelper).
+setup
+SETTINGS_FILE="${CEKERNEL_VAR_DIR}/claude-settings.json"
+echo '{}' > "$SETTINGS_FILE"
+export CEKERNEL_CLAUDE_SETTINGS="$SETTINGS_FILE"
+schedule_generate_wrapper "$TEST_ID" "$TEST_REPO" "$TEST_PATH" "$TEST_PROMPT"
+RUNNER="${CEKERNEL_VAR_DIR}/runners/${TEST_ID}.sh"
+CONTENT=$(cat "$RUNNER")
+assert_match "--settings embedded in runner" "--settings ${SETTINGS_FILE}" "$CONTENT"
+unset CEKERNEL_CLAUDE_SETTINGS
+teardown
+
+# ── Test 19: generation fails fast without --bare-compatible auth ──
+setup
+EXIT_CODE=0
+(
+  unset ANTHROPIC_API_KEY CEKERNEL_CLAUDE_SETTINGS
+  schedule_generate_wrapper "$TEST_ID" "$TEST_REPO" "$TEST_PATH" "$TEST_PROMPT" 2>/dev/null
+) || EXIT_CODE=$?
+assert_eq "generation fails without bare auth" "1" "$EXIT_CODE"
 teardown
 
 report_results

--- a/tests/shared/test-backend-headless.sh
+++ b/tests/shared/test-backend-headless.sh
@@ -14,6 +14,9 @@ echo "test: backend-headless"
 
 # ── Test session ──
 export CEKERNEL_SESSION_ID="test-headless-backend-001"
+# --bare preflight requires an auth path (never reads OAuth/keychain)
+export ANTHROPIC_API_KEY="test-key-bare"
+unset CEKERNEL_CLAUDE_SETTINGS
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
 rm -rf "$CEKERNEL_IPC_DIR"
 mkdir -p "$CEKERNEL_IPC_DIR"
@@ -156,6 +159,37 @@ fi
 
 backend_kill_worker "$ISSUE_ENV" 2>/dev/null || true
 sleep 0.2
+
+# ── Test 11: claude is launched with explicit --bare context (ADR-0016 Phase 0) ──
+# Replace the mock with an args-recording version and inspect the argv.
+ARGS_FILE="${TEST_TMP}/claude-args.txt"
+cat > "${MOCK_BIN}/claude" <<MOCK_SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > '${ARGS_FILE}'
+MOCK_SCRIPT
+chmod +x "${MOCK_BIN}/claude"
+
+ISSUE_BARE="504"
+backend_spawn_worker "$ISSUE_BARE" "worker" "$WORKTREE" "test prompt" "worker"
+if wait_for_file "$ARGS_FILE"; then
+  ARGS_CONTENT=$(cat "$ARGS_FILE")
+  assert_match "claude argv includes --bare" "--bare" "$ARGS_CONTENT"
+  assert_match "claude argv includes --plugin-dir cekernel root" "--plugin-dir" "$ARGS_CONTENT"
+  assert_match "claude argv includes --add-dir worktree" "--add-dir" "$ARGS_CONTENT"
+else
+  echo "  FAIL: mock claude was not invoked (no args file)"
+  TESTS_FAILED=$((TESTS_FAILED + 3))
+fi
+backend_kill_worker "$ISSUE_BARE" 2>/dev/null || true
+
+# ── Test 12: spawn fails fast without --bare-compatible auth ──
+EXIT_CODE=0
+(
+  unset ANTHROPIC_API_KEY CEKERNEL_CLAUDE_SETTINGS
+  backend_spawn_worker "505" "worker" "$WORKTREE" "test prompt" "worker" 2>/dev/null
+) || EXIT_CODE=$?
+assert_eq "spawn fails without bare auth" "1" "$EXIT_CODE"
+assert_not_exists "no handle file created without auth" "${CEKERNEL_IPC_DIR}/handle-505.worker"
 
 # ── Restore PATH ──
 PATH="$OLD_PATH"

--- a/tests/shared/test-backend-tmux.sh
+++ b/tests/shared/test-backend-tmux.sh
@@ -13,6 +13,9 @@ echo "test: backend-tmux"
 
 # ── Test session ──
 export CEKERNEL_SESSION_ID="test-tmux-backend-002"
+# --bare preflight requires an auth path (never reads OAuth/keychain)
+export ANTHROPIC_API_KEY="test-key-bare"
+unset CEKERNEL_CLAUDE_SETTINGS
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
 rm -rf "$CEKERNEL_IPC_DIR"
 mkdir -p "$CEKERNEL_IPC_DIR"

--- a/tests/shared/test-backend-tmux.sh
+++ b/tests/shared/test-backend-tmux.sh
@@ -210,7 +210,7 @@ tmux() {
 export -f tmux
 backend_spawn_worker "412" "worker" "$WORKTREE" "test prompt" "worker"
 RUNNER_CONTENT=$(cat "${CEKERNEL_IPC_DIR}/run-412.sh")
-assert_match "runner script uses exec claude" "exec claude -p --agent" "$RUNNER_CONTENT"
+assert_match "runner script uses exec claude" "exec claude -p --bare" "$RUNNER_CONTENT"
 if echo "$RUNNER_CONTENT" | grep -q "exec script "; then
   echo "  FAIL: runner script should not use script command"
   TESTS_FAILED=$((TESTS_FAILED + 1))

--- a/tests/shared/test-backend-wezterm.sh
+++ b/tests/shared/test-backend-wezterm.sh
@@ -14,6 +14,9 @@ echo "test: backend-wezterm"
 
 # ── Test session ──
 export CEKERNEL_SESSION_ID="test-wezterm-backend-001"
+# --bare preflight requires an auth path (never reads OAuth/keychain)
+export ANTHROPIC_API_KEY="test-key-bare"
+unset CEKERNEL_CLAUDE_SETTINGS
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
 rm -rf "$CEKERNEL_IPC_DIR"
 mkdir -p "$CEKERNEL_IPC_DIR"

--- a/tests/shared/test-backend-wezterm.sh
+++ b/tests/shared/test-backend-wezterm.sh
@@ -341,7 +341,7 @@ assert_match "command field references runner script" "run-${ISSUE}.sh" "$COMMAN
 
 # Runner script should use exec claude directly (no script command)
 RUNNER_CONTENT=$(cat "${CEKERNEL_IPC_DIR}/run-${ISSUE}.sh")
-assert_match "runner script uses exec claude" "exec claude -p --agent" "$RUNNER_CONTENT"
+assert_match "runner script uses exec claude" "exec claude -p --bare" "$RUNNER_CONTENT"
 assert_match "runner script contains unset CLAUDECODE" "unset CLAUDECODE" "$RUNNER_CONTENT"
 if echo "$RUNNER_CONTENT" | grep -q "exec script "; then
   echo "  FAIL: runner script should not use script command"

--- a/tests/shared/test-bare-mode.sh
+++ b/tests/shared/test-bare-mode.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-bare-mode.sh — Tests for bare-mode.sh (ADR-0016 Phase 0)
+#
+# Verifies the explicit-context flag builder for `claude -p --bare` spawns:
+#   bare_mode_prepare   — populates CEKERNEL_BARE_FLAGS array
+#   bare_mode_flags     — emits shell-quoted flag string for generated runners
+#   bare_mode_preflight — fails noisily when no --bare-compatible auth exists
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../helpers.sh"
+
+CEKERNEL_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BARE_SCRIPT="${CEKERNEL_DIR}/scripts/shared/bare-mode.sh"
+
+echo "test: bare-mode"
+
+# ── Test 1: bare-mode.sh exists ──
+assert_file_exists "bare-mode.sh exists" "$BARE_SCRIPT"
+
+# ── Test 2: bare_mode_prepare without context dir → --bare --plugin-dir <root> ──
+RESULT=$(
+  unset CEKERNEL_CLAUDE_SETTINGS
+  source "$BARE_SCRIPT"
+  bare_mode_prepare
+  printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
+)
+EXPECTED="--bare
+--plugin-dir
+${CEKERNEL_DIR}"
+assert_eq "prepare without context dir" "$EXPECTED" "$RESULT"
+
+# ── Test 3: bare_mode_prepare with context dir → adds --add-dir ──
+TMP_DIR="$(mktemp -d)"
+RESULT=$(
+  unset CEKERNEL_CLAUDE_SETTINGS
+  source "$BARE_SCRIPT"
+  bare_mode_prepare "$TMP_DIR"
+  printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
+)
+EXPECTED="--bare
+--plugin-dir
+${CEKERNEL_DIR}
+--add-dir
+${TMP_DIR}"
+assert_eq "prepare with context dir adds --add-dir" "$EXPECTED" "$RESULT"
+
+# ── Test 4: CEKERNEL_CLAUDE_SETTINGS set → adds --settings <path> ──
+RESULT=$(
+  export CEKERNEL_CLAUDE_SETTINGS="/tmp/my-settings.json"
+  source "$BARE_SCRIPT"
+  bare_mode_prepare "$TMP_DIR"
+  printf '%s\n' "${CEKERNEL_BARE_FLAGS[@]}"
+)
+EXPECTED="--bare
+--plugin-dir
+${CEKERNEL_DIR}
+--add-dir
+${TMP_DIR}
+--settings
+/tmp/my-settings.json"
+assert_eq "CEKERNEL_CLAUDE_SETTINGS adds --settings" "$EXPECTED" "$RESULT"
+
+# ── Test 5: bare_mode_flags emits a single-line flag string ──
+RESULT=$(
+  unset CEKERNEL_CLAUDE_SETTINGS
+  source "$BARE_SCRIPT"
+  bare_mode_flags "$TMP_DIR"
+)
+assert_match "flags string contains --bare" "--bare" "$RESULT"
+assert_match "flags string contains plugin-dir" "--plugin-dir ${CEKERNEL_DIR}" "$RESULT"
+assert_match "flags string contains add-dir" "--add-dir ${TMP_DIR}" "$RESULT"
+
+# ── Test 6: bare_mode_flags quotes paths with spaces ──
+SPACE_DIR="${TMP_DIR}/with space"
+mkdir -p "$SPACE_DIR"
+RESULT=$(
+  unset CEKERNEL_CLAUDE_SETTINGS
+  source "$BARE_SCRIPT"
+  bare_mode_flags "$SPACE_DIR"
+)
+# eval the string back into an array — the space path must survive as one word
+eval "FLAGS=($RESULT)"
+LAST_INDEX=$(( ${#FLAGS[@]} - 1 ))
+assert_eq "quoted path survives eval round-trip" "$SPACE_DIR" "${FLAGS[$LAST_INDEX]}"
+
+# ── Test 7: preflight fails when no auth path is available ──
+EXIT_CODE=0
+OUTPUT=$(
+  unset ANTHROPIC_API_KEY CEKERNEL_CLAUDE_SETTINGS
+  source "$BARE_SCRIPT"
+  bare_mode_preflight 2>&1
+) || EXIT_CODE=$?
+assert_eq "preflight fails without auth" "1" "$EXIT_CODE"
+
+# ── Test 8: preflight failure message is actionable (mentions both options) ──
+assert_match "preflight error mentions ANTHROPIC_API_KEY" "ANTHROPIC_API_KEY" "$OUTPUT"
+assert_match "preflight error mentions CEKERNEL_CLAUDE_SETTINGS" "CEKERNEL_CLAUDE_SETTINGS" "$OUTPUT"
+
+# ── Test 9: preflight passes with ANTHROPIC_API_KEY ──
+EXIT_CODE=0
+(
+  export ANTHROPIC_API_KEY="test-key"
+  unset CEKERNEL_CLAUDE_SETTINGS
+  source "$BARE_SCRIPT"
+  bare_mode_preflight
+) || EXIT_CODE=$?
+assert_eq "preflight passes with ANTHROPIC_API_KEY" "0" "$EXIT_CODE"
+
+# ── Test 10: preflight passes with CEKERNEL_CLAUDE_SETTINGS ──
+SETTINGS_FILE="${TMP_DIR}/settings.json"
+echo '{}' > "$SETTINGS_FILE"
+EXIT_CODE=0
+(
+  unset ANTHROPIC_API_KEY
+  export CEKERNEL_CLAUDE_SETTINGS="$SETTINGS_FILE"
+  source "$BARE_SCRIPT"
+  bare_mode_preflight
+) || EXIT_CODE=$?
+assert_eq "preflight passes with CEKERNEL_CLAUDE_SETTINGS" "0" "$EXIT_CODE"
+
+# ── Test 11: preflight fails when CEKERNEL_CLAUDE_SETTINGS points to missing file ──
+EXIT_CODE=0
+(
+  unset ANTHROPIC_API_KEY
+  export CEKERNEL_CLAUDE_SETTINGS="${TMP_DIR}/no-such-settings.json"
+  source "$BARE_SCRIPT"
+  bare_mode_preflight 2>/dev/null
+) || EXIT_CODE=$?
+assert_eq "preflight fails for missing settings file" "1" "$EXIT_CODE"
+
+# ── Cleanup ──
+rm -rf "$TMP_DIR"
+
+report_results

--- a/tests/shared/test-runner.sh
+++ b/tests/shared/test-runner.sh
@@ -14,6 +14,9 @@ echo "test: runner"
 
 # ── Test session ──
 export CEKERNEL_SESSION_ID="test-runner-001"
+# --bare preflight requires an auth path (never reads OAuth/keychain)
+export ANTHROPIC_API_KEY="test-key-bare"
+unset CEKERNEL_CLAUDE_SETTINGS
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
 rm -rf "$CEKERNEL_IPC_DIR"
 mkdir -p "$CEKERNEL_IPC_DIR"
@@ -80,8 +83,12 @@ else
   TESTS_PASSED=$((TESTS_PASSED + 1))
 fi
 
-# ── Test 11: Runner script uses exec claude directly ──
-assert_match "runner uses exec claude" "exec claude -p --agent" "$RUNNER_CONTENT"
+# ── Test 11: Runner script uses exec claude directly, in --bare mode ──
+assert_match "runner uses exec claude with --bare" "exec claude -p --bare" "$RUNNER_CONTENT"
+
+# ── Test 11b: Runner script injects explicit --bare context ──
+assert_match "runner passes --plugin-dir cekernel root" "--plugin-dir ${CEKERNEL_DIR}" "$RUNNER_CONTENT"
+assert_match "runner passes --add-dir worktree" "--add-dir /tmp/worktree" "$RUNNER_CONTENT"
 
 # ── Test 12: Runner script sources .cekernel-env ──
 assert_match "runner sources .cekernel-env" "source .cekernel-env" "$RUNNER_CONTENT"
@@ -112,6 +119,14 @@ printf '%s' "$TEST_PROMPT" > "${CEKERNEL_IPC_DIR}/prompt-eval.txt"
 PROMPT_READ=$(cat "${CEKERNEL_IPC_DIR}/prompt-eval.txt")
 OUTPUT=$(echo "$PROMPT_READ")
 assert_eq "prompt survives file-to-variable-to-arg pipeline" "$TEST_PROMPT" "$OUTPUT"
+
+# ── Test 17: write_runner_script fails without --bare-compatible auth ──
+EXIT_CODE=0
+(
+  unset ANTHROPIC_API_KEY CEKERNEL_CLAUDE_SETTINGS
+  write_runner_script "46" "/tmp/wt" "s" "worker" "p" >/dev/null 2>&1
+) || EXIT_CODE=$?
+assert_eq "write_runner_script fails without bare auth" "1" "$EXIT_CODE"
 
 # ── Cleanup ──
 rm -rf "$CEKERNEL_IPC_DIR"


### PR DESCRIPTION
closes #532

## Summary

ADR-0016 Phase 0。`claude -p` の全 spawn 経路 (4箇所) を `--bare` + 明示 context 注入にデフォルト化します。2.0.0 は breaking release のため `CEKERNEL_USE_BARE` のような runtime 切替は搭載せず、段階1→3を一括で適用しています (PR #535 の opt-in 版は 1.x line 向け)。

### 変更内容

- **`scripts/shared/bare-mode.sh` (新規)** — 明示 context flag builder
  - `bare_mode_prepare [dir]`: `CEKERNEL_BARE_FLAGS` 配列に `--bare --plugin-dir <cekernel-root> [--add-dir <dir>] [--settings $CEKERNEL_CLAUDE_SETTINGS]` を構築
  - `bare_mode_flags [dir]`: 生成 runner (heredoc) 埋め込み用の `printf %q` quoted 文字列
  - `bare_mode_preflight`: `--bare` は OAuth/keychain を一切読まないため、`ANTHROPIC_API_KEY` / `CEKERNEL_CLAUDE_SETTINGS` のいずれも無い場合は spawn 前に actionable なエラーで fail-fast (Rule of Repair)
- **`scripts/shared/backends/headless.sh`** — preflight + `claude -p "${CEKERNEL_BARE_FLAGS[@]}" --agent`
- **`scripts/shared/runner.sh`** (wezterm/tmux 経路) — preflight + 生成 runner に flags 埋め込み
- **`scripts/ctl/spawn-orchestrator.sh`** — preflight + repo root を `--add-dir` に
- **`scripts/scheduler/wrapper.sh`** — schedule 時 preflight + cron/at runner に flags 埋め込み。cron runtime には export した env が届かないため、`CEKERNEL_CLAUDE_SETTINGS` を `--settings` path として生成時にキャプチャ
- **`envs/README.md`** — `CEKERNEL_CLAUDE_SETTINGS` を catalog に追加

### スコープ外 (Rule of Parsimony)

`--mcp-config` / `--agents` / `--append-system-prompt` は必要性が未確認のため搭載していません。PoC (issue コメント参照) で `--plugin-dir` のみで plugin agent 解決、`--add-dir` で CLAUDE.md discovery が確認済みです。必要になった時点で helper に追加します。

### Breaking change

OAuth login のみの環境では spawn が preflight で失敗するようになります (`ANTHROPIC_API_KEY` または `CEKERNEL_CLAUDE_SETTINGS` が必須)。これは ADR-0016 の決定通りで、1.x line が legacy mode です。

## Test Plan

- [x] `tests/shared/test-bare-mode.sh` (新規, 14 cases): flag 構築 / %q quoting round-trip / preflight の成功・失敗・エラーメッセージ
- [x] `tests/shared/test-runner.sh` (20): 生成 runner の `--bare --plugin-dir --add-dir` / auth 無しで失敗
- [x] `tests/shared/test-backend-headless.sh` (16): args-recording mock で claude argv に `--bare` 系 flag が渡ることを検証 / auth 無しで handle file を作らず exit 1
- [x] `tests/scheduler/test-wrapper.sh` (23): cron runner への flags / `--settings` path 埋め込み / auth 無しで生成失敗
- [x] `tests/ctl/test-spawn-orchestrator.sh` (18)
- [x] 影響テスト: tmux 15 / wezterm 26 / dispatch 9 / agent-name-resolution 7 / at-launchd 33 / spawn-cwd-drift 11 / backend-adapter-zsh-compat 5 — すべて pass
- [ ] CI (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)