### PR TITLE
fix: propagate spawn.sh base branch to Worker via task file frontmatter

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -217,9 +217,11 @@ Repeat the cycle for each incremental change. The parenthesized sub-detail is ba
 
 **Sync with the base branch first.** Sibling PRs may have merged into the
 base branch while you were implementing; a stale base causes conflicts and
-missed-integration bugs (#562). Determine the base branch (from the issue
-body/comments or the repository default) and integrate the latest state
-before pushing:
+missed-integration bugs (#562). Determine the base branch from the `base:`
+frontmatter field of `.cekernel-task.md` (recorded at spawn time — the
+branch the worktree was created from). If the field is absent, fall back
+to the issue body/comments, then the repository default. Integrate the
+latest state before pushing:
 
 ```bash
 BASE=<base-branch>

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -248,7 +248,8 @@ else
   # Extract issue data into worktree (session memory: page cache)
   # Processes read .cekernel-task.md locally instead of calling gh issue view,
   # reducing GitHub API calls and context window consumption.
-  create_task_file "$WORKTREE" "$ISSUE_NUMBER" "$ISSUE_REPO"
+  # Record the base branch so the Worker targets it with `gh pr create --base` (#562)
+  create_task_file "$WORKTREE" "$ISSUE_NUMBER" "$ISSUE_REPO" "$BASE_BRANCH"
   echo "task file: $(task_file_path "$WORKTREE")" >&2
 fi
 

--- a/scripts/shared/task-file.sh
+++ b/scripts/shared/task-file.sh
@@ -62,14 +62,17 @@ task_file_clear_resume_marker() {
   fi
 }
 
-# create_task_file <worktree> <issue-number> [repo]
+# create_task_file <worktree> <issue-number> [repo] [base-branch]
 # Fetches issue data via gh and writes .cekernel-task.md in the worktree.
 # When [repo] (owner/repo) is given, fetches from that repository and
 # records it as a `repo:` frontmatter field (cross-repo issue, #440).
+# When [base-branch] is given, records it as a `base:` frontmatter field
+# so Workers target the correct branch with `gh pr create --base` (#562).
 create_task_file() {
-  local worktree="${1:?Usage: create_task_file <worktree> <issue-number> [repo]}"
-  local issue_number="${2:?Usage: create_task_file <worktree> <issue-number> [repo]}"
+  local worktree="${1:?Usage: create_task_file <worktree> <issue-number> [repo] [base-branch]}"
+  local issue_number="${2:?Usage: create_task_file <worktree> <issue-number> [repo] [base-branch]}"
   local repo="${3:-}"
+  local base_branch="${4:-}"
   local task_file
   task_file="$(task_file_path "$worktree")"
 
@@ -94,6 +97,9 @@ create_task_file() {
     echo "issue: ${issue_number}"
     if [[ -n "$repo" ]]; then
       echo "repo: ${repo}"
+    fi
+    if [[ -n "$base_branch" ]]; then
+      echo "base: ${base_branch}"
     fi
     echo "title: \"${title}\""
     if [[ -n "$labels" ]]; then

--- a/scripts/shared/task-file.sh
+++ b/scripts/shared/task-file.sh
@@ -8,12 +8,14 @@
 # Usage: source task-file.sh
 #
 # Functions:
-#   create_task_file <worktree> <issue-number> [repo]
+#   create_task_file <worktree> <issue-number> [repo] [base-branch]
 #     — Fetch issue and write .cekernel-task.md. When [repo] (owner/repo)
 #       is given, the issue is fetched from that repository via
 #       `gh issue view --repo` and a `repo:` frontmatter field is written
 #       so Workers can detect cross-repo issues (#440). When omitted,
 #       the current repository is used (unchanged behavior).
+#       When [base-branch] is given, a `base:` frontmatter field is
+#       written so Workers target it with `gh pr create --base` (#562).
 #   task_file_path <worktree>                   — Return the task file path
 #   task_file_exists <worktree>                 — Check if the task file exists (exit 0/1)
 #   task_file_clear_resume_marker <worktree>    — Remove "## Resume Reason:" section

--- a/tests/orchestrator/spawn.bats
+++ b/tests/orchestrator/spawn.bats
@@ -145,6 +145,26 @@ run_spawn() {
     "acme/planning#42" "$argv"
 }
 
+# ── Base branch propagation (#562) ──
+
+@test "spawn.sh records the base branch in the task file" {
+  # Non-default base branch in upstream
+  git -C "${TMP}/upstream" branch dev
+  run bash -c "cd '${TMP}/repo' && bash '${SPAWN_SCRIPT}' --agent worker 42 dev"
+  assert_eq "spawn exits 0" "0" "$status"
+  local task_file="${TMP}/repo/.worktrees/issue/42-test-issue/.cekernel-task.md"
+  assert_file_exists "task file created in worktree" "$task_file"
+  assert_match "task file has base field" "base: dev" "$(cat "$task_file")"
+}
+
+@test "spawn.sh records the default base branch (main) in the task file" {
+  run_spawn
+  assert_eq "spawn exits 0" "0" "$status"
+  local task_file="${TMP}/repo/.worktrees/issue/42-test-issue/.cekernel-task.md"
+  assert_file_exists "task file created in worktree" "$task_file"
+  assert_match "task file has base field" "base: main" "$(cat "$task_file")"
+}
+
 @test "spawn.sh without --repo keeps current-repo behavior" {
   run_spawn
   assert_eq "spawn exits 0" "0" "$status"

--- a/tests/shared/task-file.bats
+++ b/tests/shared/task-file.bats
@@ -79,3 +79,43 @@ JSON"
     return 1
   fi
 }
+
+# ── Base branch propagation (#562) ──
+
+@test "create_task_file with base arg writes base: field to frontmatter" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42 "" "2.0-dev"
+
+  assert_file_exists "task file created" "${WORKTREE}/.cekernel-task.md"
+  assert_match "frontmatter has base field" \
+    "base: 2.0-dev" "$(cat "${WORKTREE}/.cekernel-task.md")"
+}
+
+@test "create_task_file with repo and base args writes both fields" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42 "acme/planning" "2.0-dev"
+
+  local content
+  content="$(cat "${WORKTREE}/.cekernel-task.md")"
+  assert_match "frontmatter has repo field" "repo: acme/planning" "$content"
+  assert_match "frontmatter has base field" "base: 2.0-dev" "$content"
+}
+
+@test "create_task_file without base arg omits base: field" {
+  mock_gh_issue
+  source "${CEKERNEL_DIR}/scripts/shared/task-file.sh"
+
+  create_task_file "$WORKTREE" 42
+
+  local content
+  content="$(cat "${WORKTREE}/.cekernel-task.md")"
+  if [[ "$content" == *"base:"* ]]; then
+    echo "FAIL: base: field must not appear without base arg" >&2
+    return 1
+  fi
+  assert_match "task file still has issue number" "issue: 42" "$content"
+}


### PR DESCRIPTION
closes #562

## Summary
- `create_task_file` に `[base-branch]` 引数を追加し、`.cekernel-task.md` の frontmatter に `base:` フィールドを記録(#440 の `repo:` フィールドと同じパターン)
- `spawn.sh` が `git worktree add` に使う `BASE_BRANCH` を `create_task_file` に渡すよう修正 — これまで Worker への伝達経路がなく、`gh pr create` がデフォルトブランチに落ちていた(PR #559 が main 宛てになった根本原因)
- Worker プロトコル(`agents/worker.md` Phase 2)を「task file の `base:` フィールドから base branch を決定(未記載なら issue 本文/コメント → リポジトリデフォルト)」に更新

## Test Plan
- [x] `tests/shared/task-file.bats`: base 引数あり/repo+base 併用/base なし(省略時は `base:` 非出力)の 3 ケース追加
- [x] `tests/orchestrator/spawn.bats`: 非デフォルト base(`dev`)とデフォルト(`main`)で task file に `base:` が記録されることを検証
- [x] TDD (RED → GREEN → REFACTOR) で実装、`agents/worker.md` は非実行ファイルのためテストなし
- [x] 既存 legacy テスト `tests/shared/test-task-file.sh` も 23 passed で後方互換を確認