### PR TITLE
fix: prefer status over state when reading claude agents --json liveness

### DIFF
--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -241,10 +241,29 @@ Verified 2026-07-07 (Phase 1 probe, #546, session `971e554a`):
   — cwd-based matching must normalize with `pwd -P` first.
 - `claude stop <short-id>` accepts the short ID as the stop token.
 
+Verified 2026-07-07 (#581, live-session field split; claude v2.1.x):
+- **Live and terminal sessions report their state in different fields.**
+  Live sessions carry `status: "busy"` plus `state: "working"` — or no
+  `state` field at all; terminal sessions carry `state: done|stopped`
+  and no `status`. Earlier builds reported live states directly in
+  `state` (`state: busy`). Observed distribution on a real roster:
+  `busy/working`, `busy/(absent)`, `(absent)/done`, `(absent)/stopped`.
+  `blocked` is expected to appear in `status` like `busy` (not yet
+  re-observed in the split shape).
+- Liveness consumers must read `(.status // .state)` — status preferred,
+  state fallback. The fallback keeps the pre-split shape resolving
+  unchanged. Reading `.state` alone evaluates every live session as
+  `working` and mis-reports it dead (#581: watch.sh crash-flagged all
+  spawned Workers and deleted their FIFOs).
+
 **Implications for cekernel**:
 - ADR-0016 delegates spawn/supervision to `--bg`; session IDs are captured
   (never injected); `blocked` must be surfaced by supervision; cleanup
   must `claude stop` lingering `done` sessions
+- All `agents --json` liveness reads go through `(.status // .state)`
+  (`shared/claude-bg.sh`, `shared/issue-lock.sh`);
+  `tests/helpers/mock-claude.bash` emits the split shape (STALENESS
+  COUPLING: update the mock in the same PR as this section)
 
 ### Subagent Information Propagation
 

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -50,7 +50,7 @@ claude_bg_state_for_token() {
   local json state
   json=$(claude_bg_agents_json) || return 1
   state=$(echo "$json" | jq -r --arg p "$token" \
-    '[.[] | select(.sessionId | startswith($p))][0].state // empty')
+    '[.[] | select(.sessionId | startswith($p))][0] | (.status // .state) // empty')
   [[ -n "$state" ]] || return 1
   echo "$state"
 }

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -18,10 +18,13 @@
 #       errors (Rule of Repair: callers decide how to surface it).
 #
 #   claude_bg_state_for_token <token>
-#     — Echo the state (busy|blocked|done|stopped|...) of the session whose
-#       sessionId starts with <token>. Tokens are opaque: the full UUID when
-#       capture succeeded, or the short ID (first 8 hex chars) as a degraded
-#       fallback — prefix matching serves both.
+#     — Echo the logical state (busy|blocked|done|stopped|...) of the session
+#       whose sessionId starts with <token>. Live sessions report it in
+#       `status` (with `state: "working"` or no state); terminal sessions in
+#       `state` — the query reads `(.status // .state)` to serve both, plus
+#       the legacy pre-split shape (#581). Tokens are opaque: the full UUID
+#       when capture succeeded, or the short ID (first 8 hex chars) as a
+#       degraded fallback — prefix matching serves both.
 #     — Returns 1 (echoing nothing) when no session matches or the query fails.
 #
 #   claude_bg_token_alive <token>

--- a/scripts/shared/issue-lock.sh
+++ b/scripts/shared/issue-lock.sh
@@ -39,7 +39,9 @@ issue_lock_repo_hash() {
 # Numeric holders are PIDs (kill -0). Non-numeric holders are opaque
 # session tokens (ADR-0005 Amendment 1): alive iff a session whose
 # sessionId starts with the token is busy or blocked in
-# `claude agents --json`. When the query fails, assume alive —
+# `claude agents --json` — read via `(.status // .state)` since live
+# sessions report liveness in `status` (#581). When the query fails,
+# assume alive —
 # never steal a lock on doubt (duplicate Workers are worse than a
 # lock held until explicit release).
 _issue_lock_holder_alive() {

--- a/scripts/shared/issue-lock.sh
+++ b/scripts/shared/issue-lock.sh
@@ -55,7 +55,7 @@ _issue_lock_holder_alive() {
     return 0
   fi
   state=$(echo "$json" | jq -r --arg p "$holder" \
-    '[.[] | select(.sessionId | startswith($p))][0].state // empty' 2>/dev/null) || return 0
+    '[.[] | select(.sessionId | startswith($p))][0] | (.status // .state) // empty' 2>/dev/null) || return 0
   [[ "$state" == "busy" || "$state" == "blocked" ]]
 }
 

--- a/tests/helpers/mock-claude.bash
+++ b/tests/helpers/mock-claude.bash
@@ -47,7 +47,12 @@
 #     paths testable — short-ID prefix match against sessionId, and the
 #     kind+cwd+startedAt fallback including the interactive-session
 #     mis-match regression at repo root.
-#     Real records carry ADDITIONAL fields (pid, id, name, status) and a
+#     The <state> argument is the LOGICAL session state (busy|blocked|
+#     done|stopped|...). It is emitted in the observed field split
+#     (verified 2026-07-07, #581): live states (busy, blocked) become
+#     `"status":"<state>","state":"working"`; terminal states are
+#     emitted as `"state":"<state>"` with NO status field.
+#     Real records carry ADDITIONAL fields (pid, id, name) and a
 #     numeric epoch-millis startedAt with a realpath'd cwd (verified
 #     2026-07-07) — consumers MUST NOT assume an exclusive field set.
 #     Pass numeric startedAt values in tests to mirror the real shape.
@@ -137,6 +142,13 @@ mock_claude_agent_record() {
   local cwd="${3:?missing <cwd>}"
   local started_at="${4:?missing <startedAt>}"
   local state="${5:?missing <state>}"
-  printf '{"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":"%s","state":"%s"}' \
-    "$session_id" "$kind" "$cwd" "$started_at" "$state"
+  # Observed field split (#581): live sessions carry status (busy|blocked)
+  # plus state:"working"; terminal sessions carry state only, no status.
+  if [[ "$state" == "busy" || "$state" == "blocked" ]]; then
+    printf '{"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":"%s","status":"%s","state":"working"}' \
+      "$session_id" "$kind" "$cwd" "$started_at" "$state"
+  else
+    printf '{"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":"%s","state":"%s"}' \
+      "$session_id" "$kind" "$cwd" "$started_at" "$state"
+  fi
 }

--- a/tests/helpers/mock-claude.bats
+++ b/tests/helpers/mock-claude.bats
@@ -70,7 +70,26 @@ setup() {
   assert_match "kind" '"kind":"background"' "$output"
   assert_match "cwd" '"cwd":"/tmp/repo/.worktrees/issue/42-x"' "$output"
   assert_match "startedAt" '"startedAt":"2026-07-07T00:00:00Z"' "$output"
-  assert_match "state" '"state":"busy"' "$output"
+  # Live sessions carry the status/state field split (#581)
+  assert_match "status" '"status":"busy"' "$output"
+  assert_match "state" '"state":"working"' "$output"
+}
+
+@test "agent records split live status/state; terminal records carry state only" {
+  # Observed shape (verified 2026-07-07, #581): live → status:busy|blocked
+  # + state:"working"; terminal → state:done|stopped, no status field.
+  run mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 blocked
+  assert_match "live status" '"status":"blocked"' "$output"
+  assert_match "live state is working" '"state":"working"' "$output"
+
+  run mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 stopped
+  assert_match "terminal state" '"state":"stopped"' "$output"
+  if [[ "$output" == *'"status"'* ]]; then
+    echo "terminal record must not carry a status field: $output" >&2
+    return 1
+  fi
 }
 
 @test "agents --json emits [] when nothing is enqueued" {
@@ -124,7 +143,7 @@ setup() {
   mock_claude_enqueue_agents "[${rec_busy}]"
   mock_claude_enqueue_agents "[${rec_done}]"
   run claude agents --json
-  assert_match "first call is busy" '"state":"busy"' "$output"
+  assert_match "first call is busy" '"status":"busy"' "$output"
   run claude agents --json
   assert_match "second call is done" '"state":"done"' "$output"
 }
@@ -140,7 +159,7 @@ setup() {
   local i
   for i in 1 2 3; do
     run claude agents --json
-    assert_match "call ${i} stays busy" '"state":"busy"' "$output"
+    assert_match "call ${i} stays busy" '"status":"busy"' "$output"
   done
 }
 

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -66,6 +66,24 @@ setup() {
   assert_eq "missing is dead" "1" "$status"
 }
 
+@test "token_alive: live record with status but no state field is alive" {
+  # Observed live shape variant (#581): status:"busy" with NO state field.
+  mock_claude_enqueue_agents \
+    "[{\"sessionId\":\"$FULL_UUID\",\"kind\":\"background\",\"cwd\":\"/tmp/x\",\"startedAt\":1700000000000,\"status\":\"busy\"}]"
+  run claude_bg_token_alive "$FULL_UUID"
+  assert_eq "status-only busy is alive" "0" "$status"
+}
+
+@test "token_alive: legacy record shape (state:busy, no status) stays alive" {
+  # Backward compat (#581): the pre-split shape put the live state in
+  # `state` with no `status` field. The status-preferring query must
+  # still fall back to `state`.
+  mock_claude_enqueue_agents \
+    "[{\"sessionId\":\"$FULL_UUID\",\"kind\":\"background\",\"cwd\":\"/tmp/x\",\"startedAt\":1700000000000,\"state\":\"busy\"}]"
+  run claude_bg_token_alive "$FULL_UUID"
+  assert_eq "legacy busy is alive" "0" "$status"
+}
+
 # ── claude_bg_capture_session_id ──
 
 @test "capture: short ID prefix-matches to the full UUID (primary path)" {


### PR DESCRIPTION
closes #581

## Summary
- `claude agents --json` の live セッションが `status: "busy"` + `state: "working"`(または state なし)に分離され、`.state` のみを読む生存判定が全滅するブロッカーを修正
- `scripts/shared/claude-bg.sh` (`claude_bg_state_for_token`) と `scripts/shared/issue-lock.sh` (`_issue_lock_holder_alive`) の jq クエリを `(.status // .state)` に変更(status 優先・state フォールバック)。旧形状(`state: busy`、status なし)は フォールバックで従来どおり解決
- STALENESS COUPLING ルールに従い、`docs/claude-code-constraints.md` の Background Agent Sessions 節に status/state 分離を追記し、`tests/helpers/mock-claude.bash` を同一 PR で新形状(live → `status:busy|blocked` + `state:"working"`、terminal → `state` のみ)に更新
- 回帰テスト追加: status-only live レコード(`busy/N/A` 実測ケース)、旧形状の後方互換

## Test Plan
- [x] RED: mock 新形状化で `claude-bg.bats` / `issue-lock.bats` の live 判定テストが失敗することを確認(#581 の誤判定を再現)
- [x] GREEN: jq 修正後、`mock-claude.bats` / `claude-bg.bats` / `issue-lock.bats` 全 45 テスト通過
- [x] mock 消費スイート(backend-headless/tmux/wezterm, orchctl-read/mutating, spawn-orchestrator, watch, health-check)全通過
- [ ] CI 通過