### PR TITLE
test: mock-bin / mock-claude 共通モックヘルパー (ADR-0017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,10 @@ tests/
 ├── run-tests.sh             # Dual-lane test runner (legacy + bats)
 ├── helpers.sh               # Assertion functions (legacy harness)
 ├── helpers/
-│   └── assertions.bash      # Assertion functions (bats lane)
+│   ├── assertions.bash      # Assertion functions (bats lane)
+│   ├── mock-bin.bash        # mock_bin PATH-shim helper (bats lane)
+│   ├── mock-claude.bash     # Canonical claude shim for v2 spawn tests
+│   └── session.bash         # Per-test unique CEKERNEL_SESSION_ID
 ├── orchestrator/
 │   ├── test-concurrency-guard.sh
 │   ├── test-{feature}.sh   # Orchestrator script tests (legacy)
@@ -298,11 +301,50 @@ assert_not_exists <label> <path>
 report_results  # "Results: N passed, M failed"
 ```
 
+### Mocking
+
+**PATH shims are the only sanctioned mock style** (ADR-0017). Shell-function
+overrides are banned — they silently fail across `exec`/subshell boundaries.
+Do not add new function-override mocks.
+
+In `.bats` files, use the canonical helpers:
+
+```bash
+load '../helpers/mock-bin'      # mock_bin <cmd> <script-body>
+load '../helpers/mock-claude'   # canonical claude shim (--bg / agents --json / stop)
+```
+
+`mock-claude.bash` emulates the ADR-0016 delegated-spawn contract. Any PR
+updating the "Background Agent Sessions" section of
+`docs/claude-code-constraints.md` must update the mock in the same PR.
+
+`git` and `git worktree` stay **real** against temp repos (ADR-0017): mocking
+them would fake the exact behavior worktree tests exist to verify.
+
 ### Test Isolation
 
 Isolate commands with side effects (WezTerm, `gh`, `git worktree`) from tests, or structure them to be mockable.
 
-Use a dedicated `CEKERNEL_SESSION_ID` in tests, and clean up before and after:
+In `.bats` files, use a per-test unique `CEKERNEL_SESSION_ID` (derived from
+`BATS_TEST_NAME`, safe under parallel bats runs):
+
+```bash
+load '../helpers/session'
+
+setup() {
+  set_test_session_id   # exports a per-test unique CEKERNEL_SESSION_ID
+  source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+  rm -rf "$CEKERNEL_IPC_DIR"
+  mkdir -p "$CEKERNEL_IPC_DIR"
+}
+
+teardown() {
+  rm -rf "$CEKERNEL_IPC_DIR"
+}
+```
+
+In legacy-harness files, use a dedicated fixed `CEKERNEL_SESSION_ID` and
+clean up before and after:
 
 ```bash
 export CEKERNEL_SESSION_ID="test-feature-00000001"

--- a/tests/helpers/mock-bin.bash
+++ b/tests/helpers/mock-bin.bash
@@ -1,0 +1,48 @@
+# mock-bin.bash — canonical PATH-shim mock helper (ADR-0017 Decision 2)
+#
+# PATH shims are the ONLY sanctioned mock style in this test suite.
+# Shell-function overrides are BANNED: they silently fail across
+# exec/subshell boundaries (a script that execs `git` never sees a
+# function named `git`), which is exactly where spawn-path bugs hide.
+# Do not add new function-override mocks.
+#
+# Precondition: PATH shims only intercept commands invoked BY NAME.
+# Scripts that call absolute paths (e.g. /usr/bin/git) bypass the shim
+# entirely. If a subject script hardcodes an absolute path, restructure
+# the script (or the test) — do not fall back to function overrides.
+#
+# Usage (in a .bats file):
+#   load '../helpers/mock-bin'   # relative to the .bats file
+#
+#   @test "example" {
+#     mock_bin gh 'echo "$*" >> "$BATS_TEST_TMPDIR/gh-argv.log"'
+#     ...
+#   }
+#
+# API:
+#   mock_bin <cmd> <script-body>
+#     Creates an executable shim named <cmd> in MOCK_BIN_DIR (a single,
+#     fixed variable name) and prepends MOCK_BIN_DIR to PATH once per
+#     test. <script-body> runs under `#!/usr/bin/env bash` with
+#     `set -euo pipefail`; "$@" holds the original arguments.
+#     Calling mock_bin again for the same <cmd> replaces the shim.
+#
+# Cleanup: MOCK_BIN_DIR lives under BATS_TEST_TMPDIR, which bats removes
+# automatically after each test — no manual teardown needed. The PATH
+# change is confined to the test's own process (each @test runs in its
+# own process), so shims never leak between tests.
+
+mock_bin() {
+  local cmd="${1:?Usage: mock_bin <cmd> <script-body>}"
+  local body="${2:?Usage: mock_bin <cmd> <script-body>}"
+
+  if [[ -z "${MOCK_BIN_DIR:-}" ]]; then
+    MOCK_BIN_DIR="${BATS_TEST_TMPDIR:?mock_bin requires bats (BATS_TEST_TMPDIR unset)}/mock-bin"
+    mkdir -p "$MOCK_BIN_DIR"
+    PATH="${MOCK_BIN_DIR}:${PATH}"
+    export PATH MOCK_BIN_DIR
+  fi
+
+  printf '#!/usr/bin/env bash\nset -euo pipefail\n%s\n' "$body" > "${MOCK_BIN_DIR}/${cmd}"
+  chmod +x "${MOCK_BIN_DIR}/${cmd}"
+}

--- a/tests/helpers/mock-bin.bats
+++ b/tests/helpers/mock-bin.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# mock-bin.bats — contract self-tests for tests/helpers/mock-bin.bash
+#
+# ADR-0017 Decision 2: PATH shims are the single sanctioned mock style.
+# These tests verify the observable behavior of the mock_bin helper.
+
+load '../helpers/assertions'
+load '../helpers/mock-bin'
+
+@test "mock_bin shim intercepts a command invoked by name" {
+  mock_bin cekernel-fake-cmd 'echo "mocked-output"'
+  run cekernel-fake-cmd
+  assert_eq "exit status" "0" "$status"
+  assert_eq "output" "mocked-output" "$output"
+}
+
+@test "mock_bin shim receives its arguments" {
+  mock_bin cekernel-fake-cmd 'printf "%s\n" "$@"'
+  run cekernel-fake-cmd one two
+  assert_eq "first line" "one" "${lines[0]}"
+  assert_eq "second line" "two" "${lines[1]}"
+}
+
+@test "mock_bin shadows a real command for by-name invocation" {
+  mock_bin uname 'echo "mock-uname"'
+  run uname
+  assert_eq "real command shadowed" "mock-uname" "$output"
+}
+
+@test "mock_bin shim survives exec boundaries (visible in child processes)" {
+  # This is the property function overrides lack (ADR-0017: they silently
+  # fail across exec/subshell spawn paths).
+  mock_bin cekernel-fake-cmd 'echo "from-shim"'
+  run bash -c 'cekernel-fake-cmd'
+  assert_eq "shim visible in child process" "from-shim" "$output"
+}
+
+@test "mock_bin uses the single variable name MOCK_BIN_DIR under BATS_TEST_TMPDIR" {
+  mock_bin cekernel-fake-cmd 'true'
+  [[ "$MOCK_BIN_DIR" == "${BATS_TEST_TMPDIR}"/* ]] || {
+    echo "FAIL: MOCK_BIN_DIR not under BATS_TEST_TMPDIR: $MOCK_BIN_DIR" >&2
+    return 1
+  }
+  assert_file_exists "shim file" "${MOCK_BIN_DIR}/cekernel-fake-cmd"
+}
+
+@test "calling mock_bin twice for the same command replaces the shim" {
+  mock_bin cekernel-fake-cmd 'echo "first"'
+  mock_bin cekernel-fake-cmd 'echo "second"'
+  run cekernel-fake-cmd
+  assert_eq "latest shim wins" "second" "$output"
+}
+
+@test "mock_bin supports multiple distinct commands in one test" {
+  mock_bin cekernel-fake-a 'echo "a"'
+  mock_bin cekernel-fake-b 'echo "b"'
+  run cekernel-fake-a
+  assert_eq "first shim" "a" "$output"
+  run cekernel-fake-b
+  assert_eq "second shim" "b" "$output"
+}

--- a/tests/helpers/mock-claude.bash
+++ b/tests/helpers/mock-claude.bash
@@ -1,0 +1,135 @@
+# mock-claude.bash — canonical `claude` CLI shim for v2 spawn-path tests
+# (ADR-0017 Decision 2, emulating the ADR-0016 delegated-spawn contract)
+#
+# Contract source: docs/claude-code-constraints.md
+#   § Background Agent Sessions (`--bg` / on-demand daemon)
+# Observed claude version: v2.1.201 (2026-07-06).
+#
+# STALENESS COUPLING (ADR-0017 follow-up): any PR that updates the
+# "Background Agent Sessions" section of docs/claude-code-constraints.md
+# MUST update this mock in the same PR. This file is the single point of
+# update when the real `claude --bg` surface changes.
+#
+# Requires mock-bin.bash (PATH shim layer). Function overrides are banned
+# — see mock-bin.bash header.
+#
+# Usage (in a .bats file):
+#   load '../helpers/mock-bin'
+#   load '../helpers/mock-claude'
+#
+#   setup() { mock_claude; }
+#
+# API:
+#   mock_claude
+#     Installs the `claude` PATH shim and exports MOCK_CLAUDE_STATE_DIR
+#     (under BATS_TEST_TMPDIR — auto-cleaned per test, like MOCK_BIN_DIR).
+#
+#   mock_claude_enqueue_short_id <short-id>
+#     Queues a short ID (8 hex chars) for the next `--bg` call. Each
+#     `--bg` call pops one; when the queue is empty a fixed default
+#     ("deadbeef") is used.
+#
+#   mock_claude_enqueue_agents <json>
+#     Queues one full `agents --json` response body (a JSON array).
+#     Each `agents --json` call consumes one queued response IN ORDER;
+#     after the queue is exhausted the LAST response repeats forever.
+#     This makes non-terminating sequences scriptable (e.g. a session
+#     that stays `busy`, for poll-timeout branches): simply end the
+#     queue with a non-terminal state. With an empty queue, `[]` is
+#     emitted.
+#
+#   mock_claude_agent_record <sessionId> <kind> <cwd> <startedAt> <state>
+#     Prints one FULL agents record as a JSON object. All five fields
+#     are mandatory (ADR-0017): full records keep both normative capture
+#     paths testable — short-ID prefix match against sessionId, and the
+#     kind+cwd+startedAt fallback including the interactive-session
+#     mis-match regression at repo root.
+#
+# Recorded state (files under MOCK_CLAUDE_STATE_DIR):
+#   bg-argv.log   one line per `--bg` call: the full argv, space-joined
+#   stop.log      one line per `stop <id>` call: the <id> argument
+#
+# Shim behavior:
+#   claude ... --bg ...    → prints `backgrounded · <short-id>`, records argv
+#   claude agents --json   → replays the enqueued response sequence
+#   claude stop <id>       → appends <id> to stop.log
+#   anything else          → diagnostic on stderr, exit 1 (Rule of Repair:
+#                            argv shapes the mock does not model must fail
+#                            noisily, never pass silently)
+
+mock_claude() {
+  MOCK_CLAUDE_STATE_DIR="${BATS_TEST_TMPDIR:?mock_claude requires bats (BATS_TEST_TMPDIR unset)}/mock-claude"
+  mkdir -p "$MOCK_CLAUDE_STATE_DIR"
+  export MOCK_CLAUDE_STATE_DIR
+
+  # NOTE: if/elif instead of case — unquoted `)` in case patterns breaks
+  # command-substitution parsing when this template is later embedded in
+  # a double-quoted string (bash 3.2 compatibility).
+  local shim_template
+  shim_template=$(cat <<'SHIM'
+if [[ "${1:-}" == "agents" ]]; then
+  # Replay the enqueued response sequence: one response per call,
+  # repeating the last response after the queue is exhausted.
+  n=0
+  [[ -f "$STATE_DIR/agents-calls" ]] && n=$(cat "$STATE_DIR/agents-calls")
+  n=$((n + 1))
+  echo "$n" > "$STATE_DIR/agents-calls"
+  total=0
+  [[ -f "$STATE_DIR/agents-enqueued" ]] && total=$(cat "$STATE_DIR/agents-enqueued")
+  idx=$n
+  [[ "$idx" -gt "$total" ]] && idx=$total
+  if [[ "$idx" -ge 1 ]]; then
+    cat "$STATE_DIR/agents-response.$idx"
+  else
+    echo "[]"
+  fi
+elif [[ "${1:-}" == "stop" ]]; then
+  echo "${2:?mock-claude: stop requires an id}" >> "$STATE_DIR/stop.log"
+else
+  for arg in "$@"; do
+    if [[ "$arg" == "--bg" ]]; then
+      echo "$*" >> "$STATE_DIR/bg-argv.log"
+      short_id=""
+      if [[ -s "$STATE_DIR/short-ids" ]]; then
+        short_id=$(head -n 1 "$STATE_DIR/short-ids")
+        tail -n +2 "$STATE_DIR/short-ids" > "$STATE_DIR/short-ids.tmp"
+        mv "$STATE_DIR/short-ids.tmp" "$STATE_DIR/short-ids"
+      fi
+      [[ -z "$short_id" ]] && short_id="deadbeef"
+      echo "backgrounded · $short_id"
+      exit 0
+    fi
+  done
+  echo "mock-claude: unsupported invocation: $*" >&2
+  exit 1
+fi
+SHIM
+)
+  mock_bin claude "STATE_DIR=\"${MOCK_CLAUDE_STATE_DIR}\"
+${shim_template}"
+}
+
+mock_claude_enqueue_short_id() {
+  local short_id="${1:?Usage: mock_claude_enqueue_short_id <short-id>}"
+  echo "$short_id" >> "${MOCK_CLAUDE_STATE_DIR:?call mock_claude first}/short-ids"
+}
+
+mock_claude_enqueue_agents() {
+  local json="${1:?Usage: mock_claude_enqueue_agents <json>}"
+  local state_dir="${MOCK_CLAUDE_STATE_DIR:?call mock_claude first}"
+  local total=0
+  [[ -f "${state_dir}/agents-enqueued" ]] && total=$(cat "${state_dir}/agents-enqueued")
+  total=$((total + 1))
+  printf '%s\n' "$json" > "${state_dir}/agents-response.${total}"
+  echo "$total" > "${state_dir}/agents-enqueued"
+}
+
+mock_claude_agent_record() {
+  local session_id="${1:?Usage: mock_claude_agent_record <sessionId> <kind> <cwd> <startedAt> <state>}"
+  local kind="${2:?missing <kind>}"
+  local cwd="${3:?missing <cwd>}"
+  local started_at="${4:?missing <startedAt>}"
+  local state="${5:?missing <state>}"
+  printf '{"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":"%s","state":"%s"}' \
+    "$session_id" "$kind" "$cwd" "$started_at" "$state"
+}

--- a/tests/helpers/mock-claude.bats
+++ b/tests/helpers/mock-claude.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# mock-claude.bats — contract self-tests for tests/helpers/mock-claude.bash
+#
+# ADR-0017 Decision 2: the canonical claude shim emulates the delegated-spawn
+# contract (ADR-0016, observed on claude v2.1.201). These tests verify every
+# behavior consumers rely on:
+#   - `--bg` prints `backgrounded · <short-id>` and records argv
+#   - `agents --json` emits full records (sessionId/kind/cwd/startedAt/state)
+#     as a scriptable, per-call-consumed sequence that repeats its last
+#     response (non-terminating sequences for poll-timeout branches)
+#   - `stop <id>` records the call
+
+load '../helpers/assertions'
+load '../helpers/mock-bin'
+load '../helpers/mock-claude'
+
+setup() {
+  mock_claude
+}
+
+# ── --bg spawn line + argv recording ──
+
+@test "--bg prints 'backgrounded · <short-id>' with the enqueued short ID" {
+  mock_claude_enqueue_short_id cafe0001
+  run claude --bg --agent cekernel:worker "do the thing"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "spawn line" "backgrounded · cafe0001" "$output"
+}
+
+@test "--bg consumes enqueued short IDs in order across calls" {
+  mock_claude_enqueue_short_id aaaa1111
+  mock_claude_enqueue_short_id bbbb2222
+  run claude --bg "first"
+  assert_eq "first spawn" "backgrounded · aaaa1111" "$output"
+  run claude --bg "second"
+  assert_eq "second spawn" "backgrounded · bbbb2222" "$output"
+}
+
+@test "--bg falls back to a default 8-hex short ID when the queue is empty" {
+  run claude --bg "prompt"
+  assert_match "default spawn line" "^backgrounded · [0-9a-f]{8}$" "$output"
+}
+
+@test "--bg records argv (one line per call)" {
+  mock_claude_enqueue_short_id cafe0001
+  claude --bg --agent cekernel:worker "prompt text" >/dev/null
+  claude --bg --agent cekernel:reviewer "other" >/dev/null
+  run cat "${MOCK_CLAUDE_STATE_DIR}/bg-argv.log"
+  assert_eq "first call argv" "--bg --agent cekernel:worker prompt text" "${lines[0]}"
+  assert_eq "second call argv" "--bg --agent cekernel:reviewer other" "${lines[1]}"
+}
+
+@test "--bg is detected anywhere in argv, not only as the first flag" {
+  mock_claude_enqueue_short_id cafe0001
+  run claude --agent cekernel:worker --bg "prompt"
+  assert_eq "spawn line" "backgrounded · cafe0001" "$output"
+}
+
+# ── agents --json full records ──
+
+@test "agents --json emits full records: sessionId, kind, cwd, startedAt, state" {
+  local rec
+  rec=$(mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background \
+    "/tmp/repo/.worktrees/issue/42-x" "2026-07-07T00:00:00Z" busy)
+  mock_claude_enqueue_agents "[${rec}]"
+  run claude agents --json
+  assert_eq "exit status" "0" "$status"
+  assert_match "sessionId" '"sessionId":"cafe0001-0000-4000-8000-000000000001"' "$output"
+  assert_match "kind" '"kind":"background"' "$output"
+  assert_match "cwd" '"cwd":"/tmp/repo/.worktrees/issue/42-x"' "$output"
+  assert_match "startedAt" '"startedAt":"2026-07-07T00:00:00Z"' "$output"
+  assert_match "state" '"state":"busy"' "$output"
+}
+
+@test "agents --json emits [] when nothing is enqueued" {
+  run claude agents --json
+  assert_eq "empty roster" "[]" "$output"
+}
+
+@test "short-ID prefix capture path: --bg short ID prefixes a sessionId in agents --json" {
+  # Normative capture path 1 (ADR-0016): extract the short ID from the spawn
+  # line, prefix-match it against sessionId in agents --json.
+  mock_claude_enqueue_short_id cafe0001
+  local rec
+  rec=$(mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background "/tmp/wt" \
+    "2026-07-07T00:00:00Z" busy)
+  mock_claude_enqueue_agents "[${rec}]"
+  local short_id
+  short_id="$(claude --bg "prompt" | sed 's/^backgrounded · //')"
+  run claude agents --json
+  assert_match "prefix match" "\"sessionId\":\"${short_id}" "$output"
+}
+
+@test "agents --json can script the kind+cwd+startedAt fallback with an interactive session at repo root" {
+  # Normative capture path 2 (ADR-0016 fallback) and the interactive-session
+  # mis-match regression: the roster must be able to contain an interactive
+  # session sharing the repo-root cwd alongside the background worker.
+  local interactive background
+  interactive=$(mock_claude_agent_record \
+    "11111111-0000-4000-8000-000000000001" interactive "/tmp/repo" \
+    "2026-07-07T00:00:00Z" busy)
+  background=$(mock_claude_agent_record \
+    "22222222-0000-4000-8000-000000000002" background "/tmp/repo" \
+    "2026-07-07T00:01:00Z" busy)
+  mock_claude_enqueue_agents "[${interactive},${background}]"
+  run claude agents --json
+  assert_match "interactive record present" '"kind":"interactive"' "$output"
+  assert_match "background record present" '"kind":"background"' "$output"
+  assert_match "distinct startedAt for fallback" '"startedAt":"2026-07-07T00:01:00Z"' "$output"
+}
+
+# ── scriptable state sequences ──
+
+@test "agents --json replays the enqueued sequence one response per call" {
+  local rec_busy rec_done
+  rec_busy=$(mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background "/tmp/wt" \
+    "2026-07-07T00:00:00Z" busy)
+  rec_done=$(mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background "/tmp/wt" \
+    "2026-07-07T00:00:00Z" done)
+  mock_claude_enqueue_agents "[${rec_busy}]"
+  mock_claude_enqueue_agents "[${rec_done}]"
+  run claude agents --json
+  assert_match "first call is busy" '"state":"busy"' "$output"
+  run claude agents --json
+  assert_match "second call is done" '"state":"done"' "$output"
+}
+
+@test "agents --json repeats the last response forever (non-terminating sequence)" {
+  # Required so wrapper.sh's poll-timeout branch is testable (ADR-0017):
+  # a sequence that never reaches a terminal state.
+  local rec
+  rec=$(mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background "/tmp/wt" \
+    "2026-07-07T00:00:00Z" busy)
+  mock_claude_enqueue_agents "[${rec}]"
+  local i
+  for i in 1 2 3; do
+    run claude agents --json
+    assert_match "call ${i} stays busy" '"state":"busy"' "$output"
+  done
+}
+
+# ── stop recording ──
+
+@test "stop <id> records the call" {
+  claude stop cafe0001
+  claude stop beef0002
+  run cat "${MOCK_CLAUDE_STATE_DIR}/stop.log"
+  assert_eq "first stop" "cafe0001" "${lines[0]}"
+  assert_eq "second stop" "beef0002" "${lines[1]}"
+}
+
+# ── error paths ──
+
+@test "unsupported invocations fail noisily" {
+  # Rule of Repair: an argv shape the mock does not model must not be
+  # silently accepted.
+  run claude logs cafe0001
+  assert_eq "exit status" "1" "$status"
+  assert_match "diagnostic on stderr" "unsupported" "$output"
+}

--- a/tests/helpers/session.bash
+++ b/tests/helpers/session.bash
@@ -1,0 +1,42 @@
+# session.bash — per-test unique CEKERNEL_SESSION_ID helper (ADR-0017)
+#
+# Derives a session ID from BATS_TEST_FILENAME + BATS_TEST_NAME so that
+# every @test gets its own IPC directory. This prevents collisions under
+# parallel bats runs (`bats --jobs N`) and overrides any session scope
+# inherited from the invoking environment (e.g. a Worker's .cekernel-env).
+#
+# Usage (in a .bats file):
+#   load '../helpers/session'   # relative to the .bats file
+#
+#   setup() {
+#     set_test_session_id
+#     source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+#     rm -rf "$CEKERNEL_IPC_DIR" && mkdir -p "$CEKERNEL_IPC_DIR"
+#   }
+#
+# API:
+#   test_session_id
+#     Prints the derived ID: bats-{file-slug}-{hex8}. The hex8 suffix is
+#     a hash of BATS_TEST_FILENAME:BATS_TEST_NAME — deterministic for
+#     the same test, distinct across tests.
+#
+#   set_test_session_id
+#     Exports CEKERNEL_SESSION_ID (via test_session_id) and unsets any
+#     inherited CEKERNEL_IPC_DIR so session-id.sh re-derives a per-test
+#     IPC directory.
+
+test_session_id() {
+  local name hash
+  name=$(basename "${BATS_TEST_FILENAME:-unknown}" .bats \
+    | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9._-' '-')
+  name="${name%-}"
+  hash=$(printf '%s' "${BATS_TEST_FILENAME:-}:${BATS_TEST_NAME:-}" \
+    | shasum | cut -c1-8)
+  echo "bats-${name}-${hash}"
+}
+
+set_test_session_id() {
+  CEKERNEL_SESSION_ID="$(test_session_id)"
+  export CEKERNEL_SESSION_ID
+  unset CEKERNEL_IPC_DIR
+}

--- a/tests/helpers/session.bats
+++ b/tests/helpers/session.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# session.bats — contract self-tests for tests/helpers/session.bash
+#
+# ADR-0017 follow-up: per-test unique CEKERNEL_SESSION_ID (derived from
+# BATS_TEST_NAME) so parallel bats runs cannot collide on IPC directories.
+
+load '../helpers/assertions'
+load '../helpers/session'
+
+setup() {
+  CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+}
+
+@test "set_test_session_id exports a well-formed CEKERNEL_SESSION_ID" {
+  set_test_session_id
+  assert_match "format {name}-{hex8}" "^[a-z0-9._-]+-[0-9a-f]{8}$" "$CEKERNEL_SESSION_ID"
+}
+
+@test "test_session_id derives distinct IDs for distinct test names" {
+  local id1 id2
+  id1=$(BATS_TEST_NAME="alpha" test_session_id)
+  id2=$(BATS_TEST_NAME="beta" test_session_id)
+  [[ "$id1" != "$id2" ]] || {
+    echo "FAIL: IDs should differ, both were: $id1" >&2
+    return 1
+  }
+}
+
+@test "test_session_id is deterministic for the same test name" {
+  local id1 id2
+  id1=$(BATS_TEST_NAME="alpha" test_session_id)
+  id2=$(BATS_TEST_NAME="alpha" test_session_id)
+  assert_eq "same name yields same ID" "$id1" "$id2"
+}
+
+@test "set_test_session_id composes with session-id.sh for a per-test IPC dir" {
+  # Must override any CEKERNEL_IPC_DIR inherited from the environment
+  # (e.g. a Worker's .cekernel-env), otherwise tests share IPC state.
+  export CEKERNEL_IPC_DIR="/tmp/inherited-ipc-dir"
+  set_test_session_id
+  source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+  assert_match "IPC dir ends with session ID" "/${CEKERNEL_SESSION_ID}$" "$CEKERNEL_IPC_DIR"
+}


### PR DESCRIPTION
closes #544

## Summary
ADR-0017 Decision 2 のモック一本化。PATH shim を唯一のサンクション済みモック様式として、bats レーンに共通ヘルパーを追加する。

- `tests/helpers/mock-bin.bash` — `mock_bin <cmd> <script-body>`(単一変数名 `MOCK_BIN_DIR`、shim は `BATS_TEST_TMPDIR` 配下で per-test 自動クリーンアップ)。ヘッダーに「コマンドは名前で呼ばれること(絶対パス呼び出しは横取り不可)」の前提条件と function override 禁止を明記
- `tests/helpers/mock-claude.bash` — ADR-0016 delegated-spawn 契約を模倣する canonical claude shim
  - `--bg`: `backgrounded · <short-id>` を stdout に出力し argv を記録(short-ID はキューでスクリプト可能、空なら固定デフォルト)
  - `agents --json`: 完全レコード(sessionId / kind / cwd / startedAt / state)を enqueue 順に1呼び出し1応答で再生、末尾応答を無限リピート → **非終端シーケンス**(poll-timeout 分岐用)をスクリプト可能
  - short-ID 前方一致 / kind+cwd+startedAt フォールバックの捕捉2経路と、repo root での interactive 誤マッチ回帰をテスト可能
  - `stop <id>` の呼び出しを記録、未対応 argv は exit 1 で noisy に失敗(Rule of Repair)
  - ヘッダーに `docs/claude-code-constraints.md` § Background Agent Sessions へのリンク、観測バージョン v2.1.201、constraints doc 更新 PR は同一 PR で mock を追随する規約を記載
- `tests/helpers/session.bash` — `BATS_TEST_NAME` 由来の per-test 一意 `CEKERNEL_SESSION_ID` 生成ヘルパー(並列 bats 実行での IPC ディレクトリ衝突防止)
- CLAUDE.md — Mocking 節を新設(function override 禁止・staleness coupling・real-git 方針)、Test Isolation 節の固定 ID 例を bats レーンの per-test 一意ヘルパーに更新

TDD(RED → GREEN → REFACTOR)で実装。契約セルフテスト24件が全機能をカバー。

## Test Plan
- [x] `bats tests/helpers/` — 24 tests pass(mock-bin 7 / mock-claude 13 / session 4)
- [ ] CI(dual-lane run-tests.sh)がグリーン