### PR TITLE
docs: ADR-0015 follow-ups — README 使い分けガイド + agent 定義への注記

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ graph LR
 
 For details on logging, IPC, and resource governance, see [internals.md](./docs/internals.md).
 
+### cekernel vs `/workflows`
+
+Claude Code's dynamic `/workflows` also runs agents in parallel, so the two can look interchangeable. They are not — the boundary rule is: **state that must survive the session belongs to cekernel; fan-out that completes within a session belongs to `/workflows`** (in one sentence: cekernel persists, `/workflows` fans out). If your task is an issue lifecycle that spans CI waits, human review, and retries over hours or days, use cekernel; if it is a wide parallel pass that starts and finishes inside one session (e.g. a migration sweep or a multi-file analysis), use `/workflows`. See [ADR-0015](./docs/adr/0015-workflows-boundary.md) for the full analysis.
+
+| Axis | cekernel | `/workflows` |
+|------|----------|--------------|
+| Use for | Lifecycles that outlive a session (issue → PR → CI → review → merge) | Fan-out that completes within one session |
+| Survives the session | Yes — OS processes, files, git worktrees | No — a run dies with its session |
+| Time horizon | Hours–days (CI waits, human review, retries) | One session's wall-clock |
+| Identity | Issue number = PID; named branches and PRs | Anonymous agent index |
+| Trigger | Event-driven (FIFO, cron/at, human) | Single deterministic run |
+
 ## Structure
 
 ```

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -173,6 +173,12 @@ changes-requested
 
 Nothing may follow the verdict line.
 
+## `/workflows` for Single-Task Fan-out (ADR-0015)
+
+Per [ADR-0015](../docs/adr/0015-workflows-boundary.md) Decision 3, a Reviewer MAY use Claude Code's dynamic `/workflows` **within its own session** for a fan-out that serves its single review task (e.g. a per-finding find→verify pipeline), when a skill or agent definition explicitly instructs it. Such a run is an implementation detail of the review, invisible to cekernel's lifecycle. Workflow agents must respect the read-only constraints below — no file modifications, commits, or pushes.
+
+> **Not yet exercisable**: ADR-0015's Open questions (opt-in gate in non-interactive sessions, Workflow tool exposure on a subagent's tool surface — the Reviewer runs at depth 1, putting workflow agents at depth 2) are unverified. Until they are resolved, do **not** invoke `/workflows`.
+
 ## Constraints
 
 - **Reviewer must not merge PRs** — merge is the Orchestrator's responsibility

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -211,6 +211,12 @@ For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first 
 
 Repeat the cycle for each incremental change. The parenthesized sub-detail is backward-compatible — `phase1:implement` (without parentheses) remains valid for non-TDD work.
 
+#### `/workflows` for Single-Task Fan-out (ADR-0015)
+
+Per [ADR-0015](../docs/adr/0015-workflows-boundary.md) Decision 3, a Worker MAY use Claude Code's dynamic `/workflows` **within its own session** for a wide fan-out that serves its single task (e.g. a migration sweep or a multi-dimension self-review), when a skill or agent definition explicitly instructs it. Such a run is an implementation detail of the Worker's task, invisible to cekernel's lifecycle — it must start and finish inside the Worker's session and must not carry lifecycle state.
+
+> **Not yet exercisable**: ADR-0015's Open questions (opt-in gate in non-interactive sessions, Workflow tool exposure on the tool surface) are unverified for cekernel's execution contexts. Until they are resolved, do **not** invoke `/workflows`.
+
 ### Phase 2: Create PR
 
 > Transition: `phase-transition.sh <issue> RUNNING "phase2:create-pr"`


### PR DESCRIPTION
closes #555

## Summary
- README: Concept セクション直下に「cekernel vs `/workflows`」使い分けガイドを追加(表1つ + 段落1つ)。境界ルール: セッションを跨ぐ状態は cekernel、セッション内で完結する fan-out は `/workflows`(cekernel persists, `/workflows` fans out)
- `agents/worker.md`: Phase 1 配下に、single-task fan-out に限り `/workflows` 使用可の注記を追加(ADR-0015 Decision 3)。Open questions 検証前は行使不可の旨を明記
- `agents/reviewer.md`: 同様の注記を追加(per-finding find→verify pipeline の例、depth 2 の未検証事項、read-only 制約の維持を明記)

## Test Plan
- [ ] ドキュメントのみの変更(非実行ファイル)のため、テスト追加なし(CLAUDE.md のテストポリシーに準拠)
- [ ] CI がパスすること