### PR TITLE
feat: spawn.sh の cross-repo Issue サポート (--repo フラグ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,25 @@ cekernel is primarily designed for **monorepo** structures. While it may work wi
 | crontab | Linux/WSL | Untested — unit tests pass, but no live execution verification yet |
 | atd | Linux/WSL | Untested — unit tests pass, but no live execution verification yet |
 
-**Cross-repository issues:** If you manage issues in a separate meta-repository, pass the full path or URL to `/orchestrate`:
+**Cross-repository issues:** If you manage issues in a separate meta-repository, run `/orchestrate` from the **implementation repository** (worktrees, branches, and PRs are created there) and pass the full path or URL of the issue:
 
 ```bash
-/cekernel:orchestrate /org/repo/issues/123
+/cekernel:orchestrate /org/planning/issues/123
 # or
-/cekernel:orchestrate https://github.com/org/repo/issues/123
+/cekernel:orchestrate https://github.com/org/planning/issues/123
+```
+
+The issue repository is extracted from the reference and propagated via `spawn-worker.sh --repo org/planning`, so the Worker reads and comments on the correct issue while implementing in the current repository.
+
+If you use `--permission-mode auto`, declare the meta-repository as a trusted external dependency so the auto-mode classifier does not block `gh` writes targeting it:
+
+```jsonc
+// .claude/settings.local.json
+{
+  "autoMode": {
+    "environment": "Trust this working repo and the meta-repo at org/planning. gh commands targeting either repo are expected operations."
+  }
+}
 ```
 
 > **Note**: Cross-repository issue resolution has not been extensively tested. Please [open an issue](https://github.com/clonable-eden/cekernel/issues/new) if you encounter any problems.

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -42,6 +42,26 @@ For each issue, check its content with `gh issue view` and verify:
 
 If requirements are ambiguous or insufficient, FAIL immediately and return the reason. The user is expected to fix the issue and re-run.
 
+### Cross-repo Issues
+
+When the dispatch prompt references an issue in a different repository
+(`Issue repo: owner/repo`, an issue URL, or `owner/repo#N` notation), the issue
+lives outside the working repository (#440):
+
+- Pass `--repo <owner/repo>` to all issue-related `gh` commands during triage
+  (`gh issue view <N> --repo <owner/repo>`)
+- Pass `--repo <owner/repo>` to `spawn-worker.sh` so the Worker receives the
+  correct issue content and a `repo:` field in its task file:
+
+```bash
+export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --repo <owner/repo> <issue-number>
+```
+
+Worktrees, branches, and PRs stay in the working repository — `--repo` only
+changes where the issue is read from and commented on. Without `--repo`,
+`gh` would silently resolve the issue number against the working repository
+and fetch an unrelated same-numbered issue.
+
 ## Workflow
 
 ### Claude Code Session ID Persistence

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -75,7 +75,8 @@ scripts/shared/phase-transition.sh 123 RUNNING "phase0:plan"  # wrong dir anyway
    2. `.cekernel-checkpoint.md` exists → SUSPEND resume (read it to understand previous progress and continue from where the last Worker left off)
    3. Neither → fresh start
 4. Read issue content from `.cekernel-task.md` in the worktree (pre-extracted at spawn time)
-   - If `.cekernel-task.md` does not exist, fall back to `gh issue view`
+   - **Cross-repo issue detection**: If the frontmatter contains a `repo:` field, the issue lives in a different repository than the working repository. Pass `--repo <owner/repo>` to **all** issue-related `gh` commands (`gh issue view`, `gh issue comment`). PR-related commands (`gh pr create`, `gh pr checks`) still target the working repository
+   - If `.cekernel-task.md` does not exist, fall back to `gh issue view` (with `--repo` if the spawn prompt indicates a cross-repo issue)
 5. Understand the issue requirements
 6. Transition to Phase 0: `phase-transition.sh <issue-number> RUNNING "phase0:plan"`
 7. Post Execution Plan as a comment on the issue (or a Resume Plan if resuming)
@@ -235,6 +236,10 @@ gh pr create --base "$BASE" --title "..." --body "..."
 ```
 
 PR title, body, and issue link format follow the target repository's conventions.
+For cross-repo issues (task file has a `repo:` field), reference the issue as
+`<owner/repo>#<issue-number>` in the PR body — note that `closes` across
+repositories only auto-closes when permissions allow; the Orchestrator handles
+issue closure otherwise.
 Fallback when the target repository has no conventions:
 
 ```bash

--- a/scripts/orchestrator/spawn-worker.sh
+++ b/scripts/orchestrator/spawn-worker.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # spawn-worker.sh — Spawn a Worker process (wrapper for spawn.sh --agent worker)
 #
-# Usage: spawn-worker.sh [--resume] [--priority <priority>] <issue-number> [base-branch]
+# Usage: spawn-worker.sh [--resume] [--priority <priority>] [--repo <owner/repo>] <issue-number> [base-branch]
 #   priority: critical|high|normal|low or numeric 0-19 (default: normal)
 # Output: FIFO path (stdout last line)
 # Options:
 #   --resume    Resume a suspended Worker (reuse existing worktree)
 #   --priority  Set worker priority (nice value)
+#   --repo      Issue repository (owner/repo) for cross-repo issues (#440).
+#               Defaults to the current repository when omitted
 # Exit codes:
 #   0 — Worker spawned successfully
 #   1 — General error

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # spawn.sh — Create worktree + launch process via backend (common spawning logic)
 #
-# Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--fallback-model <model>] <issue-number> [base-branch]
+# Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--repo <owner/repo>] [--fallback-model <model>] <issue-number> [base-branch]
 #   type:     Process type (e.g., worker)
 #   priority: critical|high|normal|low or numeric 0-19 (default: normal)
 # Output: FIFO path (stdout last line)
@@ -9,6 +9,10 @@
 #   --agent           Process type to spawn (required)
 #   --resume          Resume a suspended process (reuse existing worktree)
 #   --priority        Set process priority (nice value)
+#   --repo            Issue repository (owner/repo) for cross-repo issues (#440).
+#                     The issue is fetched from this repository, while the
+#                     worktree/branch/PR stay in the current repository.
+#                     Defaults to the current repository when omitted
 #   --fallback-model  Forward --fallback-model <model> to claude (#529).
 #                     Overrides CEKERNEL_FALLBACK_MODEL (env/profile default)
 # Exit codes:
@@ -34,12 +38,14 @@ AGENT_TYPE=""
 RESUME=0
 PRIORITY="normal"
 CUSTOM_PROMPT=""
+ISSUE_REPO=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --agent) AGENT_TYPE="${2:?--agent requires a value}"; shift 2 ;;
     --resume) RESUME=1; shift ;;
     --priority) PRIORITY="${2:?--priority requires a value}"; shift 2 ;;
     --prompt) CUSTOM_PROMPT="${2:?--prompt requires a value}"; shift 2 ;;
+    --repo) ISSUE_REPO="${2:?--repo requires a value}"; shift 2 ;;
     --fallback-model) export CEKERNEL_FALLBACK_MODEL="${2:?--fallback-model requires a value}"; shift 2 ;;
     *) break ;;
   esac
@@ -48,11 +54,11 @@ done
 # Validate --agent is provided
 if [[ -z "$AGENT_TYPE" ]]; then
   echo "Error: --agent <type> is required" >&2
-  echo "Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--fallback-model <model>] <issue-number> [base-branch]" >&2
+  echo "Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--repo <owner/repo>] [--fallback-model <model>] <issue-number> [base-branch]" >&2
   exit 1
 fi
 
-ISSUE_NUMBER="${1:?Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--fallback-model <model>] <issue-number> [base-branch]}"
+ISSUE_NUMBER="${1:?Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--repo <owner/repo>] [--fallback-model <model>] <issue-number> [base-branch]}"
 BASE_BRANCH="${2:-main}"
 REPO_ROOT="$(resolve_repo_root)"
 
@@ -88,8 +94,16 @@ if [[ "$RESUME" -eq 0 ]]; then
 fi
 
 # ── Fetch issue info ──
-ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')
-[[ -n "$ISSUE_TITLE" ]] || { echo "Error: issue #${ISSUE_NUMBER} not found" >&2; exit 1; }
+# --repo targets a cross-repo issue (#440); default is the current repository.
+# ISSUE_REF is the human-readable issue reference used in prompts/errors.
+if [[ -n "$ISSUE_REPO" ]]; then
+  ISSUE_REF="${ISSUE_REPO}#${ISSUE_NUMBER}"
+  ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --json title -q '.title')
+else
+  ISSUE_REF="#${ISSUE_NUMBER}"
+  ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title')
+fi
+[[ -n "$ISSUE_TITLE" ]] || { echo "Error: issue ${ISSUE_REF} not found" >&2; exit 1; }
 
 # ── Branch name / path generation ──
 # Default naming convention. If the target repository has its own convention,
@@ -234,7 +248,7 @@ else
   # Extract issue data into worktree (session memory: page cache)
   # Processes read .cekernel-task.md locally instead of calling gh issue view,
   # reducing GitHub API calls and context window consumption.
-  create_task_file "$WORKTREE" "$ISSUE_NUMBER"
+  create_task_file "$WORKTREE" "$ISSUE_NUMBER" "$ISSUE_REPO"
   echo "task file: $(task_file_path "$WORKTREE")" >&2
 fi
 
@@ -259,12 +273,19 @@ EOF
 # ── Launch process via backend ──
 # If --prompt was provided, use it. Otherwise, use the default Worker prompt.
 # PATH and env vars are propagated via .cekernel-env sourced by the runner script.
+# Cross-repo issues (#440): the prompt references the issue as owner/repo#N
+# and tells the process to target issue-related gh commands at that repo.
+CROSS_REPO_NOTE=""
+if [[ -n "$ISSUE_REPO" ]]; then
+  CROSS_REPO_NOTE=" The issue lives in ${ISSUE_REPO} (see the repo: field in .cekernel-task.md); pass --repo ${ISSUE_REPO} to issue-related gh commands."
+fi
+
 if [[ -n "$CUSTOM_PROMPT" ]]; then
   PROMPT="${CUSTOM_PROMPT}"
 elif [[ "$RESUME" -eq 1 ]]; then
-  PROMPT="Resume issue #${ISSUE_NUMBER}. Read .cekernel-checkpoint.md to understand previous progress, then continue from where the previous Worker left off. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI. When done, run notify-complete.sh ${ISSUE_NUMBER} ci-passed <pr-number>."
+  PROMPT="Resume issue ${ISSUE_REF}. Read .cekernel-checkpoint.md to understand previous progress, then continue from where the previous Worker left off.${CROSS_REPO_NOTE} First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI. When done, run notify-complete.sh ${ISSUE_NUMBER} ci-passed <pr-number>."
 else
-  PROMPT="Resolve issue #${ISSUE_NUMBER}. First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI. When done, run notify-complete.sh ${ISSUE_NUMBER} ci-passed <pr-number>."
+  PROMPT="Resolve issue ${ISSUE_REF}.${CROSS_REPO_NOTE} First read the target repository's CLAUDE.md and fully follow its conventions. Follow only the kernel Worker Protocol for lifecycle: implement → create PR → verify CI. When done, run notify-complete.sh ${ISSUE_NUMBER} ci-passed <pr-number>."
 fi
 
 # Backend handles workspace resolution, window spawning, and handle file management internally.

--- a/scripts/shared/task-file.sh
+++ b/scripts/shared/task-file.sh
@@ -8,7 +8,12 @@
 # Usage: source task-file.sh
 #
 # Functions:
-#   create_task_file <worktree> <issue-number>  — Fetch issue and write .cekernel-task.md
+#   create_task_file <worktree> <issue-number> [repo]
+#     — Fetch issue and write .cekernel-task.md. When [repo] (owner/repo)
+#       is given, the issue is fetched from that repository via
+#       `gh issue view --repo` and a `repo:` frontmatter field is written
+#       so Workers can detect cross-repo issues (#440). When omitted,
+#       the current repository is used (unchanged behavior).
 #   task_file_path <worktree>                   — Return the task file path
 #   task_file_exists <worktree>                 — Check if the task file exists (exit 0/1)
 #   task_file_clear_resume_marker <worktree>    — Remove "## Resume Reason:" section
@@ -57,17 +62,24 @@ task_file_clear_resume_marker() {
   fi
 }
 
-# create_task_file <worktree> <issue-number>
-# Fetches issue data via gh and writes .cekernel-task.md in the worktree
+# create_task_file <worktree> <issue-number> [repo]
+# Fetches issue data via gh and writes .cekernel-task.md in the worktree.
+# When [repo] (owner/repo) is given, fetches from that repository and
+# records it as a `repo:` frontmatter field (cross-repo issue, #440).
 create_task_file() {
-  local worktree="${1:?Usage: create_task_file <worktree> <issue-number>}"
-  local issue_number="${2:?Usage: create_task_file <worktree> <issue-number>}"
+  local worktree="${1:?Usage: create_task_file <worktree> <issue-number> [repo]}"
+  local issue_number="${2:?Usage: create_task_file <worktree> <issue-number> [repo]}"
+  local repo="${3:-}"
   local task_file
   task_file="$(task_file_path "$worktree")"
 
   # Fetch issue data as JSON (including comments for full context)
   local issue_json
-  issue_json=$(gh issue view "$issue_number" --json title,body,labels,comments)
+  if [[ -n "$repo" ]]; then
+    issue_json=$(gh issue view "$issue_number" --repo "$repo" --json title,body,labels,comments)
+  else
+    issue_json=$(gh issue view "$issue_number" --json title,body,labels,comments)
+  fi
 
   # Extract fields
   local title body labels comments_count
@@ -80,6 +92,9 @@ create_task_file() {
   {
     echo "---"
     echo "issue: ${issue_number}"
+    if [[ -n "$repo" ]]; then
+      echo "repo: ${repo}"
+    fi
     echo "title: \"${title}\""
     if [[ -n "$labels" ]]; then
       echo "labels: [${labels}]"

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -22,9 +22,29 @@ Examples:
 /orchestrate #108
 /orchestrate --env headless #108 #109
 /orchestrate --env ci #42
+/orchestrate https://github.com/org/planning/issues/578
 ```
 
 Note: In plugin mode, `/cekernel:orchestrate` also works.
+
+### Cross-repo Issue References (#440)
+
+Issue references may be plain numbers (`#108`) or full references to another
+repository (issue URL `https://github.com/owner/repo/issues/N`, path
+`/owner/repo/issues/N`, or `owner/repo#N` notation). For each non-plain
+reference, extract `owner/repo` and the issue number, then compare
+`owner/repo` with the current repository (from `git config --get
+remote.origin.url`):
+
+- **Same repository** → treat as a plain issue number (no special handling)
+- **Different repository (cross-repo)** → record `owner/repo` as the issue
+  repo for that issue. Pass `--repo <owner/repo>` to all issue-related `gh`
+  commands in triage, and include the issue repo in the Orchestrator prompt
+  (see Step 2) so it is propagated to `spawn-worker.sh --repo`
+
+The working repository (current directory) always hosts the worktrees,
+branches, and PRs — run `/orchestrate` from the implementation repository,
+not from the meta-repository that hosts the issues.
 
 ## Workflow
 
@@ -128,6 +148,7 @@ Note: Claude Code session ID (`orchestrator.claude-session-id`) persistence is h
 Process the following issues: <#N title, #M title, ...>
 <Execution order if determined in Step 1, otherwise omit this line>
 <Base branch: <branch> if specified, otherwise omit this line>
+<Issue repo: <owner/repo> — pass --repo <owner/repo> to spawn-worker.sh and to issue-related gh commands. Only for cross-repo issues, otherwise omit this line>
 
 Environment values to propagate in ALL script invocations:
 - CEKERNEL_SESSION_ID=<session-id>

--- a/tests/orchestrator/spawn.bats
+++ b/tests/orchestrator/spawn.bats
@@ -5,7 +5,8 @@
 # (headless backend) and asserts the recorded claude argv (ADR-0017) —
 # never the text of generated scripts.
 #
-# Covers --fallback-model / CEKERNEL_FALLBACK_MODEL passthrough (#529).
+# Covers --fallback-model / CEKERNEL_FALLBACK_MODEL passthrough (#529)
+# and --repo cross-repo issue support (#440).
 
 load '../helpers/assertions'
 
@@ -20,12 +21,15 @@ setup() {
     commit -q --allow-empty -m "init"
   git clone -q "${TMP}/upstream" "${TMP}/repo"
 
-  # Mock gh: spawn.sh reads the title, task-file.sh reads full JSON
+  # Mock gh: spawn.sh reads the title, task-file.sh reads full JSON.
+  # Records argv so tests can assert executed effects (ADR-0017).
   MOCK_BIN="${TMP}/bin"
   mkdir -p "$MOCK_BIN"
-  cat > "${MOCK_BIN}/gh" <<'GH'
+  GH_ARGS_FILE="${TMP}/gh-args.txt"
+  cat > "${MOCK_BIN}/gh" <<GH
 #!/usr/bin/env bash
-if [[ "$*" == *"-q"* ]]; then
+echo "\$*" >> '${GH_ARGS_FILE}'
+if [[ "\$*" == *"-q"* ]]; then
   echo "Test issue"
 else
   echo '{"title":"Test issue","body":"test body","labels":[],"comments":[]}'
@@ -107,6 +111,53 @@ run_spawn() {
   argv="$(cat "$ARGS_FILE")"
   if [[ "$argv" == *"--fallback-model"* ]]; then
     echo "FAIL: --fallback-model must not appear by default: ${argv}" >&2
+    return 1
+  fi
+}
+
+# ── Cross-repo issue support (#440) ──
+
+@test "spawn.sh --repo passes --repo to gh issue view" {
+  run_spawn --repo acme/planning
+  assert_eq "spawn exits 0" "0" "$status"
+  local gh_argv
+  gh_argv="$(tr '\n' ' ' < "$GH_ARGS_FILE")"
+  assert_match "gh argv contains --repo owner/repo" \
+    "--repo acme/planning" "$gh_argv"
+}
+
+@test "spawn.sh --repo writes repo: field into the task file" {
+  run_spawn --repo acme/planning
+  assert_eq "spawn exits 0" "0" "$status"
+  local task_file="${TMP}/repo/.worktrees/issue/42-test-issue/.cekernel-task.md"
+  assert_file_exists "task file created in worktree" "$task_file"
+  assert_match "task file has repo field" \
+    "repo: acme/planning" "$(cat "$task_file")"
+}
+
+@test "spawn.sh --repo references owner/repo#N in the worker prompt" {
+  run_spawn --repo acme/planning
+  assert_eq "spawn exits 0" "0" "$status"
+  wait_for_file "$ARGS_FILE"
+  local argv
+  argv="$(tr '\n' ' ' < "$ARGS_FILE")"
+  assert_match "claude argv references cross-repo issue" \
+    "acme/planning#42" "$argv"
+}
+
+@test "spawn.sh without --repo keeps current-repo behavior" {
+  run_spawn
+  assert_eq "spawn exits 0" "0" "$status"
+  local gh_argv
+  gh_argv="$(tr '\n' ' ' < "$GH_ARGS_FILE")"
+  if [[ "$gh_argv" == *"--repo"* ]]; then
+    echo "FAIL: --repo must not appear in gh argv by default: ${gh_argv}" >&2
+    return 1
+  fi
+  local task_file="${TMP}/repo/.worktrees/issue/42-test-issue/.cekernel-task.md"
+  assert_file_exists "task file created in worktree" "$task_file"
+  if grep -q '^repo:' "$task_file"; then
+    echo "FAIL: repo: field must not appear in task file by default" >&2
     return 1
   fi
 }

--- a/tests/shared/task-file.bats
+++ b/tests/shared/task-file.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# task-file.bats — bats-core tests for scripts/shared/task-file.sh
+#
+# Covers the cross-repo `repo` argument of create_task_file (#440):
+# recorded gh argv (ADR-0017: executed effects, not generated text) and
+# the `repo:` frontmatter field. Legacy coverage for the repo-less
+# behavior lives in tests/shared/test-task-file.sh.
+
+load '../helpers/assertions'
+load '../helpers/mock-bin'
+
+setup() {
+  CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  WORKTREE="${BATS_TEST_TMPDIR}/worktree"
+  mkdir -p "$WORKTREE"
+  GH_ARGV_LOG="${BATS_TEST_TMPDIR}/gh-argv.log"
+}
+
+# mock_gh_issue — PATH-shim gh that records argv and returns canned issue JSON
+mock_gh_issue() {
+  mock_bin gh "printf '%s\n' \"\$*\" >> \"${GH_ARGV_LOG}\"
+cat <<'JSON'
+{\"title\":\"feat: cross repo issue\",\"body\":\"issue body\",\"labels\":[{\"name\":\"enhancement\"}],\"comments\":[]}
+JSON"
+}
+
+@test "create_task_file with repo arg passes --repo to gh" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42 "acme/planning"
+
+  assert_file_exists "gh argv recorded" "$GH_ARGV_LOG"
+  assert_match "gh argv contains --repo owner/repo" \
+    "--repo acme/planning" "$(cat "$GH_ARGV_LOG")"
+}
+
+@test "create_task_file with repo arg writes repo: field to frontmatter" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42 "acme/planning"
+
+  assert_file_exists "task file created" "${WORKTREE}/.cekernel-task.md"
+  assert_match "frontmatter has repo field" \
+    "repo: acme/planning" "$(cat "${WORKTREE}/.cekernel-task.md")"
+}
+
+@test "create_task_file without repo arg omits --repo and repo: field" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42
+
+  local gh_argv content
+  gh_argv="$(cat "$GH_ARGV_LOG")"
+  content="$(cat "${WORKTREE}/.cekernel-task.md")"
+  if [[ "$gh_argv" == *"--repo"* ]]; then
+    echo "FAIL: --repo must not appear without repo arg: ${gh_argv}" >&2
+    return 1
+  fi
+  if [[ "$content" == *"repo:"* ]]; then
+    echo "FAIL: repo: field must not appear without repo arg" >&2
+    return 1
+  fi
+  assert_match "task file still has issue number" "issue: 42" "$content"
+}
+
+@test "create_task_file with empty repo arg behaves like no repo arg" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42 ""
+
+  local gh_argv
+  gh_argv="$(cat "$GH_ARGV_LOG")"
+  if [[ "$gh_argv" == *"--repo"* ]]; then
+    echo "FAIL: --repo must not appear with empty repo arg: ${gh_argv}" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
closes #440

## Summary

`spawn.sh` に `--repo <owner/repo>` フラグを追加し、別リポジトリ(メタリポジトリ)の Issue を参照して作業する cross-repo ケースをサポートしました。

- **`scripts/orchestrator/spawn.sh`**: `--repo` フラグ追加。`gh issue view` に `--repo` を付与して正しい Issue タイトルを取得(→ ブランチ名も正しいタイトルから生成)。Worker プロンプトでは Issue を `owner/repo#N` 形式で参照し、issue 系 `gh` コマンドに `--repo` を付与する指示を追加
- **`scripts/shared/task-file.sh`**: `create_task_file <worktree> <issue> [repo]` に repo 引数を追加。cross-repo 時は frontmatter に `repo: owner/repo` フィールドを出力し、Worker が cross-repo を検知可能に(post-mortem 提案 2)
- **`scripts/orchestrator/spawn-worker.sh`**: usage ヘッダに `--repo` を追記(フラグ自体は `"$@"` でパススルー)
- **`skills/orchestrate/SKILL.md`**: Issue URL / `owner/repo#N` 参照から repo を抽出し、Orchestrator プロンプトへ伝播するロジックを追記
- **`agents/orchestrator.md`**: Cross-repo Issues 節を追加(triage と `spawn-worker.sh --repo` への伝播)
- **`agents/worker.md`**: task file の `repo:` フィールド検知と issue 系 `gh` コマンドへの `--repo` 付与を追記
- **`README.md`**: cross-repo フローの説明と `autoMode.environment` trust snippet を併記

### 互換性

`--repo` 未指定時はカレントリポジトリ(現行動作)に完全フォールバック。既存の呼び出し元・task file 形式に影響なし。

### スコープ外

- Worker の CLOSED issue cross-validation ガード(post-mortem 提案 3)は Worker 挙動の独立した変更のため本 PR には含めず、必要なら別 issue で対応

## Test Plan

- [x] `tests/shared/task-file.bats`(新規): repo 引数 → `gh --repo` argv / `repo:` frontmatter、repo なし・空文字時の現行動作維持
- [x] `tests/orchestrator/spawn.bats`(追加): `--repo` → gh argv、task file の `repo:` フィールド、Worker プロンプトの `owner/repo#N` 参照、デフォルト時の非付与
- [x] `tests/shared/test-task-file.sh`(既存 legacy): 23 passed(回帰なし)
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)