### PR TITLE
feat: Phase 4 — orchctl ps を claude agents --json の view 層に

### DIFF
--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -177,16 +177,7 @@ compute_elapsed() {
   spawned_at=$(cat "${ipc_dir}/${process_type}-${issue}.spawned" 2>/dev/null || true)
   spawned_at="${spawned_at:-$(date +%s)}"
 
-  local now elapsed
-  now=$(date +%s)
-  elapsed=$((now - spawned_at))
-  if [[ $elapsed -ge 3600 ]]; then
-    echo "$((elapsed / 3600))h$((elapsed % 3600 / 60))m"
-  elif [[ $elapsed -ge 60 ]]; then
-    echo "$((elapsed / 60))m"
-  else
-    echo "${elapsed}s"
-  fi
+  format_elapsed "$(($(date +%s) - spawned_at))"
 }
 
 # ── Helper: detect backend from metadata file (with heuristic fallback) ──

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -145,6 +145,18 @@ set_ipc_context() {
   export CEKERNEL_IPC_DIR="${IPC_BASE}/${RESOLVED_SESSION}"
 }
 
+# ── Helper: format elapsed seconds as h/m/s ──
+format_elapsed() {
+  local elapsed="$1"
+  if [[ $elapsed -ge 3600 ]]; then
+    echo "$((elapsed / 3600))h$((elapsed % 3600 / 60))m"
+  elif [[ $elapsed -ge 60 ]]; then
+    echo "$((elapsed / 60))m"
+  else
+    echo "${elapsed}s"
+  fi
+}
+
 # ── Helper: compute elapsed time from .spawned file ──
 compute_elapsed() {
   local fifo="$1"
@@ -291,12 +303,15 @@ cmd_ls() {
   fi
 }
 
-# ── ps: Show orchestrator sessions (session-ID based, ADR-0016 Phase 2) ──
-# Liveness comes from `claude agents --json` state via the token captured
-# in orchestrator.claude-session-id. States are shown as-is so `blocked`
+# ── ps: agents --json view layer (ADR-0016 Phase 4) ──
+# `claude agents --json` is fetched ONCE per invocation; every registered
+# token (orchestrator.claude-session-id, handle-{issue}.{type}) is
+# prefix-matched against that single body. States print as-is so `blocked`
 # (permission-dialog stall) is surfaced distinctly; an unlisted token shows
-# as `missing`. The former PID process tree / managed-process display was
-# PID-based and is gone — #549 (Phase 4) rebuilds the view on agents --json.
+# as `missing`. Worker/Reviewer rows join the cekernel-specific columns —
+# issue, phase (state-file detail), priority — per the ADR-0015 boundary:
+# the view adds only what `claude agents` cannot know. Sessions without an
+# orchestrator token (interactive orchestrators) still list their workers.
 cmd_ps() {
   local session_filter=""
 
@@ -315,6 +330,10 @@ cmd_ps() {
     return 0
   fi
 
+  # Single fetch — the whole command is a view over this one response
+  local agents_json
+  agents_json=$(claude_bg_agents_json) || agents_json="[]"
+
   for session_dir in "$IPC_BASE"/*/; do
     [[ -d "$session_dir" ]] || continue
     local sid
@@ -325,37 +344,56 @@ cmd_ps() {
       continue
     fi
 
+    # ── Orchestrator row ──
     local sid_file="${session_dir}orchestrator.claude-session-id"
-    [[ -f "$sid_file" ]] || continue
+    if [[ -f "$sid_file" ]]; then
+      local token
+      token=$(tr -d '[:space:]' < "$sid_file")
+      if [[ -n "$token" ]]; then
+        # Compute elapsed from orchestrator.spawned
+        local elapsed=""
+        local spawned_file="${session_dir}orchestrator.spawned"
+        if [[ -f "$spawned_file" ]]; then
+          local spawned_at
+          spawned_at=$(tr -d '[:space:]' < "$spawned_file")
+          spawned_at="${spawned_at:-$(date +%s)}"
+          elapsed=$(format_elapsed "$(($(date +%s) - spawned_at))")
+        fi
 
-    local token
-    token=$(tr -d '[:space:]' < "$sid_file")
-    [[ -n "$token" ]] || continue
+        local state
+        state=$(claude_bg_state_from_json "$agents_json" "$token") || state="missing"
 
-    # Compute elapsed from orchestrator.spawned
-    local elapsed=""
-    local spawned_file="${session_dir}orchestrator.spawned"
-    if [[ -f "$spawned_file" ]]; then
-      local spawned_at now elapsed_sec
-      spawned_at=$(tr -d '[:space:]' < "$spawned_file")
-      spawned_at="${spawned_at:-$(date +%s)}"
-      now=$(date +%s)
-      elapsed_sec=$((now - spawned_at))
-      if [[ $elapsed_sec -ge 3600 ]]; then
-        elapsed="$((elapsed_sec / 3600))h$((elapsed_sec % 3600 / 60))m"
-      elif [[ $elapsed_sec -ge 60 ]]; then
-        elapsed="$((elapsed_sec / 60))m"
-      else
-        elapsed="${elapsed_sec}s"
+        found=$((found + 1))
+        echo "orchestrator  claude=${token}  session=${sid}  elapsed=${elapsed}  ${state}"
       fi
     fi
 
-    local state
-    state=$(claude_bg_state_for_token "$token" 2>/dev/null) || state="missing"
+    # ── Managed rows (Worker/Reviewer sessions) ──
+    for handle_file in "${session_dir}"handle-*.*; do
+      [[ -f "$handle_file" ]] || continue
+      local fname issue_type issue mtype
+      fname=$(basename "$handle_file")
+      issue_type="${fname#handle-}"
+      issue="${issue_type%%.*}"
+      mtype="${issue_type#*.}"
+      [[ "$issue" =~ ^[0-9]+$ ]] || continue
 
-    found=$((found + 1))
+      local mtoken
+      mtoken=$(tr -d '[:space:]' < "$handle_file")
+      [[ -n "$mtoken" ]] || continue
 
-    echo "orchestrator  claude=${token}  session=${sid}  elapsed=${elapsed}  ${state}"
+      local mstate
+      mstate=$(claude_bg_state_from_json "$agents_json" "$mtoken") || mstate="missing"
+
+      # Join cekernel-specific columns from state/priority files
+      export CEKERNEL_IPC_DIR="$session_dir"
+      local phase priority
+      phase=$(worker_state_read "$issue" | jq -r '.detail')
+      priority=$(worker_priority_read "$issue" | jq -r '.priority')
+
+      found=$((found + 1))
+      echo "  ${mtype}  #${issue}  claude=${mtoken}  phase=${phase}  priority=${priority}  ${mstate}"
+    done
   done
 
   if [[ "$found" -eq 0 ]]; then
@@ -943,10 +981,15 @@ cmd_gc() {
 # ── count: Count running orchestrators (internal, ADR-0014) ──
 # Session-ID based (ADR-0016 Phase 2): a session counts when its captured
 # token maps to a busy or blocked session in `claude agents --json`.
+# Single fetch per invocation (Phase 4): all tokens resolve against one
+# `agents --json` response.
 cmd_count() {
   local count=0
 
   if [[ -d "$IPC_BASE" ]]; then
+    local agents_json
+    agents_json=$(claude_bg_agents_json) || agents_json="[]"
+
     for session_dir in "$IPC_BASE"/*/; do
       [[ -d "$session_dir" ]] || continue
 
@@ -957,7 +1000,9 @@ cmd_count() {
       token=$(tr -d '[:space:]' < "$sid_file")
       [[ -n "$token" ]] || continue
 
-      if claude_bg_token_alive "$token" 2>/dev/null; then
+      local state
+      state=$(claude_bg_state_from_json "$agents_json" "$token") || continue
+      if [[ "$state" == "busy" || "$state" == "blocked" ]]; then
         count=$((count + 1))
       fi
     done

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -971,7 +971,8 @@ cmd_gc() {
 
 # ── count: Count running orchestrators (internal, ADR-0014) ──
 # Session-ID based (ADR-0016 Phase 2): a session counts when its captured
-# token maps to a busy or blocked session in `claude agents --json`.
+# token is alive (busy/blocked) per claude_bg_token_alive_from_json — the
+# liveness vocabulary lives in claude-bg.sh, not here (Rule of Separation).
 # Single fetch per invocation (Phase 4): all tokens resolve against one
 # `agents --json` response.
 cmd_count() {
@@ -991,9 +992,7 @@ cmd_count() {
       token=$(tr -d '[:space:]' < "$sid_file")
       [[ -n "$token" ]] || continue
 
-      local state
-      state=$(claude_bg_state_from_json "$agents_json" "$token") || continue
-      if [[ "$state" == "busy" || "$state" == "blocked" ]]; then
+      if claude_bg_token_alive_from_json "$agents_json" "$token"; then
         count=$((count + 1))
       fi
     done

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -376,11 +376,12 @@ cmd_ps() {
       local mstate
       mstate=$(claude_bg_state_from_json "$agents_json" "$mtoken") || mstate="missing"
 
-      # Join cekernel-specific columns from state/priority files
-      export CEKERNEL_IPC_DIR="$session_dir"
+      # Join cekernel-specific columns from state/priority files.
+      # CEKERNEL_IPC_DIR is scoped to each command substitution (subshell)
+      # — a read-only view must not mutate the global session context.
       local phase priority
-      phase=$(worker_state_read "$issue" | jq -r '.detail')
-      priority=$(worker_priority_read "$issue" | jq -r '.priority')
+      phase=$(CEKERNEL_IPC_DIR="$session_dir" worker_state_read "$issue" | jq -r '.detail')
+      priority=$(CEKERNEL_IPC_DIR="$session_dir" worker_priority_read "$issue" | jq -r '.priority')
 
       found=$((found + 1))
       echo "  ${mtype}  #${issue}  claude=${mtoken}  phase=${phase}  priority=${priority}  ${mstate}"

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -17,6 +17,13 @@
 #     — List sessions as JSON. Fails when the claude CLI is unavailable or
 #       errors (Rule of Repair: callers decide how to surface it).
 #
+#   claude_bg_state_from_json <json> <token>
+#     — Echo the state of the session whose sessionId starts with <token>,
+#       resolved against a pre-fetched `agents --json` body. Lets view
+#       layers (orchctl ps/count) fetch once and join many tokens
+#       (ADR-0016 Phase 4).
+#     — Returns 1 (echoing nothing) when no session matches.
+#
 #   claude_bg_state_for_token <token>
 #     — Echo the logical state (busy|blocked|done|stopped|...) of the session
 #       whose sessionId starts with <token>. Live sessions report it in
@@ -47,15 +54,23 @@ claude_bg_agents_json() {
   claude agents --json 2>/dev/null
 }
 
-# claude_bg_state_for_token <token>
-claude_bg_state_for_token() {
-  local token="$1"
-  local json state
-  json=$(claude_bg_agents_json) || return 1
+# claude_bg_state_from_json <json> <token>
+claude_bg_state_from_json() {
+  local json="$1"
+  local token="$2"
+  local state
   state=$(echo "$json" | jq -r --arg p "$token" \
     '[.[] | select(.sessionId | startswith($p))][0] | (.status // .state) // empty')
   [[ -n "$state" ]] || return 1
   echo "$state"
+}
+
+# claude_bg_state_for_token <token>
+claude_bg_state_for_token() {
+  local token="$1"
+  local json
+  json=$(claude_bg_agents_json) || return 1
+  claude_bg_state_from_json "$json" "$token"
 }
 
 # claude_bg_token_alive <token>

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -34,10 +34,17 @@
 #       degraded fallback — prefix matching serves both.
 #     — Returns 1 (echoing nothing) when no session matches or the query fails.
 #
-#   claude_bg_token_alive <token>
-#     — exit 0 when the session state is busy or blocked (alive), 1 otherwise.
+#   claude_bg_token_alive_from_json <json> <token>
+#     — exit 0 when the session state is busy or blocked (alive), 1
+#       otherwise, resolved against a pre-fetched `agents --json` body.
 #       blocked means the session waits on a permission dialog — alive but
-#       stalled; supervision surfaces it distinctly (ADR-0016).
+#       stalled; supervision surfaces it distinctly (ADR-0016). This is the
+#       single home of the busy/blocked liveness vocabulary — view layers
+#       (orchctl count) delegate here instead of comparing states inline.
+#
+#   claude_bg_token_alive <token>
+#     — Fetching variant of claude_bg_token_alive_from_json: queries
+#       `agents --json` itself, then delegates.
 #
 #   claude_bg_capture_session_id <short-id> <cwd>
 #     — Echo the full session UUID (ADR-0016 normative capture order):
@@ -73,12 +80,21 @@ claude_bg_state_for_token() {
   claude_bg_state_from_json "$json" "$token"
 }
 
+# claude_bg_token_alive_from_json <json> <token>
+claude_bg_token_alive_from_json() {
+  local json="$1"
+  local token="$2"
+  local state
+  state=$(claude_bg_state_from_json "$json" "$token") || return 1
+  [[ "$state" == "busy" || "$state" == "blocked" ]]
+}
+
 # claude_bg_token_alive <token>
 claude_bg_token_alive() {
   local token="$1"
-  local state
-  state=$(claude_bg_state_for_token "$token") || return 1
-  [[ "$state" == "busy" || "$state" == "blocked" ]]
+  local json
+  json=$(claude_bg_agents_json) || return 1
+  claude_bg_token_alive_from_json "$json" "$token"
 }
 
 # claude_bg_capture_session_id <short-id> <cwd>

--- a/skills/orchctl/SKILL.md
+++ b/skills/orchctl/SKILL.md
@@ -69,23 +69,26 @@ Format the output as a readable table for the user:
 | Session | Repo | Issue | State | Priority | Elapsed | Backend |
 |---------|------|-------|-------|----------|---------|---------|
 
-#### ps — Show Orchestrator process trees
+#### ps — Show Orchestrator sessions and their managed Worker/Reviewer sessions
 
 ```bash
 bash "$ORCHCTL" ps [--session <id>]
 ```
 
-Shows all Orchestrator sessions across all cekernel sessions. Unlike `ls` (which shows Workers from IPC state files), `ps` reads the `orchestrator.claude-session-id` token captured at spawn time and resolves its state via `claude agents --json` (ADR-0016 Phase 2).
+Shows all Orchestrator sessions across all cekernel sessions, plus the managed Worker/Reviewer sessions in each. `ps` is a view layer over a single `claude agents --json` fetch (ADR-0016 Phase 4): it resolves the `orchestrator.claude-session-id` token and every `handle-{issue}.{type}` token against that response, and joins the cekernel-specific columns (issue, phase from the state file, priority) that `claude agents` cannot know (ADR-0015).
 
 Output format:
 
 ```
 orchestrator  claude=aaaa1111-2222-4333-8444-555566667777  session=cekernel-7069bc3d  elapsed=5m  busy
+  worker  #42  claude=dddd4444-5555-4666-8777-888899990000  phase=phase1:implement  priority=10  busy
+  reviewer  #43  claude=eeee5555-6666-4777-8888-99990000aaaa  phase=reviewing  priority=10  blocked
 ```
 
 - `--session <id>`: Filter to a specific session
 - The trailing state is the raw `claude agents --json` state (`busy`, `blocked`, `done`, `stopped`, ...); `missing` means the session is no longer listed. `blocked` means the session is stalled on a permission dialog — surface it to the user prominently.
-- If no orchestrators are found, outputs `no orchestrators.`
+- Sessions spawned by an interactive Orchestrator have no `orchestrator` row, but their Worker/Reviewer rows still appear.
+- If nothing is found, outputs `no orchestrators.`
 
 Present the output as-is (pre-formatted) to the user.
 

--- a/tests/ctl/orchctl-read.bats
+++ b/tests/ctl/orchctl-read.bats
@@ -9,8 +9,10 @@
 #
 # ps/count are session-ID based (ADR-0016 Phase 2, #547): orchestrator
 # liveness maps to `claude agents --json` state via the token captured in
-# orchestrator.claude-session-id — orchestrator.pid is gone. #549 (Phase 4:
-# agents --json view layer) further evolves the ps contract when it lands.
+# orchestrator.claude-session-id — orchestrator.pid is gone. #549 (Phase 4)
+# makes ps/count a single-fetch view over `claude agents --json`, joining
+# managed Worker/Reviewer rows (handle-{issue}.{type} tokens) with
+# cekernel-specific columns (issue, phase, priority) per ADR-0015.
 #
 # Mutating subcommands (term/suspend/resume/kill/nice/recover/gc) are
 # covered in orchctl-mutating.bats.
@@ -21,6 +23,8 @@ load '../helpers/mock-claude'
 
 ORCH_TOKEN_A="aaaa1111-2222-4333-8444-555566667777"
 ORCH_TOKEN_B="bbbb2222-3333-4444-8555-666677778888"
+WORKER_TOKEN="dddd4444-5555-4666-8777-888899990000"
+REVIEWER_TOKEN="eeee5555-6666-4777-8888-99990000aaaa"
 
 setup() {
   CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
@@ -60,6 +64,14 @@ make_orchestrator() {
   mkdir -p "$ipc_dir"
   echo "$token" > "${ipc_dir}/orchestrator.claude-session-id"
   date +%s > "${ipc_dir}/orchestrator.spawned"
+}
+
+# Register a managed session handle (ADR-0016 Phase 4: opaque session
+# token in handle-{issue}.{type}).
+make_handle() {
+  local ipc_dir="$1" issue="$2" type="$3" token="$4"
+  mkdir -p "$ipc_dir"
+  echo "$token" > "${ipc_dir}/handle-${issue}.${type}"
 }
 
 # ── ls ──
@@ -336,6 +348,109 @@ make_orchestrator() {
   assert_eq "legacy pid file alone shows nothing" "no orchestrators." "$output"
 }
 
+# ── ps managed rows (agents --json view layer, ADR-0016 Phase 4 / #549) ──
+
+@test "ps joins worker row: issue, phase, priority from cekernel files" {
+  make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
+  make_worker "$IPC_A" 10
+  make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
+  mock_claude_enqueue_agents "[
+    $(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy),
+    $(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy)
+  ]"
+  run bash "$ORCHCTL" ps
+  local worker_line
+  worker_line=$(echo "$output" | grep "#10")
+  assert_match "row shows type worker" "worker" "$worker_line"
+  assert_match "row shows claude token" "claude=${WORKER_TOKEN}" "$worker_line"
+  assert_match "row joins phase from state file" "phase=phase1:implement" "$worker_line"
+  assert_match "row joins priority from priority file" "priority=10" "$worker_line"
+  assert_match "row shows busy state" "busy" "$worker_line"
+}
+
+@test "ps surfaces a blocked worker session distinctly (ADR-0016 MUST)" {
+  make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
+  make_worker "$IPC_A" 10
+  make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
+  mock_claude_enqueue_agents "[
+    $(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy),
+    $(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 blocked)
+  ]"
+  run bash "$ORCHCTL" ps
+  assert_match "worker row shows blocked" "blocked" "$(echo "$output" | grep "#10")"
+}
+
+@test "ps shows missing for a worker token not listed in agents --json" {
+  make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
+  make_worker "$IPC_A" 10
+  make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
+  run bash "$ORCHCTL" ps
+  assert_match "worker row shows missing" "missing" "$(echo "$output" | grep "#10")"
+}
+
+@test "ps shows worker rows in a session without an orchestrator token" {
+  # Interactive orchestrators have no orchestrator.claude-session-id,
+  # but their spawned workers must still be visible.
+  make_worker "$IPC_A" 10
+  make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy)]"
+  run bash "$ORCHCTL" ps
+  assert_match "worker row shown" "#10" "$output"
+  assert_match "worker row shows busy" "busy" "$(echo "$output" | grep "#10")"
+  if [[ "$output" == *"no orchestrators."* ]]; then
+    echo "FAIL: worker rows found — must not print 'no orchestrators.'" >&2
+    return 1
+  fi
+}
+
+@test "ps shows reviewer type from handle-{issue}.reviewer" {
+  make_worker "$IPC_A" 11 "RUNNING:2026-02-28T10:00:00Z:reviewing"
+  make_handle "$IPC_A" 11 reviewer "$REVIEWER_TOKEN"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$REVIEWER_TOKEN" background /repo 1700000001000 busy)]"
+  run bash "$ORCHCTL" ps
+  assert_match "row shows type reviewer" "reviewer" "$(echo "$output" | grep "#11")"
+}
+
+@test "ps --session filter applies to worker rows" {
+  make_worker "$IPC_A" 10
+  make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
+  make_worker "$IPC_B" 20
+  make_handle "$IPC_B" 20 worker "$REVIEWER_TOKEN"
+  mock_claude_enqueue_agents "[
+    $(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy),
+    $(mock_claude_agent_record "$REVIEWER_TOKEN" background /repo 1700000002000 busy)
+  ]"
+  run bash "$ORCHCTL" ps --session "$SESSION_A"
+  assert_match "filtered session worker shown" "#10" "$output"
+  if [[ "$output" == *"#20"* ]]; then
+    echo "FAIL: ps --session should not show other sessions' workers" >&2
+    return 1
+  fi
+}
+
+@test "ps fetches agents --json exactly once per invocation (single-fetch view)" {
+  make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
+  make_worker "$IPC_A" 10
+  make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
+  make_orchestrator "$IPC_B" "$ORCH_TOKEN_B"
+  make_worker "$IPC_B" 20
+  make_handle "$IPC_B" 20 worker "$REVIEWER_TOKEN"
+  mock_claude_enqueue_agents "[
+    $(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy),
+    $(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy),
+    $(mock_claude_agent_record "$ORCH_TOKEN_B" background /repo 1700000002000 busy),
+    $(mock_claude_agent_record "$REVIEWER_TOKEN" background /repo 1700000003000 busy)
+  ]"
+  run bash "$ORCHCTL" ps
+  assert_eq "exit 0" "0" "$status"
+  assert_eq "agents --json called once" "1" \
+    "$(cat "${MOCK_CLAUDE_STATE_DIR}/agents-calls")"
+}
+
 # ── count (session-ID based, ADR-0016 Phase 2 / ADR-0014) ──
 
 @test "count with no sessions is 0" {
@@ -379,6 +494,19 @@ make_orchestrator() {
   run bash "$ORCHCTL" count
   assert_eq "busy + blocked counted, stopped ignored" "2" "$output"
   assert_match "output is a plain integer" '^[0-9]+$' "$output"
+}
+
+@test "count fetches agents --json exactly once per invocation (single-fetch view)" {
+  make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
+  make_orchestrator "$IPC_B" "$ORCH_TOKEN_B"
+  mock_claude_enqueue_agents "[
+    $(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy),
+    $(mock_claude_agent_record "$ORCH_TOKEN_B" background /repo 1700000001000 busy)
+  ]"
+  run bash "$ORCHCTL" count
+  assert_eq "count busy sessions" "2" "$output"
+  assert_eq "agents --json called once" "1" \
+    "$(cat "${MOCK_CLAUDE_STATE_DIR}/agents-calls")"
 }
 
 # ── usage ──

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -84,6 +84,51 @@ setup() {
   assert_eq "legacy busy is alive" "0" "$status"
 }
 
+# ── claude_bg_token_alive_from_json ──
+
+@test "token_alive_from_json: busy and blocked are alive; done and missing are not" {
+  # Pre-fetched body — no CLI call. Single-fetch views (orchctl ps/count)
+  # resolve every token against one response (ADR-0016 Phase 4); the
+  # busy/blocked liveness vocabulary lives HERE, not in the view layers.
+  local json
+  json="[
+    $(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy),
+    $(mock_claude_agent_record "bbbb0000-1111-4222-8333-444455556666" background /tmp/x 1700000001000 blocked),
+    $(mock_claude_agent_record "cccc0000-1111-4222-8333-444455556666" background /tmp/x 1700000002000 done)
+  ]"
+
+  run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
+  assert_eq "busy is alive" "0" "$status"
+
+  run claude_bg_token_alive_from_json "$json" "bbbb0000"
+  assert_eq "blocked is alive" "0" "$status"
+
+  run claude_bg_token_alive_from_json "$json" "cccc0000"
+  assert_eq "done is dead" "1" "$status"
+
+  run claude_bg_token_alive_from_json "$json" "ffff0000"
+  assert_eq "missing is dead" "1" "$status"
+}
+
+@test "token_alive_from_json: real live shape (status:busy + state:working) is alive" {
+  # Real CLI live records carry the normative state in `status` while
+  # `state` reads "working" (#581). The raw literal pins the shape
+  # independently of the mock helper.
+  local json
+  json="[{\"sessionId\":\"$FULL_UUID\",\"kind\":\"background\",\"cwd\":\"/tmp/x\",\"startedAt\":1700000000000,\"status\":\"busy\",\"state\":\"working\"}]"
+  run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
+  assert_eq "status busy + state working is alive" "0" "$status"
+}
+
+@test "token_alive_from_json: does not call the claude CLI" {
+  local json
+  json="[$(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy)]"
+  run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_not_exists "no agents --json call recorded" \
+    "${MOCK_CLAUDE_STATE_DIR}/agents-calls"
+}
+
 # ── claude_bg_capture_session_id ──
 
 @test "capture: short ID prefix-matches to the full UUID (primary path)" {


### PR DESCRIPTION
closes #549

## Summary
ADR-0016 Phase 4。`orchctl ps`/`count` を `claude agents --json` の single-fetch view 層として再構築した。

- **managed 行の復活**: Phase 2 で削除された Worker/Reviewer 表示を `handle-{issue}.{type}` の opaque session token ベースで再構築(PID スキャンなし)。cekernel 固有列(issue、phase = state file の detail、priority)を state/priority ファイルから join(ADR-0015 境界: view は cekernel 固有価値の join のみ)
- **single-fetch**: `ps`/`count` は `agents --json` を 1 回だけ取得し、全 token を `claude_bg_state_from_json`(新ヘルパー、`claude_bg_state_for_token` はこれに委譲)で prefix-match。従来の token ごとの N+1 呼び出しを解消
- **`blocked` の表面化**: 全行で state をそのまま表示(ADR-0016 MUST)。未登録 token は `missing`
- **interactive orchestrator 対応**: `orchestrator.claude-session-id` がない session でも worker 行を表示
- `compute_elapsed` と orchestrator 行の h/m/s 整形重複を `format_elapsed` に集約
- `/orchctl` skill の ps セクションを新出力に更新

旧テスト(test-orchctl-ps.sh / test-orchctl-count.sh)は ADR-0017 統合バッチで既に `tests/ctl/orchctl-read.bats`(mock-claude ベース)へ統合済みのため、本 PR は同ファイルにテストを追加。

## Test Plan
- [x] `bats tests/ctl/ tests/shared/claude-bg.bats` — 100 tests passed
- [x] 新規: worker 行 join(issue/phase/priority)、blocked 表面化、missing、orchestrator token なし session、reviewer type、--session filter、single-fetch 呼び出し回数(ps/count)
- [ ] CI(full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)