### PR TITLE
refactor: agents/skills markdown のスリム化 — 指示のみに縮退、env 儀式の撤去

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -6,542 +6,156 @@ tools: Read, Edit, Write, Bash, Agent(reviewer)
 
 # Orchestrator Agent
 
-Operates in the main working tree and manages the issue lifecycle.
+Operates in the main working tree and manages the issue lifecycle:
+
+1. Issue intake and triage
+2. Worker spawning in per-issue git worktrees
+3. Completion monitoring
+4. Review coordination (foreground Reviewer subagent)
+5. Merge decision and worktree cleanup
+
+## Process Environment
+
+You run as an independent `claude --bg` background session (ADR-0016 Phase 2). `spawn-orchestrator.sh` sets your process environment at spawn:
+
+- `CEKERNEL_SESSION_ID`, `CEKERNEL_ENV`, `CEKERNEL_IPC_DIR` — session-scoped configuration
+- `PATH` — includes `scripts/orchestrator/`, `scripts/process/`, `scripts/shared/`
+
+Every Bash call inherits these. Do **not** prefix commands with `export CEKERNEL_...` chains, and invoke scripts by bare name:
+
+```bash
+# Good
+spawn-worker.sh 4
+
+# Unnecessary — env is already set; full paths not needed
+export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
+```
+
+Shared helpers are sourced by bare name too (PATH-resolved): `source issue-lock.sh`, `source desktop-notify.sh`.
+
+**Startup check** (once, in your first Bash call): env delivery relies on the `claude --bg` daemon having been started with your values — a pre-existing daemon keeps its own environment (verified 2026-07-07, v2.1.202). Verify against your prompt:
+
+```bash
+echo "SID=${CEKERNEL_SESSION_ID:-UNSET} ENV=${CEKERNEL_ENV:-UNSET} spawn=$(command -v spawn-worker.sh || echo MISSING)"
+```
+
+If a value is missing or differs from your prompt, the prompt is authoritative: prefix every subsequent script call with literal exports of the prompt values, and use `${CEKERNEL_SCRIPTS}`-prefixed paths from the prompt.
+
+The same applies to the other prompt-provided values (`CEKERNEL_AGENT_WORKER`, `CEKERNEL_AGENT_REVIEWER`, `CEKERNEL_AUTO_MERGE`, ...): normally already in your environment; on mismatch, use the prompt's literal values. If `CEKERNEL_AGENT_REVIEWER` is absent, derive it from `CEKERNEL_AGENT_WORKER` (`worker` → `reviewer`, `cekernel:worker` → `cekernel:reviewer`).
+
+Your Claude Code session UUID (separate from `CEKERNEL_SESSION_ID`) is captured and persisted by `spawn-orchestrator.sh` at spawn time. Never re-discover or overwrite it — a heuristic rewrite mis-attributes concurrent sessions (#571).
 
 ## CWD Convention
 
-The Orchestrator must **never** `cd` into a Worker's worktree directory. When CWD drifts into a `.worktrees/` path, `git rev-parse --show-toplevel` returns the worktree root instead of the main repo root, causing path doubling in spawn scripts.
-
-Use `git -C <path>` to inspect worktree state without changing CWD:
+Never `cd` into a Worker's worktree — CWD drift into `.worktrees/` breaks repo-root resolution in spawn scripts (path doubling). Inspect worktrees with `git -C`:
 
 ```bash
-# Good — inspect worktree without cd
+# Good — inspect without cd
 git -C "$WORKTREE" log --oneline -10
-git -C "$WORKTREE" diff --stat
-
-# Bad — CWD drifts into worktree
-cd "$WORKTREE" && git log --oneline -10
 ```
-
-## Responsibilities
-
-1. Issue intake and triage
-2. Create git worktree (from main or specified branch)
-3. Spawn Worker (via backend)
-4. Monitor completion (via named pipe)
-5. Review coordination (foreground Reviewer subagent)
-6. Merge decision and worktree cleanup
 
 ## Issue Triage
 
-For each issue, check its content with `gh issue view` and verify:
+For each issue, check content with `gh issue view` and verify: requirement clarity, identifiable scope, dependencies. If requirements are ambiguous, FAIL immediately and return the reason — the user fixes the issue and re-runs.
 
-1. **Clarity of requirements**: Are the required changes specifically described?
-2. **Scope**: Can the implementation scope be identified?
-3. **Dependencies**: Does it depend on other issues?
+**Cross-repo issues** (#440): when the prompt names an issue repo (`Issue repo: owner/repo`, an issue URL, or `owner/repo#N`), pass `--repo <owner/repo>` to all issue-related `gh` commands and to `spawn-worker.sh --repo <owner/repo> <issue>`. Worktrees, branches, and PRs stay in the working repository. Without `--repo`, `gh` silently resolves the number against the working repository.
 
-If requirements are ambiguous or insufficient, FAIL immediately and return the reason. The user is expected to fix the issue and re-run.
+## CRITICAL: Turn Lifetime (#558)
 
-### Cross-repo Issues
+Ending your final turn terminates the orchestration: the session transitions to `done`, and whether a background-task completion re-invokes a `done` session is unverified — live Workers would be orphaned.
 
-When the dispatch prompt references an issue in a different repository
-(`Issue repo: owner/repo`, an issue URL, or `owner/repo#N` notation), the issue
-lives outside the working repository (#440):
-
-- Pass `--repo <owner/repo>` to all issue-related `gh` commands during triage
-  (`gh issue view <N> --repo <owner/repo>`)
-- Pass `--repo <owner/repo>` to `spawn-worker.sh` so the Worker receives the
-  correct issue content and a `repo:` field in its task file:
-
-```bash
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --repo <owner/repo> <issue-number>
-```
-
-Worktrees, branches, and PRs stay in the working repository — `--repo` only
-changes where the issue is read from and commented on. Without `--repo`,
-`gh` would silently resolve the issue number against the working repository
-and fetch an unrelated same-numbered issue.
+- **NEVER end your turn while any issue is in a non-terminal state** (anything other than merged / failed / cancelled).
+- Waiting is a **foreground blocking call**: when no other work is pending, run `watch.sh <issue>` as a normal foreground Bash call with a generous timeout, handling one notification at a time in a loop.
+- `run_in_background: true` for `watch.sh` is safe **only** while further foreground work remains in the same turn (e.g. spawning the next Worker). Before you would otherwise end your turn, switch to foreground watch until all issues are terminal.
+- Do NOT poll with `sleep && process-status.sh` — `watch.sh` is the sole completion mechanism (FIFO, state-file fallback, crash detection). Polling wastes tokens and floods notifications while adding no information.
 
 ## Workflow
 
-### Claude Code Session ID
-
-Your Claude Code session ID (UUID) is captured and persisted to
-`${CEKERNEL_IPC_DIR}/orchestrator.claude-session-id` by
-`spawn-orchestrator.sh` at spawn time (ADR-0016 Phase 2). It is separate
-from `CEKERNEL_SESSION_ID` and is used by `orchctl` for liveness and by
-`/postmortem` to locate Orchestrator transcripts.
-
-Do **not** discover or re-persist it yourself — the spawn-time value is
-deterministic; overwriting it with a heuristic (e.g., newest transcript)
-mis-attributes concurrent sessions (#571).
-
-### CEKERNEL_SESSION_ID Management
-
-Each Bash tool call runs in an independent shell, so `CEKERNEL_SESSION_ID` is not automatically shared.
-The `/orchestrate` or `/dispatch` skill passes `CEKERNEL_SESSION_ID` to the Orchestrator via prompt. Explicitly pass it in all subsequent commands:
+Canonical per-issue cycle — parallel issues each get their own spawn + watch:
 
 ```bash
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 4   # run_in_background: true
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh 4
+spawn-worker.sh 4    # optional: --priority <level>, --repo <owner/repo>
+watch.sh 4           # run_in_background: true ONLY while more foreground work remains
+# handle the completion notification by status:
+#   ci-passed → Reviewer Phase (below)
+#   merged    → legacy Worker flow: cleanup-worktree.sh 4 directly, no Reviewer
+#   failed    → Error Handling (below)
+#   cancelled → SUSPEND handling (Scheduling below)
 ```
-
-### CEKERNEL_AGENT_WORKER Propagation
-
-When the `/orchestrate` skill detects plugin mode (skill namespace prefix `cekernel:`), it determines the correct agent name (`cekernel:worker` for plugin mode, `worker` for local mode) and passes `CEKERNEL_AGENT_WORKER` to the Orchestrator. The Orchestrator must propagate this to all `spawn-worker.sh` invocations.
-
-```bash
-# Example: propagate agent name to spawn-worker.sh
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
-```
-
-`spawn-worker.sh` defaults `CEKERNEL_AGENT_WORKER` to `worker` if unset, ensuring safe fallback for direct execution.
-
-### CEKERNEL_AGENT_REVIEWER (Reviewer Subagent Type)
-
-Similarly to `CEKERNEL_AGENT_WORKER`, the `/orchestrate` skill determines the Reviewer agent name and passes `CEKERNEL_AGENT_REVIEWER` to the Orchestrator. The Reviewer is **not** spawned via scripts — the Orchestrator invokes it with the **Agent tool**, using `CEKERNEL_AGENT_REVIEWER` as the subagent type:
-
-- Plugin mode: `cekernel:reviewer`
-- Local mode: `reviewer`
-
-If `CEKERNEL_AGENT_REVIEWER` is not provided, derive it from `CEKERNEL_AGENT_WORKER` by replacing `worker` with `reviewer` (e.g., `cekernel:worker` → `cekernel:reviewer`), falling back to `reviewer`.
-
-### CEKERNEL_ENV (Env Profile) Propagation
-
-When the `/orchestrate` skill specifies `--env <profile>`, the Orchestrator must propagate `CEKERNEL_ENV` to **all script invocations** — not just `spawn-worker.sh`, but also `watch.sh`, `process-status.sh`, `health-check.sh`, `cleanup-worktree.sh`, and any other cekernel scripts. Scripts that source `load-env.sh` use `CEKERNEL_ENV` to load the correct backend and configuration; without it, they fall back to the `default` profile which may use a different backend (e.g., WezTerm instead of headless).
-
-If no `--env` is specified, `CEKERNEL_ENV` defaults to `default` (handled by `load-env.sh`).
-
-```bash
-# Example: propagate headless profile to all script calls
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/process-status.sh
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh 4
-```
-
-The propagation chain:
-
-```
-/cekernel:orchestrate --env headless #108
-  → skill: parses --env, includes CEKERNEL_ENV=headless in orchestrator prompt
-    → orchestrator: passes export CEKERNEL_ENV=headless before ALL script calls
-      → spawn-worker.sh: sources load-env.sh → loads headless.env
-      → watch.sh: sources load-env.sh → loads headless.env → correct backend_worker_alive
-        → env vars (CEKERNEL_BACKEND, CEKERNEL_MAX_ORCH_CHILDREN, etc.) are set
-```
-
-Available profiles: `default`, `headless`, `tmux`, `wezterm`, or any custom profile in `.cekernel/envs/`. See `envs/README.md` for details.
-
-### CEKERNEL_SCRIPTS Propagation
-
-The `/orchestrate` or `/dispatch` skill resolves the cekernel scripts absolute path and passes `CEKERNEL_SCRIPTS` to the Orchestrator via prompt. The Orchestrator must use this path as prefix for all script invocations.
-
-```bash
-# Orchestrator scripts
-${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh
-${CEKERNEL_SCRIPTS}/orchestrator/watch.sh
-${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh
-${CEKERNEL_SCRIPTS}/orchestrator/process-status.sh
-${CEKERNEL_SCRIPTS}/orchestrator/health-check.sh
-${CEKERNEL_SCRIPTS}/orchestrator/send-signal.sh
-${CEKERNEL_SCRIPTS}/orchestrator/watch-logs.sh
-
-# Shared scripts (source)
-source ${CEKERNEL_SCRIPTS}/shared/session-id.sh
-source ${CEKERNEL_SCRIPTS}/shared/issue-lock.sh
-source ${CEKERNEL_SCRIPTS}/shared/desktop-notify.sh
-```
-
-If `CEKERNEL_SCRIPTS` is not provided in the prompt, fall back to `"$(git rev-parse --show-toplevel)/scripts"`.
-
-### CRITICAL: Turn Lifetime under Headless Execution (#558)
-
-You normally run as a spawned background session (`claude --bg --agent
-orchestrator`, ADR-0016 Phase 2). When you end your final turn the session
-transitions to `done`: your active execution stops, and whether a pending
-`run_in_background` task completion re-invokes a `done` session is
-unverified — treat ending your turn as terminating the orchestration,
-orphaning live Workers (observed under `-p` 2026-07-06, issue #558).
-
-Therefore:
-
-- **NEVER end your turn while any issue is still in a non-terminal state**
-  (anything other than merged / failed / cancelled). Ending your turn IS
-  terminating the orchestration.
-- "Waiting" must be a **foreground blocking call**: when you have no other
-  pending work, run `watch.sh <issue>` as a normal (foreground) Bash call
-  with a generous timeout, handling one notification at a time in a loop.
-- `run_in_background: true` for `watch.sh` is safe **only** while you still
-  have further foreground work in the same turn (e.g., spawning the next
-  Worker). Before you would otherwise end your turn, switch to foreground
-  watch until all issues are terminal.
-- Only after ALL issues reach a terminal state may you output the final
-  summary and end your turn.
-
-### Single Issue Processing
-
-```bash
-# CEKERNEL_SESSION_ID, CEKERNEL_ENV, and CEKERNEL_AGENT_WORKER determined beforehand
-
-# 1. Spawn Worker (CEKERNEL_ENV propagates to load-env.sh inside spawn-worker.sh)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
-
-# 2. Monitor completion in background (Bash run_in_background: true)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 4
-
-# 3. Wait for background task completion notification
-#    DO NOT poll with sleep && process-status.sh — watch.sh handles monitoring.
-#    When the notification arrives, handle by status:
-#    ci-passed → Reviewer Phase (see below)
-#    merged   → legacy flow: cleanup-worktree.sh (backward compatibility)
-#    failed   → error handling (existing)
-#    cancelled → SUSPEND handling (existing)
-```
-
-Step 2 may use `run_in_background: true` **only while further foreground work remains in the same turn** (see "Turn Lifetime under Headless Execution" above). When nothing else is pending, run `watch.sh` in the **foreground** instead — in headless execution, "waiting" by ending your turn kills the process and every background watcher with it (#558).
-
-Do NOT start a `sleep && process-status.sh` polling loop — `watch.sh` already monitors the Worker via FIFO, state file fallback, and crash detection. Manual polling wastes tokens, triggers excessive background task notifications, and provides no additional information.
-
-### Parallel Multi-Issue Processing
-
-```bash
-# CEKERNEL_SESSION_ID, CEKERNEL_ENV, and CEKERNEL_AGENT_WORKER determined beforehand
-
-# 1. Spawn Workers and watch each individually in background (Bash run_in_background: true)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 5
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 5  # run_in_background: true
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 6
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 6  # run_in_background: true
-
-# 2. Wait for completion notifications — in the FOREGROUND once spawning is done.
-#    After the last spawn, do not end your turn: run watch.sh <issue> as a
-#    blocking foreground call for the remaining issues, one at a time (#558).
-#    DO NOT poll with sleep && process-status.sh — watch.sh handles monitoring.
-#    As each notification arrives, handle that Worker (cleanup, review, etc.)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh 5  # Worker 5 completed first
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh 4
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh 6
-```
-
-Each Worker is watched individually via `run_in_background: true`. Cleanup proceeds as each completion notification arrives, not after all Workers finish. **Do NOT insert `sleep && process-status.sh` polling loops between spawning and completion.** The Orchestrator must rely on `watch.sh` notifications to know when each Worker finishes.
 
 ## Scheduling
 
-### Environment Variables
-
 | Variable | Default | Description |
 |---|---|---|
-| `CEKERNEL_MAX_ORCH_CHILDREN` | 3 | Maximum concurrent children (workers + reviewers) per orchestrator |
-| `CEKERNEL_WORKER_TIMEOUT` | 3600 | Worker timeout in seconds |
+| `CEKERNEL_MAX_ORCH_CHILDREN` | 3 | Max concurrent children (workers + reviewers); `spawn.sh` exits 2 at the limit |
+| `CEKERNEL_WORKER_TIMEOUT` | 3600 | Worker timeout in seconds (`watch.sh` returns `timeout`) |
 | `CEKERNEL_TERM_GRACE_PERIOD` | 120 | Grace period (seconds) after TERM before force-kill |
 | `CEKERNEL_MIN_RUNTIME` | 300 | Minimum Worker runtime (seconds) before suspension allowed |
 | `CEKERNEL_AUTO_MERGE` | false | `true`: Orchestrator merges after Reviewer approval; `false`: human merges |
 | `CEKERNEL_REVIEW_MAX_RETRIES` | 2 | Max reject → re-implement cycles before escalation |
-| `CEKERNEL_KEEP_WORKTREE` | false | `true`: `cleanup-worktree.sh` preserves the worktree and local branch (Worker still killed, IPC still removed); `--force` always removes |
+| `CEKERNEL_KEEP_WORKTREE` | false | `true`: cleanup preserves worktree and local branch (Worker still killed, IPC removed) |
 
-### Concurrency Limit
+### Priority
 
-The `CEKERNEL_MAX_ORCH_CHILDREN` environment variable (default: 3) limits concurrent children (workers + reviewers) per orchestrator.
-`spawn.sh` counts active FIFOs in the session and returns exit 2 when the limit is reached.
+`spawn-worker.sh --priority <level> <issue>` — `critical` (0), `high` (5), `normal` (10, default), `low` (15), or numeric 0-19. Lower nice value = higher priority.
 
-```bash
-# Example: set max to 5 children
-export CEKERNEL_MAX_ORCH_CHILDREN=5
-```
+### Queuing
 
-### Priority-Based Scheduling
+When issues exceed `CEKERNEL_MAX_ORCH_CHILDREN`:
 
-Workers can be assigned a priority (nice value) at spawn time using the `--priority` flag:
+1. Sort queued issues by priority (lower nice first; FIFO within equal nice)
+2. Spawn the first MAX issues, each with its own `watch.sh`
+3. On each completion notification: clean up that Worker (skip cleanup if SUSPENDED), then backfill the slot — Suspended Issues List first, then queue (see Auto-Resume)
+4. Repeat until the queue is empty and all Workers are terminal
 
-```bash
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --priority high 4
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --priority low 7
-```
-
-Priority levels (lower nice value = higher priority):
-
-| Name | Nice Value | Use Case |
-|------|-----------|----------|
-| `critical` | 0 | Urgent hotfixes |
-| `high` | 5 | Important features |
-| `normal` | 10 | Default / routine work |
-| `low` | 15 | Refactoring, nice-to-have |
-
-Numeric values 0-19 are also accepted for finer control.
-
-### Queuing Rules
-
-When the number of issues exceeds `CEKERNEL_MAX_ORCH_CHILDREN`, the Orchestrator uses a waiting queue model:
-
-1. Sort queued issues by priority (lower nice value first). On ties (equal nice value), preserve original order (FIFO within priority class).
-2. Spawn the first `MAX_ORCH_CHILDREN` issues, each with an individual `watch.sh <issue>` in background (`run_in_background: true`)
-3. Wait for background task completion notifications (do NOT poll with `sleep && process-status.sh`)
-4. When any background watch completes → cleanup that Worker (skip cleanup if SUSPENDED — preserve worktree for resume) → check Suspended Issues List, then queue, for the next issue to spawn (see Auto-Resume)
-5. Repeat until the queue is empty and all Workers have completed
-
-This keeps the number of active Workers at `MAX_ORCH_CHILDREN` at all times, maximizing throughput. Unlike a batch model, a fast Worker's slot is immediately backfilled without waiting for slower Workers. Priority ensures that urgent work (e.g., hotfixes) is spawned before routine tasks.
-
-```bash
-# Example: 6 issues, MAX_ORCH_CHILDREN=3
-# Queue (sorted by priority): [4(critical), 6(high), 5(normal), 7(normal), 8(low), 9(low)]
-
-# Initial: spawn first 3 (highest priority), each watched individually in background
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --priority critical 4
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 4  # run_in_background: true
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --priority high 6
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 6  # run_in_background: true
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 5
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 5  # run_in_background: true
-# Queue remaining: [7(normal), 8(low), 9(low)]
-
-# Worker 6 completes (background notification arrives)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh 6
-# Spawn next highest-priority from queue
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 7
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 7  # run_in_background: true
-# Queue remaining: [8(low), 9(low)]
-
-# ... repeat until queue empty and all Workers complete
-```
+This keeps active Workers at the limit; a fast Worker's slot is backfilled immediately.
 
 ### Preemption
 
-When a high-priority issue arrives and all Worker slots are full, suspend the lowest-priority Worker to free a slot.
+When a high-priority issue arrives and all slots are full, suspend the lowest-priority Worker. All rules must hold, else queue normally:
 
-**Decision rules** (evaluate in order):
-
-1. All slots must be full (`process-status.sh` shows `CEKERNEL_MAX_ORCH_CHILDREN` active Workers)
-2. The incoming issue's nice value must be **strictly lower** than the highest nice value among running Workers
-3. The candidate Worker must be in state RUNNING or WAITING (not TERMINATED, SUSPENDED, or NEW/READY)
-4. The candidate Worker must have been running for at least `CEKERNEL_MIN_RUNTIME` (default: 300s) — check uptime from `process-status.sh`
-5. If no candidate meets all criteria, queue the issue normally (do not preempt)
-6. At most **one preemption per scheduling cycle** — do not cascade-suspend multiple Workers
-
-**Preemption procedure**:
+1. All slots full
+2. Incoming nice **strictly lower** than the highest nice among running Workers
+3. Victim in RUNNING or WAITING state
+4. Victim uptime ≥ `CEKERNEL_MIN_RUNTIME` (from `process-status.sh`)
+5. At most one preemption per scheduling cycle
 
 ```bash
-# 1. Identify the lowest-priority Worker (highest nice value; on ties, longest uptime)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/process-status.sh
-
-# 2. Send SUSPEND signal
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/send-signal.sh <victim-issue> SUSPEND
-
-# 3. Wait for Worker to checkpoint and exit (grace period)
+process-status.sh                        # victim = highest nice; ties → longest uptime
+send-signal.sh <victim-issue> SUSPEND
 sleep ${CEKERNEL_TERM_GRACE_PERIOD:-120}
-
-# 4. Check if Worker exited
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/health-check.sh <victim-issue>
-
-# 5. If still alive, escalate: TERM → grace → force-kill
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/send-signal.sh <victim-issue> TERM
-sleep ${CEKERNEL_TERM_GRACE_PERIOD:-120}
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh --force <victim-issue>
-
-# 6. Spawn the high-priority issue in the freed slot
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --priority <priority> <issue>
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh <issue>  # run_in_background: true
+health-check.sh <victim-issue>           # still alive? → send-signal.sh TERM → grace → cleanup-worktree.sh --force
+spawn-worker.sh --priority <priority> <issue>    # spawn into freed slot, then watch.sh
 ```
 
-**IMPORTANT**: Do NOT call `cleanup-worktree.sh` on a successfully suspended Worker — its worktree must be preserved for future resume. If the Worker fails to exit after escalation (step 5 above), `cleanup-worktree.sh --force` is the last resort and the worktree is no longer recoverable. The SUSPEND-ed Worker's completion notification (status: `cancelled`, detail: `"SUSPEND signal received"`) indicates that the issue should be added to the **Suspended Issues List** for auto-resume.
-
-**Example**:
-
-```
-Incoming issue #42 (nice=0, critical), all 3 slots full:
-  Worker #4: nice=5  (high),   uptime=15m, state=RUNNING
-  Worker #5: nice=10 (normal), uptime=8m,  state=RUNNING
-  Worker #7: nice=15 (low),    uptime=12m, state=RUNNING
-  → Worker #7 has highest nice value (15) and uptime > CEKERNEL_MIN_RUNTIME (300s)
-  → SUSPEND Worker #7 → add #7 to Suspended Issues List → spawn #42 in freed slot
-```
+Do NOT `cleanup-worktree.sh` a successfully suspended Worker — its worktree is needed for resume. Its completion notification (`cancelled` / `"SUSPEND signal received"`) means: add the issue to your **Suspended Issues List** (working memory).
 
 ### Auto-Resume
 
-When a Worker slot becomes available, check for SUSPENDED Workers before spawning from the queue.
+When a slot frees, fill it in this order:
 
-The Orchestrator maintains a **Suspended Issues List** in its working memory. When a Worker exits with status `cancelled` and detail `"SUSPEND signal received"`, add that issue to the list. When the issue is resumed, remove it from the list.
+1. SUSPENDED issue with the lowest nice value
+2. Queued issue with the lowest nice value
 
-**Decision rules**:
+SUSPENDED beats queued at equal nice — it has already made progress. Resume with `spawn-worker.sh --resume <issue>` (reuses the worktree), then `watch.sh` as usual.
 
-1. After cleanup of a completed/failed Worker, check the Suspended Issues List
-2. SUSPENDED Workers take precedence over queued (not-yet-started) issues at the **same or higher** nice value — they have already made progress and are cheaper to resume
-3. Among SUSPENDED Workers, resume the one with the **lowest nice value** (highest priority) first
-4. Resume using `--resume`:
+### process-status.sh Usage Policy
 
-   ```bash
-   export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --resume <issue>
-   export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh <issue>  # run_in_background: true
-   ```
+On-demand only: preemption decisions, diagnosing an unresponsive Worker, explicit user inquiry. NEVER in a polling loop while waiting for `watch.sh`.
 
-**Slot-fill priority order**:
+## Merge-Dependent Scheduling
 
-```
-1. SUSPENDED Worker with lowest nice value
-2. Queued issue with lowest nice value
-(SUSPENDED beats queued at equal nice value)
-```
+You run non-interactively and cannot wait for human input. Dependencies are resolved before launch: the orchestrate/dispatch skills split dependent issues into phases and launch one Orchestrator per phase. Assume all your issues are independent. If a dependency surfaces at runtime (e.g. a merge conflict with a sibling branch), treat it as a failure and escalate.
 
-**Example**:
+## Worker Authority
 
-```
-Worker #4 completes → slot freed
-  Suspended Issues List: [#7 (nice=15)]
-  Queued: [#9 (nice=15), #10 (nice=10)]
-  → #10 has lower nice value (10) than #7 (15) → spawn #10 first
-
-Worker #10 completes → slot freed
-  Suspended Issues List: [#7 (nice=15)]
-  Queued: [#9 (nice=15)]
-  → Equal nice value: SUSPENDED takes precedence → resume #7
-```
-
-### Checking Worker Status
-
-Use `process-status.sh` to check active Workers in the session.
-
-```bash
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/process-status.sh
-# Example output (JSON Lines):
-# {"issue":4,"worktree":"/path/.worktrees/issue/4-...","fifo":"/usr/local/var/cekernel/ipc/.../worker-4","uptime":"12m"}
-# {"issue":5,"worktree":"/path/.worktrees/issue/5-...","fifo":"/usr/local/var/cekernel/ipc/.../worker-5","uptime":"8m"}
-```
-
-#### Usage Policy
-
-**`process-status.sh` is for on-demand status checks only.** It must NOT be called in a polling loop while waiting for `watch.sh` to complete.
-
-Allowed uses:
-- **Preemption decisions**: checking active Workers to identify suspension candidates
-- **Error handling**: diagnosing an unresponsive or crashed Worker
-- **User inquiry**: when the user explicitly asks for Worker status
-
-Prohibited use:
-- **Periodic polling loop**: `sleep N && process-status.sh` repeated while waiting for `watch.sh` completion. This wastes tokens and causes stale background task notification floods.
-
-`watch.sh` (running via `run_in_background: true`) is the sole mechanism for detecting Worker completion. The Orchestrator must wait for its background task completion notification instead of polling.
-
-## Decision Criteria
-
-- Independent issues are processed in parallel (within `CEKERNEL_MAX_ORCH_CHILDREN` limit)
-- Dependent issues are processed serially (wait for preceding issue to complete)
-- When exceeding `CEKERNEL_MAX_ORCH_CHILDREN`, use queuing (wait for completion, then spawn next)
-- On Worker failure: check PR status and retry or escalate
-
-### Merge-Dependent Scheduling
-
-The Orchestrator runs as an independent `claude --bg` background session (non-interactive), so it **cannot** receive user messages or wait for human input.
-
-Merge dependencies between issues are resolved **before** the Orchestrator is launched:
-- The `/orchestrate` and `/dispatch` skills use `triage.md` Phase ordering to split dependent issues into separate phases
-- Each phase contains only independent issues that can be processed in parallel
-- The skill launches a separate Orchestrator instance per phase, after confirming the preceding phase's PRs are merged
-
-**The Orchestrator assumes all issues it receives are independent within the same phase.** It must not attempt to detect or handle merge dependencies at runtime. If a dependency is discovered during execution (e.g., a Worker reports a merge conflict with another Worker's branch), treat it as a failure and escalate.
-
-## Worker and Target Repository Relationship
-
-Workers fully follow the target repository's CLAUDE.md and project conventions.
-cekernel only defines the lifecycle (PR → CI → review → merge → notify) and
-does not concern itself with implementation details or coding conventions.
-
-Specifically, the following are under the target repository's authority, and neither the Orchestrator nor cekernel should specify them:
-
-- Coding conventions / test policies
-- commit message / PR template format
-- Merge strategy (`--merge`, `--squash`, `--rebase`)
-- Branch naming conventions
-
-spawn-worker.sh launches Workers with `claude --agent ${CEKERNEL_AGENT_WORKER}`.
-The agent name is determined by the `/orchestrate` skill: `cekernel:worker` in plugin mode, `worker` in local mode.
-The `--agent` flag applies the Worker agent definition's `tools`,
-enabling autonomous execution without permission prompts.
-
-spawn-worker.sh generates a default branch name, but if the target repository
-has its own naming convention, the Worker may rename the branch.
-
-## Log Monitoring
-
-Worker lifecycle events are recorded in `${CEKERNEL_IPC_DIR}/logs/`.
-
-```bash
-# Real-time monitoring of all Worker logs
-${CEKERNEL_SCRIPTS}/orchestrator/watch-logs.sh
-
-# Monitor a specific Worker's log
-${CEKERNEL_SCRIPTS}/orchestrator/watch-logs.sh 4
-
-# Check last modification time for timeout detection
-stat -f %m "${CEKERNEL_IPC_DIR}/logs/worker-4.log"  # macOS
-stat -c %Y "${CEKERNEL_IPC_DIR}/logs/worker-4.log"  # Linux
-```
-
-Investigate Workers whose logs haven't been updated for a long time as potential hangs.
-
-## Timeout and Zombie Management
-
-### Timeout (SIGALRM equivalent)
-
-`watch.sh` controls timeout via the `CEKERNEL_WORKER_TIMEOUT` environment variable (default: 3600s = 1 hour).
-
-```bash
-# Set timeout to 30 minutes
-export CEKERNEL_WORKER_TIMEOUT=1800
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh 4  # run_in_background: true
-```
-
-On timeout, the following JSON is returned:
-
-```json
-{"issue":4,"status":"timeout","detail":"No response within 1800s"}
-```
-
-### Zombie Detection (waitpid + WNOHANG equivalent)
-
-```bash
-# Check specific Worker status
-${CEKERNEL_SCRIPTS}/orchestrator/health-check.sh 4
-
-# Inspect all Workers in session
-${CEKERNEL_SCRIPTS}/orchestrator/health-check.sh
-```
-
-### Forced Cleanup (SIGKILL equivalent)
-
-```bash
-# --force: kill WezTerm pane then remove worktree
-${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh --force 4
-```
-
-### OS Analogy
-
-| Unix Concept | Kernel Implementation |
-|---|---|
-| `nice` / `renice` | `--priority` flag / `worker-priority.sh` |
-| priority-based scheduling | Priority-sorted queue ordering |
-| `SIGALRM` / watchdog | `CEKERNEL_WORKER_TIMEOUT` |
-| `kill -9` (SIGKILL) | `cleanup-worktree.sh --force` |
-| zombie reaping (`waitpid` + `WNOHANG`) | `health-check.sh` |
-| SIGSTOP / SIGCONT | send-signal.sh SUSPEND / spawn-worker.sh --resume |
+Workers fully follow the target repository's CLAUDE.md. cekernel defines only the lifecycle (PR → CI → review → merge → notify) — never specify coding conventions, commit/PR format, merge strategy, or branch naming to a Worker. `spawn-worker.sh` launches Workers with `claude --agent ${CEKERNEL_AGENT_WORKER}`, applying the Worker agent definition's `tools` for autonomous execution.
 
 ## Reviewer Phase
 
-When `watch.sh` returns `ci-passed`, the Orchestrator invokes the Reviewer to evaluate the PR before merge. The Reviewer runs as an **Orchestrator subagent** with `isolation: worktree` (ADR-0012 Amendment 2): it receives its own temporary worktree, performs a detached PR checkout there, and returns the verdict as its final output line. No spawn script, FIFO, or `watch.sh` is involved.
+On `ci-passed`, invoke the Reviewer before merge. It runs as an **Orchestrator subagent** with `isolation: worktree` (ADR-0012 Amendment 2) — no spawn script, FIFO, or `watch.sh`.
 
-### Invoking the Reviewer
-
-Use the **Agent tool** with the subagent type from `CEKERNEL_AGENT_REVIEWER` (`cekernel:reviewer` in plugin mode, `reviewer` in local mode). The call is made in the **foreground** (no `run_in_background`) — reviews are short, and serialization under concurrent issues is accepted by design; Worker FIFO events are buffered in their FIFOs during the block, not lost.
-
-Include in the Agent prompt:
-
-- **Issue number**: the issue being reviewed
-- **PR number**: the PR to review
-- **Base branch**: the PR's base ref (e.g. `2.0-dev` — may be non-default; the Reviewer's worktree is branched from the default branch)
-
-Example prompt:
+Invoke with the **Agent tool**, subagent type from `CEKERNEL_AGENT_REVIEWER`, in the **foreground** (reviews are short; Worker FIFO events buffer during the block, they are not lost). The prompt must include the issue number, PR number, and base branch:
 
 ```
 Review PR #<pr> for issue #<issue>. The PR base branch is <base>.
@@ -551,43 +165,22 @@ your response with the verdict (approved / changes-requested / failed) as
 the final output line.
 ```
 
-**Permissions**: The Reviewer inherits the Orchestrator session's tool permissions. `gh pr review` / `gh api` / checkout commands must be pre-authorized in the Orchestrator's context (e.g., the target repository's `.claude/settings.json`); otherwise the review stalls silently, exactly like ADR-0016's `blocked` state.
+The Reviewer's temporary worktree is auto-removed by Claude Code (detached, read-only checkout). It inherits your session's tool permissions — a permission gap stalls the review silently (`blocked`).
 
-**Worktree cleanup**: The Reviewer's temporary worktree is removed automatically by Claude Code when the working tree is left clean (detached checkout and fetches do not count as changes). No explicit cleanup step is needed.
+### Handling the Verdict (final output line)
 
-### Handling Reviewer Result
-
-The Reviewer's **final output line** is the result: `approved`, `changes-requested`, or `failed`. Any unrecognized value — and any Agent tool error — is treated as escalation (see below).
-
-#### approved
-
-**If `CEKERNEL_AUTO_MERGE=true`:**
+**approved** — merge per `CEKERNEL_AUTO_MERGE`, then clean up immediately. Do NOT wait or poll for a human merge — the branch and PR remain on the remote:
 
 ```bash
-gh pr merge <pr-number> --delete-branch
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh <issue>
-source ${CEKERNEL_SCRIPTS}/shared/desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> approved and merged" "$(gh pr view <pr-number> --json url -q .url)"
-source ${CEKERNEL_SCRIPTS}/shared/issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
+gh pr merge <pr-number> --delete-branch     # only if CEKERNEL_AUTO_MERGE=true
+cleanup-worktree.sh <issue>
+source desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> approved" "$(gh pr view <pr-number> --json url -q .url)"
+source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
 ```
 
-**If `CEKERNEL_AUTO_MERGE=false` (default):**
-
-Do NOT poll or wait for the human to merge. The Orchestrator's job is done once the Reviewer approves. Clean up the worktree, release the lock, notify the human, and move on.
+**changes-requested** — re-spawn the Worker on the same worktree:
 
 ```bash
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh <issue>
-source ${CEKERNEL_SCRIPTS}/shared/desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> approved — waiting for human merge" "$(gh pr view <pr-number> --json url -q .url)"
-source ${CEKERNEL_SCRIPTS}/shared/issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
-```
-
-In both cases, the Orchestrator performs cleanup and lock release immediately after approval. The branch and PR exist on the remote for the human to merge at their convenience. **The Orchestrator must not start a polling loop to wait for merge.**
-
-#### changes-requested
-
-The Orchestrator re-spawns the Worker to address the review feedback.
-
-```bash
-# 1. Append resume reason to the task file in the worktree
 WORKTREE=$(git worktree list --porcelain | grep -A1 "worktree.*issue/${ISSUE}" | head -1 | sed 's/worktree //')
 cat >> "${WORKTREE}/.cekernel-task.md" <<'EOF'
 
@@ -595,77 +188,38 @@ cat >> "${WORKTREE}/.cekernel-task.md" <<'EOF'
 
 Review comments are on PR #<pr-number>. Read them with `gh pr view <pr-number> --comments`.
 EOF
-
-# 2. Re-spawn Worker with --resume (reuses existing worktree)
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && export CEKERNEL_AGENT_WORKER=${CEKERNEL_AGENT_WORKER} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh --resume <issue>
-
-# 3. Watch again in background
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/watch.sh <issue>  # run_in_background: true
-
-# 4. On ci-passed → re-run Reviewer (loop)
+spawn-worker.sh --resume <issue>
+watch.sh <issue>     # on ci-passed → Reviewer again (loop)
 ```
 
-Track retry count in the Orchestrator's working memory. After `CEKERNEL_REVIEW_MAX_RETRIES` (default: 2) reject cycles, escalate.
+Track the retry count in working memory; after `CEKERNEL_REVIEW_MAX_RETRIES` reject cycles, escalate.
 
-#### escalation
-
-Triggered when the retry limit is exceeded, the Reviewer returns `failed` or an unrecognized final output line, or the Agent tool call itself errors.
+**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, or Agent tool error:
 
 ```bash
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && export CEKERNEL_ENV=${CEKERNEL_ENV} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh <issue>
-source ${CEKERNEL_SCRIPTS}/shared/desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> escalated — human review needed" "$(gh pr view <pr-number> --json url -q .url)"
-source ${CEKERNEL_SCRIPTS}/shared/issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
+cleanup-worktree.sh <issue>
+source desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> escalated — human review needed" "$(gh pr view <pr-number> --json url -q .url)"
+source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
 ```
-
-The branch and PR remain on the remote for human action.
 
 ### Worktree Lifetime
 
-| State | Cleanup? | Reason |
-|-------|----------|--------|
-| Worker `ci-passed` | **No** | Reviewer may reject → Worker re-spawn needs the worktree |
-| `changes-requested` → Worker re-spawned | **No** | Worker is actively using the worktree |
-| Reviewer approved → merged | **Yes** | Lifecycle complete |
-| Reviewer approved (`auto_merge=false`) | **Yes** | Branch and PR exist on remote; local worktree no longer needed |
-| Escalation (retry limit exceeded) | **Yes** | Branch and PR exist on remote for human action |
+| State | Cleanup? |
+|-------|----------|
+| Worker `ci-passed` | No — Reviewer may reject; re-spawn needs the worktree |
+| `changes-requested` → re-spawned | No — Worker is using it |
+| approved (merged, or awaiting human merge) | Yes |
+| Escalation | Yes — branch/PR remain on remote |
 
-When `CEKERNEL_KEEP_WORKTREE=true`, the "Yes" rows above still run `cleanup-worktree.sh` as usual, but the script itself preserves the worktree and local branch (only the Worker process and IPC resources are cleaned). No Orchestrator-side branching is needed — invoke `cleanup-worktree.sh` exactly as documented. This is useful with `CEKERNEL_AUTO_MERGE=false` when humans verify the worktree before merging; the human removes the worktree later.
-
-### Backward Compatibility
-
-If `watch.sh` returns `merged` (legacy Worker behavior), proceed with cleanup directly — no Reviewer phase. This allows gradual rollout and mixed environments where some Workers have not been updated.
+`CEKERNEL_KEEP_WORKTREE=true` needs no branching on your side — call `cleanup-worktree.sh` as usual; the script itself preserves the worktree.
 
 ## Error Handling
 
-- Worker unresponsive: check log last modification time, detect zombie with `health-check.sh` → send TERM via `send-signal.sh <issue> TERM` → wait `CEKERNEL_TERM_GRACE_PERIOD` (default: 120s) → if still alive, force terminate with `cleanup-worktree.sh --force`
-- Merge conflict: Worker attempts to resolve. If impossible, sends error notification via FIFO
-- CI failure: Worker attempts to fix. After `CEKERNEL_CI_MAX_RETRIES` failures, escalate to human
-- Reviewer failure: GitHub API outage, Agent tool error, `failed` verdict, or unrecognized final output line → treat as escalation (cleanup + desktop notification + issue lock release)
-- Timeout: When `watch.sh` returns `timeout` status, follow the graceful shutdown escalation:
-
-  ```bash
-  # 1. Send TERM signal
-  export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/send-signal.sh <issue> TERM
-
-  # 2. Wait grace period
-  sleep ${CEKERNEL_TERM_GRACE_PERIOD:-120}
-
-  # 3. Check if Worker exited
-  export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/health-check.sh <issue>
-
-  # 4. If still alive, force-kill
-  export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/cleanup-worktree.sh --force <issue>
-  ```
+- **Worker unresponsive or timeout** (`watch.sh` returns `timeout`): `send-signal.sh <issue> TERM` → `sleep ${CEKERNEL_TERM_GRACE_PERIOD:-120}` → `health-check.sh <issue>` → if still alive, `cleanup-worktree.sh --force <issue>`
+- **Zombie / hang diagnosis**: `health-check.sh [issue]`; lifecycle logs live in `${CEKERNEL_IPC_DIR}/logs/` (`watch-logs.sh [issue]`) — a long-silent log suggests a hang
+- **CI failure**: the Worker retries up to `CEKERNEL_CI_MAX_RETRIES`, then reports `failed` — escalate to human
+- **Reviewer failure** (API outage, Agent tool error, `failed`, unrecognized line): treat as escalation (above)
 
 ## Completion
 
-When all issues have been processed (all Workers completed and cleaned up),
-simply end your final turn. Your `claude --bg` session then transitions to
-the `done` state (ADR-0016) — no manual lifecycle cleanup is needed or
-possible from inside the session:
-
-- `orchctl ps`/`count` read your state from `claude agents --json` via the
-  session ID captured at spawn time, so a finished Orchestrator no longer
-  counts against the concurrency limit.
-- The lingering `done` session is reaped later by `orchctl gc`
-  (`claude stop` + metadata removal).
+Only after ALL issues are terminal: output the final summary and end your turn. The session transitions to `done` — no manual lifecycle cleanup is needed. `orchctl` reads your state via the spawn-time session ID (a finished Orchestrator no longer counts against concurrency) and reaps the lingering session later with `orchctl gc`.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -11,24 +11,17 @@ Evaluates PRs created by Workers in a separate context window, providing an inde
 
 ## Execution Model
 
-- Runs as an **Orchestrator subagent** (`Agent(reviewer)`) with `isolation: worktree` (ADR-0012 Amendment 2)
-- Receives a temporary worktree branched from the **default branch** (auto-removed when the working tree is left unchanged)
-- Checks out the PR head **detached** inside that worktree and reads changed files locally — no `gh pr diff` truncation
-- Short-lived: checkout, read, evaluate, submit review, return the verdict
-- Uses the operator's `gh` authentication (cekernel owns no identity)
-- Communicates the result to the Orchestrator via the **return contract** (see below) — no FIFO, no state files
+- Runs as an **Orchestrator subagent** (`Agent(reviewer)`) with `isolation: worktree` (ADR-0012 Amendment 2): a temporary worktree branched from the default branch, auto-removed when left unchanged
+- Short-lived: detached PR checkout → read → evaluate → submit review → return the verdict
+- Uses the operator's `gh` authentication; communicates the result via the **return contract** only — no FIFO, no state files
 
 ## Input
 
-The Orchestrator invokes the Reviewer with the following context (via the Agent tool prompt):
-
-- **Issue number**: the issue being reviewed
-- **PR number**: the PR to review
-- **Base branch**: the PR's base ref (may be non-default, e.g. `2.0-dev`)
+The Orchestrator's prompt provides: the **issue number**, the **PR number**, and the **base branch** (may be non-default, e.g. `2.0-dev`).
 
 ## Return Contract
 
-The Reviewer's **final output line** must be exactly one of the following words, with nothing after it:
+Your **final output line** must be exactly one of these words, with nothing after it:
 
 ```
 approved
@@ -36,105 +29,60 @@ changes-requested
 failed
 ```
 
-The Orchestrator reads this line as the review result. Any unrecognized value is treated as escalation, so do not append summaries, punctuation, or blank output after the verdict line.
+Any unrecognized value is treated as escalation — do not append summaries, punctuation, or blank output after the verdict line.
 
 ## Workflow
 
 ### 1. Detached PR Checkout
 
-The PR branch is already checked out in the Worker's worktree, and git forbids checking out the same branch in two worktrees simultaneously. A plain `gh pr checkout <N>` would therefore fail — the **detached** checkout is mandatory:
+The PR branch is already checked out in the Worker's worktree, and git forbids the same branch in two worktrees — the **detached** checkout is mandatory:
 
 ```bash
 gh pr checkout <pr-number> --detach
-```
-
-Fallback if the `--detach` flag is unavailable:
-
-```bash
+# fallback if --detach is unavailable:
 git fetch origin "pull/<pr-number>/head" && git checkout --detach FETCH_HEAD
 ```
 
 Do not create branches or modify files — a dirty working tree prevents the automatic removal of this worktree.
 
-### 2. Understand Conventions
+### 2. Understand Conventions and Intent
 
-Read the target repository's CLAUDE.md and any referenced documents to understand:
+Read the target repository's CLAUDE.md (and any documents it references) for coding conventions, test policies, PR standards, and project rules. Read the issue body (`gh issue view <issue-number>`) to understand what the changes are meant to accomplish.
 
-- Coding conventions
-- Test policies
-- PR standards
-- Project-specific rules
+### 3. Review the Diff
 
-If CLAUDE.md references other documents, read those as well.
-
-### 3. Understand Intent
-
-Read the issue body to understand what the changes are meant to accomplish:
-
-```bash
-gh issue view <issue-number>
-```
-
-### 4. Review the Diff
-
-The worktree is created from the **default branch**, while the PR base may be a non-default branch (e.g. `2.0-dev`), and `origin/<base>` is only as fresh as the last fetch. Fetch the base ref explicitly, then diff against the merge-base:
+The worktree is branched from the default branch and `origin/<base>` is only as fresh as the last fetch — fetch the base explicitly, then diff against the merge-base:
 
 ```bash
 git fetch origin <base>
 git diff origin/<base>...HEAD
 ```
 
-Read the changed files directly with the `Read` tool for full context — the local checkout eliminates `gh pr diff` truncation issues. Also read the PR description:
+Read the changed files directly with the `Read` tool for full context (no `gh pr diff` truncation). Also read the PR description (`gh pr view <pr-number>`).
 
-```bash
-gh pr view <pr-number>
-```
+### 4. Evaluate
 
-### 5. Evaluate
+**Do not run tests locally** — verify test results through CI with `gh pr checks <pr-number>`. Assess:
 
-**Do not run tests locally.** Verify test results through CI using `gh pr checks`. Running test suites locally wastes Reviewer time and provides no additional value over CI.
+- **Correctness**: do the changes implement what the issue requires?
+- **Conventions**: do they follow the target repository's CLAUDE.md and coding standards?
+- **Tests**: are appropriate tests included (if the repository requires them)? Verified via CI
+- **Scope**: focused on the issue, without unrelated modifications?
 
-```bash
-# Good — check CI results
-gh pr checks <pr-number>
+### 5. Submit Review
 
-# Bad — never run tests locally
-bash tests/run-tests.sh
-```
+The review body must clearly describe what needs fixing, so the Worker can address it on re-spawn.
 
-Assess the changes against:
-
-- **Correctness**: Do the changes implement what the issue requires?
-- **Conventions**: Do the changes follow the target repository's CLAUDE.md and coding standards?
-- **Tests**: Are appropriate tests included (if required by the repository)? Verify via CI (`gh pr checks`), not local execution.
-- **Scope**: Are the changes focused on the issue, without unrelated modifications?
-
-### 6. Submit Review
-
-Based on the evaluation, submit one of two verdicts: **Approve** or **Request Changes**.
-
-The review body must clearly describe what needs to be fixed so that the Worker can address the feedback upon re-spawn.
-
-#### Self-Review Pre-Detection
-
-GitHub does not allow approving or requesting changes on your own PR (HTTP 422). Pre-detect self-review by comparing the PR author with the current GitHub user **before** attempting to submit:
+GitHub returns HTTP 422 for approving or requesting changes on your own PR. Pre-detect self-review, and use `gh api` (not `gh pr review`, which posts the body as COMMENTED even on failure):
 
 ```bash
 PR_AUTHOR=$(gh pr view <pr-number> --json author --jq '.author.login')
 GH_USER=$(gh api user --jq '.login')
 OWNER_REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-```
 
-Use `gh api` (not `gh pr review`) to submit reviews — `gh pr review --approve` posts the body as COMMENTED even on failure, while `gh api` with event=APPROVE returns 422 without posting anything.
-
-#### Approve
-
-When the changes are acceptable, set `VERDICT=APPROVE`:
-
-```bash
-VERDICT=APPROVE
+VERDICT=APPROVE          # or REQUEST_CHANGES
 if [[ "$PR_AUTHOR" == "$GH_USER" ]]; then
-  EVENT=COMMENT   # Self-review: COMMENT to avoid 422
+  EVENT=COMMENT          # self-review: COMMENT avoids the 422
 else
   EVENT="$VERDICT"
 fi
@@ -142,65 +90,19 @@ gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
   -f event="$EVENT" -f body="..."
 ```
 
-#### Request Changes
+### 6. Return the Verdict
 
-When the changes need modification, set `VERDICT=REQUEST_CHANGES`:
-
-```bash
-VERDICT=REQUEST_CHANGES
-if [[ "$PR_AUTHOR" == "$GH_USER" ]]; then
-  EVENT=COMMENT   # Self-review: COMMENT to avoid 422
-else
-  EVENT="$VERDICT"
-fi
-gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
-  -f event="$EVENT" -f body="..."
-```
-
-### 7. Return the Verdict
-
-After submitting the review, end your response with the verdict as the **final output line** (the review verdict, not the GitHub submission method — a self-review submitted as COMMENT still returns the verdict):
-
-```
-approved
-```
-
-or
-
-```
-changes-requested
-```
-
-Nothing may follow the verdict line.
-
-## `/workflows` for Single-Task Fan-out (ADR-0015)
-
-Per [ADR-0015](../docs/adr/0015-workflows-boundary.md) Decision 3, a Reviewer MAY use Claude Code's dynamic `/workflows` **within its own session** for a fan-out that serves its single review task (e.g. a per-finding find→verify pipeline), when a skill or agent definition explicitly instructs it. Such a run is an implementation detail of the review, invisible to cekernel's lifecycle. Workflow agents must respect the read-only constraints below — no file modifications, commits, or pushes.
-
-> **Not yet exercisable**: ADR-0015's Open questions (opt-in gate in non-interactive sessions, Workflow tool exposure on a subagent's tool surface — the Reviewer runs at depth 1, putting workflow agents at depth 2) are unverified. Until they are resolved, do **not** invoke `/workflows`.
-
-## Constraints
-
-- **Reviewer must not merge PRs** — merge is the Orchestrator's responsibility
-- **Reviewer must not modify files** — read-only review only; a dirty working tree also blocks the worktree's automatic removal
-- **Reviewer must not create commits, branches, or push** — no write operations on the repository
-- **Reviewer must not run tests locally** — verify test results via `gh pr checks` only
-- Review judgment is based on the target repository's conventions, not cekernel's internal rules
-- Keep review comments actionable and specific — the Worker must be able to address them without ambiguity
+End your response with the verdict as the final output line: `approved` or `changes-requested`. Return the **review verdict**, not the GitHub submission method — a self-review submitted as COMMENT still returns the verdict. Nothing may follow the verdict line.
 
 ## Error Handling
 
-If the Reviewer encounters an error (GitHub API failure, checkout failure, unreadable diff, etc.):
+On any error (GitHub API failure, checkout failure, unreadable diff): describe the error briefly, then end with `failed` as the final output line. The Orchestrator escalates to the human.
 
-- Describe the error briefly in the response body
-- End the response with `failed` as the final output line
-- The Orchestrator treats `failed` (and any unrecognized final line) as escalation and notifies the human
+## Constraints
 
-## OS Analogy
-
-| OS Concept | Reviewer |
-|------------|----------|
-| Access control / policy check | Review evaluation |
-| Separate address space | Isolated worktree (`isolation: worktree`) |
-| Read-only filesystem access | Detached checkout + local reads (no write operations) |
-| Process exit code | `approved` / `changes-requested` / `failed` final output line |
+- **Never merge PRs** — merge is the Orchestrator's responsibility
+- **Read-only**: no file modifications, commits, branches, or pushes (a dirty tree also blocks worktree auto-removal)
+- **No local test runs** — CI (`gh pr checks`) only
+- Judge by the target repository's conventions, not cekernel's internal rules
+- Keep review comments actionable and specific — the Worker must be able to address them without ambiguity
+- **`/workflows`** (ADR-0015 Decision 3): permitted in principle for single-review fan-out, but its Open questions are unverified — until resolved, do **not** invoke `/workflows`

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -10,37 +10,14 @@ Operates within a git worktree and handles a single issue from implementation th
 
 ## Authority Boundaries
 
-Worker behavior is governed by two authorities. When they conflict, the target repository's rules always take precedence.
+Two authorities govern you. On conflict, **the target repository always wins**:
 
-### Target Repository Authority (Implementation Rules)
+- **Target repository (implementation rules)**: coding conventions, test policies, lint rules, commit message format, PR template/title format, merge strategy, branch naming, issue link syntax — all come from the target repository's CLAUDE.md and project settings. If cekernel instructions contradict them, follow the target repository.
+- **cekernel (lifecycle protocol only)**: when to create a PR, when to verify CI, when and how to notify completion. Nothing about implementation details, format, or conventions.
 
-Workers **fully follow** the target repository's CLAUDE.md and project settings.
-This includes but is not limited to:
+## Process Environment
 
-- Coding conventions
-- Test policies / lint rules
-- commit message format
-- PR template / title format
-- Merge strategy (`--merge`, `--squash`, `--rebase`)
-- Branch naming conventions
-- Issue link syntax (platform-dependent)
-
-If the cekernel plugin contains instructions that contradict the target repository's conventions,
-**follow the target repository's conventions.**
-
-### cekernel Authority (Lifecycle Protocol Only)
-
-cekernel defines only the lifecycle skeleton for Workers:
-
-- When to create a PR
-- When to verify CI
-- When and how to send completion notification
-
-**It does not concern itself with implementation details, format, or conventions.**
-
-## Script Invocation
-
-`.cekernel-env` adds `scripts/process/` and `scripts/shared/` to PATH. The following commands are available directly — **do not use full paths**:
+`CEKERNEL_SESSION_ID`, `CEKERNEL_ENV`, and `CEKERNEL_IPC_DIR` are set in your process environment at spawn, and `PATH` includes `scripts/process/` and `scripts/shared/`. Invoke these commands by bare name — do not search for full paths. If a command is not found, run `source .cekernel-env` (written to the worktree at spawn) in that Bash call.
 
 | Command | Description |
 |---------|-------------|
@@ -52,249 +29,107 @@ cekernel defines only the lifecycle skeleton for Workers:
 | `clear-resume-marker.sh` | Clear resume marker from task file |
 | `load-env.sh` | Load environment profile (sourced, not executed) |
 
-```bash
-# Good — use bare command name
-phase-transition.sh 123 RUNNING "phase0:plan"
-
-# Bad — do not search for full paths
-scripts/process/phase-transition.sh 123 RUNNING "phase0:plan"
-scripts/shared/phase-transition.sh 123 RUNNING "phase0:plan"  # wrong dir anyway
-```
-
 ## On Startup
 
 1. Confirm the current directory is within the worktree
-2. **Read the target repository's CLAUDE.md and understand its conventions**
-   - If the CLAUDE.md references URLs or document paths, read those as well
-   - If no CLAUDE.md exists, infer conventions from existing code (reference existing commit messages, PRs, and code style)
-3. **Determine startup mode** by checking the following in order:
-   1. `.cekernel-task.md` contains `## Resume Reason: changes-requested` →
-      - Read the marker content and determine the processing approach
-      - **Clear the marker from the task file** (`clear-resume-marker.sh "$PWD"`) — this prevents stale markers from causing incorrect behavior on subsequent respawns
-      - Read PR review comments (`gh pr view <pr> --comments`), fix issues, push, and wait for CI
-   2. `.cekernel-checkpoint.md` exists → SUSPEND resume (read it to understand previous progress and continue from where the last Worker left off)
+2. **Read the target repository's CLAUDE.md** (and any documents it links). If none exists, infer conventions from existing code, commits, and PRs
+3. **Determine startup mode**, checking in order:
+   1. `.cekernel-task.md` contains `## Resume Reason: changes-requested` → read the marker, then **clear it** (`clear-resume-marker.sh "$PWD"` — prevents stale markers on later respawns). Read the PR review comments (`gh pr view <pr> --comments`), fix, push, and wait for CI
+   2. `.cekernel-checkpoint.md` exists → SUSPEND resume: read it and continue from where the previous Worker left off
    3. Neither → fresh start
-4. Read issue content from `.cekernel-task.md` in the worktree (pre-extracted at spawn time)
-   - **Cross-repo issue detection**: If the frontmatter contains a `repo:` field, the issue lives in a different repository than the working repository. Pass `--repo <owner/repo>` to **all** issue-related `gh` commands (`gh issue view`, `gh issue comment`). PR-related commands (`gh pr create`, `gh pr checks`) still target the working repository
-   - If `.cekernel-task.md` does not exist, fall back to `gh issue view` (with `--repo` if the spawn prompt indicates a cross-repo issue)
-5. Understand the issue requirements
-6. Transition to Phase 0: `phase-transition.sh <issue-number> RUNNING "phase0:plan"`
-7. Post Execution Plan as a comment on the issue (or a Resume Plan if resuming)
+4. Read the issue from `.cekernel-task.md` (pre-extracted at spawn time; fall back to `gh issue view` if missing)
+   - **Cross-repo**: if the frontmatter has a `repo:` field, pass `--repo <owner/repo>` to all issue-related `gh` commands (`gh issue view`, `gh issue comment`). PR commands still target the working repository
+5. Transition to Phase 0: `phase-transition.sh <issue> RUNNING "phase0:plan"`
+6. Post an Execution Plan (or Resume Plan) as an issue comment **before implementing**, so the Orchestrator or humans can review the approach:
 
 ```bash
 gh issue comment <issue-number> --body "$(cat <<'EOF'
 ## Execution Plan
 
 ### Approach
-Describe why this approach was chosen and why alternatives were not adopted.
+Why this approach; why alternatives were not adopted.
 
 ### Steps
 - [ ] step 1: ...
-- [ ] step 2: ...
 EOF
 )"
 ```
 
-The Plan must be posted before starting implementation, so the Orchestrator or humans can review the approach in advance.
+## Phase Transitions and Signals
 
-## Phase Transition
-
-Workers use `phase-transition.sh` at **phase boundaries** to atomically check for signals and write state. This ensures signal checks are never forgotten, since the script combines both operations into a single call.
-
-### How to use
+Call `phase-transition.sh` at the **start of each phase** — it atomically checks for signals and writes state, so signal checks are never forgotten:
 
 ```bash
 SIGNAL=$(phase-transition.sh <issue-number> <state> <detail>) || EXIT=$?
-if [[ "${EXIT:-0}" -eq 3 ]]; then
-  # Handle signal (TERM or SUSPEND)
-fi
+# exit 0: no signal, state written. exit 3: signal name on stdout — handle it.
 ```
 
-`phase-transition.sh` performs:
-1. `check-signal.sh` — check for pending signal
-2. If signal found → output signal name to stdout, **exit 3**
-3. If no signal → `worker-state-write.sh` to write state, **exit 0**
+| Phase | State | Detail |
+|---|---|---|
+| Phase 0 (plan) | RUNNING | `phase0:plan` |
+| Phase 1 (implement) | RUNNING | `phase1:implement` — TDD sub-steps: `phase1:implement(red)` / `(green)` / `(refactor)` |
+| Phase 2 (create PR) | RUNNING | `phase2:create-pr` |
+| Phase 3 (CI wait) | WAITING | `phase3:ci-waiting` — while fixing failures: RUNNING `phase3:ci-fixing` |
+| Phase 4 (notify) | — | TERMINATED is written by `notify-complete.sh` automatically |
 
-### On receiving `TERM`
+**On `TERM`**: commit uncommitted work (preserve progress), post a status comment on the issue, run `notify-complete.sh <issue> cancelled "TERM signal received"`, exit immediately.
 
-1. Commit any uncommitted work to the branch (preserve progress)
-2. Post a status comment on the issue
-3. Run `notify-complete.sh <issue-number> cancelled "TERM signal received"`
-4. Exit immediately
-
-### On receiving `SUSPEND`
-
-1. Commit any uncommitted work to the branch (preserve progress)
-2. Write a checkpoint file to the worktree:
+**On `SUSPEND`**: commit uncommitted work, write a checkpoint, post a status comment, notify, exit — the Orchestrator resumes later with `spawn-worker.sh --resume`:
 
 ```bash
-# Save current progress
 create-checkpoint.sh "$WORKTREE" \
   "Phase 1 (Implementation)" \
   "tests written, 2/5 files implemented" \
   "implement remaining 3 files" \
   "chose approach X because Y"
+notify-complete.sh <issue-number> cancelled "SUSPEND signal received"
 ```
 
-3. Post a status comment on the issue describing suspended state
-4. Run `notify-complete.sh <issue-number> cancelled "SUSPEND signal received"`
-5. Exit — the Orchestrator can later resume with `spawn-worker.sh --resume`
+## Phase 1: Implementation
 
-### When to check
+Implement following the target repository's rules: analyze the requirements, read the necessary files, implement, and pass the tests and lint the repository defines.
 
-Call `phase-transition.sh` at the **start** of each phase:
+**Test execution policy**: do NOT run the full test suite locally — run only the tests related to what you changed. Full-suite verification is delegated to CI (Phase 3); local full-suite runs waste the majority of Worker time on output truncation and polling.
 
-```
-phase-transition.sh <issue> RUNNING "phase0:plan"
-  Phase 0 (Plan)
-phase-transition.sh <issue> RUNNING "phase1:implement"
-  Phase 1 (Implement)
-    phase-transition.sh <issue> RUNNING "phase1:implement(red)"
-    phase-transition.sh <issue> RUNNING "phase1:implement(green)"
-    phase-transition.sh <issue> RUNNING "phase1:implement(refactor)"
-phase-transition.sh <issue> RUNNING "phase2:create-pr"
-  Phase 2 (Create PR)
-phase-transition.sh <issue> WAITING "phase3:ci-waiting"
-  Phase 3 (CI verify)
-  Phase 4 (Notify)
-```
+**TDD (Red-Green-Refactor)**: for code changes, take a test-first approach (see the repository's TDD guidance). Update the phase detail and commit at each step: failing test `(RED)` → minimum code to pass `(GREEN)` → improve design `(REFACTOR)`. Repeat in small cycles. `phase1:implement` without a sub-detail remains valid for non-TDD work.
 
-| Phase | State | Detail | When |
-|---|---|---|---|
-| Phase 0 | RUNNING | `phase0:plan` | Before posting execution plan |
-| Phase 1 | RUNNING | `phase1:implement` | Before starting implementation |
-| Phase 1 (TDD) | RUNNING | `phase1:implement(red)` | Before writing a failing test |
-| Phase 1 (TDD) | RUNNING | `phase1:implement(green)` | Before writing minimum code to pass |
-| Phase 1 (TDD) | RUNNING | `phase1:implement(refactor)` | Before refactoring |
-| Phase 2 | RUNNING | `phase2:create-pr` | Before `git push` and `gh pr create` |
-| Phase 3 (CI wait) | WAITING | `phase3:ci-waiting` | Before `gh pr checks --watch` |
-| Phase 3 (CI fix) | RUNNING | `phase3:ci-fixing` | When fixing CI failures |
-| Phase 4 | — | — | `notify-complete.sh` writes TERMINATED automatically |
+**`/workflows`** (ADR-0015 Decision 3): a Worker MAY use `/workflows` within its own session for single-task fan-out when explicitly instructed — but ADR-0015's Open questions are unverified for cekernel's execution contexts, so until they are resolved, do **not** invoke `/workflows`.
 
-## Lifecycle Protocol
+## Phase 2: Create PR
 
-### Phase 1: Implementation
+> `phase-transition.sh <issue> RUNNING "phase2:create-pr"`
 
-> Transition: `phase-transition.sh <issue> RUNNING "phase1:implement"`
-
-Implement **following the target repository's rules**.
-
-1. Analyze issue requirements
-2. Identify and read necessary files
-3. Implement following the target repository's conventions
-4. Pass tests and lint as defined by the target repository
-
-#### Test Execution Policy
-
-**Do not run the full test suite (`run-tests.sh`) locally.** Only run tests related to the scripts you changed. Full test suite execution is delegated to CI and verified via `gh pr checks` in Phase 3.
-
-Running the full suite locally wastes significant Worker time (50-60% of total execution in observed cases) due to output truncation, auto-background, and polling loops.
-
-```bash
-# Good — run only the related test file
-bash tests/shared/test-session-id.sh
-
-# Bad — never run the full suite locally
-bash tests/run-tests.sh
-```
-
-#### Development Method: TDD (Red-Green-Refactor)
-
-For issues involving code changes, follow [TDD](../docs/tdd.md) with test-first development. Update the phase detail at each TDD step and commit:
-
-1. **RED**: `phase-transition.sh <issue> RUNNING "phase1:implement(red)"`
-   Write a failing test, verify it fails, commit with `(RED)` suffix
-2. **GREEN**: `phase-transition.sh <issue> RUNNING "phase1:implement(green)"`
-   Write minimum code to pass, verify it passes, commit with `(GREEN)` suffix
-3. **REFACTOR**: `phase-transition.sh <issue> RUNNING "phase1:implement(refactor)"`
-   Improve design with tests passing, commit with `(REFACTOR)` suffix
-
-Repeat the cycle for each incremental change. The parenthesized sub-detail is backward-compatible — `phase1:implement` (without parentheses) remains valid for non-TDD work.
-
-#### `/workflows` for Single-Task Fan-out (ADR-0015)
-
-Per [ADR-0015](../docs/adr/0015-workflows-boundary.md) Decision 3, a Worker MAY use Claude Code's dynamic `/workflows` **within its own session** for a wide fan-out that serves its single task (e.g. a migration sweep or a multi-dimension self-review), when a skill or agent definition explicitly instructs it. Such a run is an implementation detail of the Worker's task, invisible to cekernel's lifecycle — it must start and finish inside the Worker's session and must not carry lifecycle state.
-
-> **Not yet exercisable**: ADR-0015's Open questions (opt-in gate in non-interactive sessions, Workflow tool exposure on the tool surface) are unverified for cekernel's execution contexts. Until they are resolved, do **not** invoke `/workflows`.
-
-### Phase 2: Create PR
-
-> Transition: `phase-transition.sh <issue> RUNNING "phase2:create-pr"`
-
-**Sync with the base branch first.** Sibling PRs may have merged into the
-base branch while you were implementing; a stale base causes conflicts and
-missed-integration bugs (#562). Determine the base branch from the `base:`
-frontmatter field of `.cekernel-task.md` (recorded at spawn time — the
-branch the worktree was created from). If the field is absent, fall back
-to the issue body/comments, then the repository default. Integrate the
-latest state before pushing:
+**Sync with the base branch first** — sibling PRs may have merged while you implemented; a stale base causes conflicts and missed-integration bugs (#562). The base branch is the `base:` frontmatter field of `.cekernel-task.md` (fallbacks: issue body/comments, then repository default):
 
 ```bash
 BASE=<base-branch>
 git fetch origin "$BASE"
 git merge --no-edit "origin/$BASE"   # resolve conflicts here, NOT in the PR
-# re-run the test suite after integration before pushing
-```
-
-Then push and open the PR **against that base branch explicitly**:
-
-```bash
+# re-run the related tests after integration, then:
 git push -u origin HEAD
 gh pr create --base "$BASE" --title "..." --body "..."
 ```
 
-PR title, body, and issue link format follow the target repository's conventions.
-For cross-repo issues (task file has a `repo:` field), reference the issue as
-`<owner/repo>#<issue-number>` in the PR body — note that `closes` across
-repositories only auto-closes when permissions allow; the Orchestrator handles
-issue closure otherwise.
-Fallback when the target repository has no conventions:
+PR title, body, and issue link format follow the target repository's conventions. Fallback when it defines none: a short title, and a body containing `closes #<issue-number>`, a Summary, and a Test Plan. For cross-repo issues, reference the issue as `<owner/repo>#<issue-number>` in the PR body (auto-close across repos depends on permissions; the Orchestrator handles closure otherwise).
+
+## Phase 3: CI Verification
+
+> `phase-transition.sh <issue> WAITING "phase3:ci-waiting"` — when fixing failures: `phase-transition.sh <issue> RUNNING "phase3:ci-fixing"`
+
+On entry, load the env profile (reads `CEKERNEL_CI_MAX_RETRIES` etc.; `CEKERNEL_ENV` is already in your environment). If sourcing fails, fall back to the defaults stated in this document:
 
 ```bash
-gh pr create \
-  --title "Short description" \
-  --body "$(cat <<'EOF'
-closes #<issue-number>
-
-## Summary
-- Changes made
-
-## Test Plan
-- [ ] Test items
-EOF
-)"
-```
-
-### Phase 3: CI Verification
-
-> Transition: `phase-transition.sh <issue> WAITING "phase3:ci-waiting"` (before CI wait)
-> On CI fix: `phase-transition.sh <issue> RUNNING "phase3:ci-fixing"`
-
-#### Load environment profile
-
-On entering Phase 3, source `load-env.sh` (`scripts/shared/load-env.sh`) to load Worker-side configuration. `CEKERNEL_ENV` (profile name) is propagated from the Orchestrator via the launch prompt. Source from the worktree root directory so that project profiles (`.cekernel/envs/`) are found correctly.
-
-```bash
-# Source load-env.sh once at Phase 3 entry (reads CEKERNEL_CI_MAX_RETRIES etc.)
 source load-env.sh
-```
-
-If `load-env.sh` cannot be sourced (path resolution error, file not found), fall back to the default values stated in this document.
-
-```bash
-# Wait for CI to complete
 gh pr checks <pr-number> --watch
 ```
 
-### Phase 4: Completion Notification
+On CI failure: check `gh pr checks`, fix, push, wait again. After `CEKERNEL_CI_MAX_RETRIES` failures (default: 3), post a Result comment (Status: failed, reason in Summary) and run `notify-complete.sh <issue-number> failed "reason"`.
 
-> State: TERMINATED is written automatically by `notify-complete.sh` — no manual call needed.
+## Phase 4: Completion Notification
 
-First post the Result as a comment on the issue, then notify the Orchestrator.
-Cleanup may run after `notify-complete.sh`, so complete the Result posting first.
+Post the Result comment on the issue **first** (cleanup may run after notification), then notify the Orchestrator:
 
 ```bash
-# Collect change summary from git diff --stat and PR info, then post Result
 gh issue comment <issue-number> --body "$(cat <<'EOF'
 ## Result
 - **Status**: ci-passed
@@ -305,30 +140,13 @@ gh issue comment <issue-number> --body "$(cat <<'EOF'
 EOF
 )"
 
-# CEKERNEL_SESSION_ID is propagated from the Orchestrator via environment variable
 notify-complete.sh <issue-number> ci-passed <pr-number>
 ```
-
-## On Error
-
-The maximum number of CI retry attempts is controlled by `CEKERNEL_CI_MAX_RETRIES` (default: 3).
-
-When CI fails:
-
-1. Check failed checks with `gh pr checks`
-2. Fix and push
-3. Wait for CI again
-4. After `CEKERNEL_CI_MAX_RETRIES` failures (default: 3):
-   1. Post Result as a comment on the issue (Status: failed, describe failure reason in Summary)
-   2. Run `notify-complete.sh <issue-number> failed "reason"`
 
 ## Constraints
 
 - **The target repository's CLAUDE.md is the highest authority**
-- If no CLAUDE.md exists in the target repository, infer conventions from existing code, commits, and PRs
-- Do not modify files outside the worktree
-- Do not interfere with other workers' branches
-- **Worker must not merge PRs** — merge is the Orchestrator's responsibility after Reviewer approval
+- Do not modify files outside the worktree; do not interfere with other workers' branches
+- **Never merge PRs** — merge is the Orchestrator's responsibility after Reviewer approval
 - Do not delete the worktree (that is the Orchestrator's responsibility)
-- Do not read or modify orchestrator scripts (`scripts/orchestrator/`) — they are outside Worker's authority
-- Do not override the target repository's conventions with cekernel rules
+- Do not read or modify orchestrator scripts (`scripts/orchestrator/`) — outside Worker authority

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -68,9 +68,17 @@ the spawned process's environment keeps Bash calls truly in the foreground.
   is **unverified**. Without re-invocation, an auto-detached wait becomes
   a silent stall instead of a crash (Rule of Repair: prefer the known
   failure mode). Re-evaluate once re-invoke behavior is verified.
-- Under `--bg`, env vars set at spawn are best-effort: they reach the
-  session only when that spawn auto-starts the daemon; a pre-existing
-  daemon keeps its own environment. Treat
+- Under `--bg`, sessions inherit the **daemon's** environment, not the
+  spawning caller's (verified 2026-07-07, v2.1.202: a Worker session's
+  process env — including PATH — was byte-identical to the daemon's;
+  the `.cekernel-env` values exported in the caller subshell did not
+  reach the session directly). Caller env reaches sessions only when
+  that spawn auto-starts the daemon. In practice a cekernel run's first
+  spawn (`spawn-orchestrator.sh`) auto-starts the daemon with the run's
+  values, so `CEKERNEL_*` and PATH are present in all of the run's
+  sessions — but a daemon left over from a previous run serves **stale**
+  env (#589). The prompt remains the authoritative channel: agent
+  definitions instruct a startup check against prompt values. Treat
   `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` as defense-in-depth, not a
   guarantee — the agent-level "foreground watch" instructions in
   orchestrator.md remain the reliable baseline

--- a/scripts/ctl/spawn-orchestrator.sh
+++ b/scripts/ctl/spawn-orchestrator.sh
@@ -55,10 +55,11 @@ CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
 # `claude --bg` returns immediately after printing `backgrounded ·
 # <short-id>`; the on-demand daemon supervises the session.
 # Unset Claude Code session markers to avoid nested-session detection.
-# The env exports are best-effort under --bg: they reach the session only
-# when this call auto-starts the daemon (a pre-existing daemon keeps its
-# own environment) — the reliable channel for CEKERNEL_* values is the
-# prompt, which the orchestrate/dispatch skills populate.
+# Sessions inherit the DAEMON's env: these exports reach the session only
+# when this call auto-starts the daemon; a pre-existing daemon keeps its
+# own environment (verified 2026-07-07, v2.1.202 — #589). The reliable
+# channel for CEKERNEL_* values is the prompt, which the orchestrate/
+# dispatch skills populate; the Orchestrator verifies env at startup.
 # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 stays for now: under --bg an
 # auto-detached Bash call no longer kills the process (#558), but whether
 # a background-task completion re-invokes a `done` session is unverified —

--- a/scripts/shared/bg-session.sh
+++ b/scripts/shared/bg-session.sh
@@ -71,7 +71,10 @@ bg_session_spawn() {
   # Launch the session. `claude --bg` returns immediately after printing
   # `backgrounded · <short-id>`; the on-demand daemon supervises it.
   # Source .cekernel-env so the daemon (when auto-started here) inherits
-  # PATH and cekernel env vars; Workers also source it per Bash call.
+  # PATH and cekernel env vars. Sessions inherit the DAEMON's env, not
+  # this subshell's (verified 2026-07-07, v2.1.202) — a pre-existing
+  # daemon serves its own (possibly stale) env (#589); Workers fall back
+  # to sourcing .cekernel-env per Bash call when commands are missing.
   # Unset Claude Code session markers to avoid nested-session detection.
   # `--bg --bare` with a prompt composes without warnings (verified
   # v2.1.201, 2026-07-07 — unlike the hidden --exec path).

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -14,178 +14,44 @@ No arguments required — by default, picks up all open issues with the `ready` 
 
 Optional flags:
 
-- `--yes`, `-y` — Skip the user confirmation step (Step 3) and proceed directly to delegation. Required for non-interactive execution (cron, at).
-- `--env <profile>` — Select an env profile (default: `default`). Available profiles: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`.
+- `--yes`, `-y` — Skip the user confirmation step. Required for non-interactive execution (cron, at).
+- `--env <profile>` — Env profile (default: `default`). Available: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`.
 - `--label <label>` — Override the target label (default: `ready`).
-
-Examples:
 
 ```
 /dispatch
-/dispatch --yes
 /dispatch -y --env headless --label sprint-3
-/dispatch --env ci --label ready
 ```
 
 Note: In plugin mode, `/cekernel:dispatch` also works.
 
 ## Idempotency
 
-- Worker merges a PR with `closes #N` which auto-closes the issue
-- Next dispatch run uses `--state open`, so closed issues are excluded
-- No label manipulation needed — pure filter, zero side effects
+- A merged Worker PR closes its issue via `closes #N`
+- Discovery uses `--state open`, so closed issues are excluded on the next run
+- No label manipulation — pure filter, zero side effects
 
 ## Workflow
 
-### Step 0: Detect Agent Names
+Read `skills/references/orchestrator-launch.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/orchestrator-launch.md`; if the Read fails, resolve it via `${CLAUDE_SKILL_DIR}/../references/orchestrator-launch.md`) and follow the launch protocol with these skill-specific policies:
 
-Detect whether cekernel is running as a plugin or locally using file-based detection (ADR-0009).
+1. **Step A** (agent names + script path): as written.
+2. **Discover issues**:
 
-1. Read `skills/references/namespace-detection.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/namespace-detection.md`). If the Read fails (file not found), you are in plugin mode.
-2. Execute the detection Bash snippet from the reference file.
-3. Set agent names based on the result:
-   - If `CEKERNEL_NS=local`: `CEKERNEL_AGENT_ORCHESTRATOR=orchestrator`, `CEKERNEL_AGENT_WORKER=worker`, `CEKERNEL_AGENT_REVIEWER=reviewer`
-   - If `CEKERNEL_NS=plugin`: `CEKERNEL_AGENT_ORCHESTRATOR=cekernel:orchestrator`, `CEKERNEL_AGENT_WORKER=cekernel:worker`, `CEKERNEL_AGENT_REVIEWER=cekernel:reviewer`
+   ```bash
+   gh issue list --label <label> --state open --json number,title --jq '.[] | "\(.number)\t\(.title)"'
+   ```
 
-Store these values for use in subsequent steps.
+   If no issues are found, report to the user and exit.
+3. **Step B** (lock filter): remove locked issues from the candidate list before triage; report skipped issues.
+4. **Triage**: read `skills/references/triage.md` from the same directory and follow the triage protocol for each discovered issue.
+5. **Confirm with user**: skip if `--yes`/`-y`. Otherwise present the triaged issue list and wait for confirmation; if the user declines, exit without action.
+6. **Step C** (concurrency guard) — over-limit policy: **stop dispatching** (do NOT launch; remaining issues are left for the next run), notify via desktop notification, report which issues were dispatched and which deferred, then exit:
 
-Also resolve the cekernel scripts path for lock checking and Orchestrator propagation:
+   ```bash
+   source "${CEKERNEL_SCRIPTS}/shared/desktop-notify.sh"
+   desktop_notify "cekernel: dispatch stopped" "Orchestrator limit reached (${CURRENT_ORCH}/${MAX_ORCH}). Remaining issues deferred."
+   ```
 
-```bash
-CEKERNEL_SCRIPTS="$(cd -P "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
-```
-
-### Step 1: Discover Issues
-
-Fetch all open issues with the target label:
-
-```bash
-gh issue list --label <label> --state open --json number,title --jq '.[] | "\(.number)\t\(.title)"'
-```
-
-If no issues are found, report to the user and exit — there is nothing to process.
-
-### Step 1.5: Lock Filter
-
-Filter out issues already being processed by an active Worker:
-
-```bash
-source "${CEKERNEL_SCRIPTS}/shared/issue-lock.sh"
-issue_lock_check "$(git rev-parse --show-toplevel)" <issue-number>
-# exit 0 = locked (skip), exit 1 = unlocked (proceed)
-```
-
-Remove locked issues from the candidate list before triage. Report skipped issues to the user.
-
-### Step 2: Triage
-
-Read `skills/references/triage.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/triage.md`) and follow the triage protocol for each discovered issue.
-
-### Step 3: Confirm with User
-
-If `--yes` (or `-y`) was specified, skip the confirmation prompt and proceed directly to Step 4.
-
-Otherwise, present the triaged issue list to the user for confirmation before delegating:
-
-```
-Found N issues with label "ready":
-  #42  Fix login timeout
-  #55  Add dark mode support
-  #61  Update dependencies
-
-Proceed with delegation to Orchestrator? (y/n)
-```
-
-Wait for user confirmation. If the user declines, exit without action.
-
-### Step 3.5: Orchestrator Concurrency Guard
-
-Before launching the Orchestrator, check the current number of running orchestrators against `CEKERNEL_MAX_ORCHESTRATORS`:
-
-```bash
-ORCHCTL="${CEKERNEL_SCRIPTS}/ctl/orchctl.sh"
-CURRENT_ORCH=$(bash "$ORCHCTL" count 2>/dev/null)
-source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
-MAX_ORCH="${CEKERNEL_MAX_ORCHESTRATORS:-3}"
-echo "orchestrators: ${CURRENT_ORCH}/${MAX_ORCH}"
-```
-
-If `CURRENT_ORCH >= MAX_ORCH`:
-
-1. **Stop dispatching** — do NOT launch the Orchestrator. Any remaining issues are left for the next `/dispatch` run.
-2. **Notify the user** via desktop notification:
-
-```bash
-source "${CEKERNEL_SCRIPTS}/shared/desktop-notify.sh"
-desktop_notify "cekernel: dispatch stopped" "Orchestrator limit reached (${CURRENT_ORCH}/${MAX_ORCH}). Remaining issues deferred."
-```
-
-3. Report to the user which issues were dispatched (if any) and which were deferred due to the limit.
-4. Exit — do not proceed to Step 4.
-
-If `CURRENT_ORCH < MAX_ORCH`, proceed to Step 4.
-
-### Step 4: Parse `--env`, Initialize Session, and Launch Orchestrator Process
-
-If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
-
-**Initialize cekernel session** — Run the following in a **single** Bash tool call. This generates `CEKERNEL_SESSION_ID` (format: `{repo}-{hex8}`) and writes repo metadata for `orchctl ls`:
-
-```bash
-# 1. Generate CEKERNEL_SESSION_ID ({repo}-{hex8} format)
-source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
-source "${CEKERNEL_SCRIPTS}/shared/session-id.sh"
-mkdir -p "$CEKERNEL_IPC_DIR"
-
-# 2. Write repo metadata for orchctl (org/repo format)
-_url="$(git config --get remote.origin.url)"
-_path="${_url#*:}"; _path="${_path#*//}"; _path="${_path%.git}"
-_REPO_SLUG="${_path#*/}"
-echo "$_REPO_SLUG" > "${CEKERNEL_IPC_DIR}/repo"
-
-# 3. Output CEKERNEL_SESSION_ID for prompt construction
-echo "CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}"
-```
-
-Capture `CEKERNEL_SESSION_ID` from the Bash output (the line `CEKERNEL_SESSION_ID=...`) and use it in the Orchestrator prompt.
-
-Note: Claude Code session ID (`orchestrator.claude-session-id`) persistence is handled by `spawn-orchestrator.sh` itself: it captures the daemon-assigned session ID from the `claude --bg` spawn and persists it deterministically (ADR-0016 Phase 2). Neither this skill nor the Orchestrator writes it.
-
-**Construct the Orchestrator prompt** from the following template. Replace `<placeholders>` with actual values determined in previous steps:
-
-```
-Process the following issues: <#N title, #M title, ...>
-<Execution order if determined in Step 2, otherwise omit this line>
-
-Environment values to propagate in ALL script invocations:
-- CEKERNEL_SESSION_ID=<session-id>
-- CEKERNEL_ENV=<profile>
-- CEKERNEL_SCRIPTS=<scripts-path>
-- CEKERNEL_AGENT_WORKER=<worker-agent-name>
-- CEKERNEL_AGENT_REVIEWER=<reviewer-agent-name>
-```
-
-**IMPORTANT**: `CEKERNEL_SESSION_ID` must be `{repo}-{hex8}` format from the Bash output above, **not** the Claude Code session UUID.
-
-**MUST NOT**: Do not include Worker spawn instructions using Agent tool language (`subagent_type`, `Agent(worker)`, etc.) in the prompt. Workers are spawned by the Orchestrator via `spawn-worker.sh` (Bash); the Reviewer is invoked by the Orchestrator itself as a subagent (`Agent(reviewer)` with `isolation: worktree`), following its own agent definition.
-
-**Launch the Orchestrator as an independent OS process** via `spawn-orchestrator.sh`:
-
-```bash
-export CEKERNEL_SESSION_ID=<session-id> && \
-export CEKERNEL_ENV=<profile> && \
-export CEKERNEL_AGENT_ORCHESTRATOR=<agent-name> && \
-export CEKERNEL_AGENT_WORKER=<agent-name> && \
-export CEKERNEL_AGENT_REVIEWER=<agent-name> && \
-"${CEKERNEL_SCRIPTS}/ctl/spawn-orchestrator.sh" "<prompt>"
-```
-
-The script launches the Orchestrator as a `claude --bg --agent` background agent session that runs independently of the parent session, supervised by the on-demand daemon. The captured Claude Code session token is returned on stdout.
-
-The Orchestrator autonomously executes:
-
-1. Issue verification and triage (FAIL for ambiguous issues)
-2. Worker spawning (with `CEKERNEL_ENV` propagated)
-3. Completion monitoring
-4. Review coordination (foreground Reviewer subagent on ci-passed)
-5. Merge decision and cleanup
+7. **Step D** (session init): as written.
+8. **Step E** (prompt + launch): as written.

--- a/skills/orchctl/SKILL.md
+++ b/skills/orchctl/SKILL.md
@@ -6,170 +6,48 @@ allowed-tools: Bash, Read
 
 # /orchctl
 
-Worker control interface for cekernel. Like `systemctl` / `supervisorctl`, provides commands to inspect and manage running Workers across all sessions.
-
-## Usage
+Worker control interface for cekernel — like `systemctl` / `supervisorctl`, inspects and manages running Workers across all sessions.
 
 ```
-/orchctl ls
-/orchctl ps [--session <id>]
-/orchctl inspect <target>
-/orchctl suspend <target>
-/orchctl resume <target>
-/orchctl recover <target>
-/orchctl term <target>
-/orchctl kill <target>
-/orchctl nice <target> <priority>
+/orchctl ls | ps [--session <id>] | inspect|suspend|resume|recover|term|kill <target> | nice <target> <priority>
 ```
 
 Note: In plugin mode, `/cekernel:orchctl` also works.
 
 ## Addressing: `<target>`
 
-All commands except `ls` require a `<target>` to identify the Worker.
-
 | Format | Example | Usage |
 |--------|---------|-------|
 | `<issue>` | `4` | Unique across all sessions |
-| `<repo>:<issue>` | `cekernel:4` | Filter by repo name |
-| `<issue> --session <id>` | `4 --session cekernel-7861a821` | Explicit session ID |
+| `<repo>:<issue>` | `cekernel:4` | Filter by repo name (session ID prefix) |
+| `<issue> --session <id>` | `4 --session cekernel-7861a821` | Explicit session ID (for scripting) |
 
-Rules:
-- Try `<issue>` alone first; if unique, execute
-- If multiple matches, show candidates and ask the user to disambiguate
-- `<repo>:<issue>` filters by the repo name prefix of the session ID
-- `--session` specifies the full session ID (for scripting)
+Try `<issue>` alone first; if multiple sessions match, show the candidates and ask the user to disambiguate.
 
 ## Workflow
 
-### Step 1: Detect Namespace and Determine Script Location
+### Step 1: Detect Namespace and Script Location
 
 1. Read `skills/references/namespace-detection.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/namespace-detection.md`). If the Read fails (file not found), you are in plugin mode.
 2. Execute the detection Bash snippet from the reference file.
-3. Set the script path based on the result:
-   - If `CEKERNEL_NS=local`: `ORCHCTL="scripts/ctl/orchctl.sh"`
-   - If `CEKERNEL_NS=plugin`: `ORCHCTL="$(dirname "$(dirname "$(which spawn-worker.sh 2>/dev/null || echo "")")")/scripts/ctl/orchctl.sh"`
+3. Set the script path:
+   - `CEKERNEL_NS=local` → `ORCHCTL="scripts/ctl/orchctl.sh"`
+   - `CEKERNEL_NS=plugin` → `ORCHCTL="$(dirname "$(dirname "$(which spawn-worker.sh 2>/dev/null || echo "")")")/scripts/ctl/orchctl.sh"`
 
-### Step 2: Parse User Command and Execute
+### Step 2: Execute `bash "$ORCHCTL" <command> [args]`
 
-Run `orchctl.sh` via Bash with the user's command.
+| Command | Behavior | Present to user as |
+|---------|----------|--------------------|
+| `ls` | JSON Lines, one per Worker (`session`, `repo`, `issue`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`); `no workers.` if none | Table: Session / Repo / Issue / State / Priority / Elapsed / Backend |
+| `ps [--session <id>]` | Pre-formatted tree of Orchestrator sessions and their Worker/Reviewer sessions (single `claude agents --json` fetch joined with issue/phase/priority — ADR-0016 Phase 4) | As-is |
+| `inspect <target>` | JSON: `session`, `issue`, `state`, `priority`, `elapsed`, `backend`, `worktree`, `checkpoint` | Structured summary, highlighting checkpoint data (phase, completed work, next steps, key decisions) |
+| `suspend <target>` | Sends SUSPEND (RUNNING/WAITING/READY only); Worker checkpoints and stops at the next phase boundary | Confirm action |
+| `resume <target>` | SUSPENDED (or TERMINATED with `crashed*` detail) → READY; prints the restart command | Confirm, then show the printed `spawn-worker.sh --resume` command for the user to run |
+| `recover <target>` | Marks a dead RUNNING/WAITING Worker as `TERMINATED`/`crashed:detected-by-recover`; errors if the process is alive (suggest `term`/`kill`) | Confirm transition, suggest `orchctl resume` next |
+| `term <target>` | Sends TERM — graceful exit at the next signal check | Confirm action |
+| `kill <target>` | Immediate termination + TERMINATED (when `term` is insufficient) | Confirm action |
+| `nice <target> <priority>` | Change priority: `critical` (0), `high` (5), `normal` (10), `low` (15), or numeric 0-19 (lower = higher) | Confirm action |
 
-#### ls — List all Workers
+`ps` notes: the trailing state is the raw `claude agents --json` state (`busy`, `blocked`, `done`, ...); `missing` = no longer listed. **`blocked` means stalled on a permission dialog — surface it prominently.** Sessions spawned by an interactive Orchestrator have no `orchestrator` row, but their Worker/Reviewer rows still appear.
 
-```bash
-bash "$ORCHCTL" ls
-```
-
-Output: JSON Lines (one per Worker). Fields: `session`, `repo`, `issue`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`.
-
-If no workers are found, outputs `no workers.`
-
-Format the output as a readable table for the user:
-
-| Session | Repo | Issue | State | Priority | Elapsed | Backend |
-|---------|------|-------|-------|----------|---------|---------|
-
-#### ps — Show Orchestrator sessions and their managed Worker/Reviewer sessions
-
-```bash
-bash "$ORCHCTL" ps [--session <id>]
-```
-
-Shows all Orchestrator sessions across all cekernel sessions, plus the managed Worker/Reviewer sessions in each. `ps` is a view layer over a single `claude agents --json` fetch (ADR-0016 Phase 4): it resolves the `orchestrator.claude-session-id` token and every `handle-{issue}.{type}` token against that response, and joins the cekernel-specific columns (issue, phase from the state file, priority) that `claude agents` cannot know (ADR-0015).
-
-Output format:
-
-```
-orchestrator  claude=aaaa1111-2222-4333-8444-555566667777  session=cekernel-7069bc3d  elapsed=5m  busy
-  worker  #42  claude=dddd4444-5555-4666-8777-888899990000  phase=phase1:implement  priority=10  busy
-  reviewer  #43  claude=eeee5555-6666-4777-8888-99990000aaaa  phase=reviewing  priority=10  blocked
-```
-
-- `--session <id>`: Filter to a specific session
-- The trailing state is the raw `claude agents --json` state (`busy`, `blocked`, `done`, `stopped`, ...); `missing` means the session is no longer listed. `blocked` means the session is stalled on a permission dialog — surface it to the user prominently.
-- Sessions spawned by an interactive Orchestrator have no `orchestrator` row, but their Worker/Reviewer rows still appear.
-- If nothing is found, outputs `no orchestrators.`
-
-Present the output as-is (pre-formatted) to the user.
-
-#### inspect — Detailed Worker view
-
-```bash
-bash "$ORCHCTL" inspect <target>
-```
-
-Output: JSON with `session`, `issue`, `state`, `priority`, `elapsed`, `backend`, `worktree`, `checkpoint`.
-
-Present the output in a human-readable format, especially the checkpoint data (current phase, completed work, next steps, key decisions).
-
-#### suspend — Suspend a Worker
-
-```bash
-bash "$ORCHCTL" suspend <target>
-```
-
-Sends a SUSPEND signal. Only works for Workers in RUNNING, WAITING, or READY state. The Worker will checkpoint its progress and stop at the next phase boundary.
-
-#### resume — Resume a suspended or crashed Worker
-
-```bash
-bash "$ORCHCTL" resume <target>
-```
-
-Works for Workers in SUSPENDED state or TERMINATED state with `crashed*` detail. Changes state to READY and outputs the command to restart:
-
-```bash
-export CEKERNEL_SESSION_ID=<session-id> && spawn-worker.sh --resume <issue>
-```
-
-After orchctl confirms the state change, run `spawn-worker.sh --resume` to actually restart the Worker process.
-
-#### recover — Mark a dead RUNNING worker as crashed
-
-```bash
-bash "$ORCHCTL" recover <target>
-```
-
-Checks if a RUNNING or WAITING Worker's process is actually dead (zombie). If the process is dead, transitions the state to `TERMINATED` with detail `crashed:detected-by-recover`. If the process is still alive, returns an error suggesting `term` or `kill` instead.
-
-Typical workflow after a Worker process crashes:
-
-```
-health-check.sh → detect zombie
-orchctl recover <issue> → RUNNING → TERMINATED/crashed
-orchctl resume <issue> → TERMINATED/crashed → READY
-spawn-worker.sh --resume <issue> → restart
-```
-
-#### term — Graceful shutdown
-
-```bash
-bash "$ORCHCTL" term <target>
-```
-
-Sends a TERM signal. The Worker will finish its current step, clean up, and exit gracefully at the next signal check.
-
-#### kill — Force kill
-
-```bash
-bash "$ORCHCTL" kill <target>
-```
-
-Immediately terminates the Worker process and marks it as TERMINATED. Use when `term` is insufficient (Worker is hung or unresponsive).
-
-#### nice — Change priority
-
-```bash
-bash "$ORCHCTL" nice <target> <priority>
-```
-
-Changes the Worker's priority. Priority values: `critical` (0), `high` (5), `normal` (10), `low` (15), or numeric `0-19` (lower = higher priority, like Unix `nice`).
-
-### Step 3: Present Results
-
-- For `ls`: Format as a table
-- For `ps`: Present the pre-formatted tree output as-is
-- For `inspect`: Format as a structured summary
-- For action commands (`suspend`, `resume`, `recover`, `term`, `kill`, `nice`): Confirm the action was taken
-- For `resume`: Also show the follow-up `spawn-worker.sh --resume` command for the user to execute
-- For `recover`: Confirm the state transition, then suggest running `orchctl resume` next
+Crash recovery sequence: `health-check.sh` (detect zombie) → `orchctl recover` → `orchctl resume` → `spawn-worker.sh --resume`.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Read
 
 # /orchestrate
 
-Delegates specified issues to the Orchestrator agent for parallel processing using git worktrees + WezTerm windows.
+Delegates specified issues to the Orchestrator agent for parallel processing using git worktrees.
 
 ## Usage
 
@@ -14,14 +14,11 @@ Receive issue numbers (single or multiple) from the user.
 
 Optional flags:
 
-- `--env <profile>` — Select an env profile (default: `default`). Available profiles: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`.
-
-Examples:
+- `--env <profile>` — Env profile (default: `default`). Available: `default`, `headless`, `ci`, or any custom profile in `.cekernel/envs/`.
 
 ```
 /orchestrate #108
 /orchestrate --env headless #108 #109
-/orchestrate --env ci #42
 /orchestrate https://github.com/org/planning/issues/578
 ```
 
@@ -29,157 +26,20 @@ Note: In plugin mode, `/cekernel:orchestrate` also works.
 
 ### Cross-repo Issue References (#440)
 
-Issue references may be plain numbers (`#108`) or full references to another
-repository (issue URL `https://github.com/owner/repo/issues/N`, path
-`/owner/repo/issues/N`, or `owner/repo#N` notation). For each non-plain
-reference, extract `owner/repo` and the issue number, then compare
-`owner/repo` with the current repository (from `git config --get
-remote.origin.url`):
+Issue references may be plain numbers (`#108`) or references to another repository (issue URL, `/owner/repo/issues/N` path, or `owner/repo#N`). For each non-plain reference, extract `owner/repo` and the issue number, then compare with the current repository (`git config --get remote.origin.url`):
 
-- **Same repository** → treat as a plain issue number (no special handling)
-- **Different repository (cross-repo)** → record `owner/repo` as the issue
-  repo for that issue. Pass `--repo <owner/repo>` to all issue-related `gh`
-  commands in triage, and include the issue repo in the Orchestrator prompt
-  (see Step 2) so it is propagated to `spawn-worker.sh --repo`
+- **Same repository** → treat as a plain issue number
+- **Different repository** → record `owner/repo` as that issue's repo. Pass `--repo <owner/repo>` to issue-related `gh` commands during triage, and include the issue repo in the Orchestrator prompt so it propagates to `spawn-worker.sh --repo`
 
-The working repository (current directory) always hosts the worktrees,
-branches, and PRs — run `/orchestrate` from the implementation repository,
-not from the meta-repository that hosts the issues.
+The working repository (current directory) always hosts the worktrees, branches, and PRs — run `/orchestrate` from the implementation repository, not from the meta-repository hosting the issues.
 
 ## Workflow
 
-### Step 0: Detect Agent Names
+Read `skills/references/orchestrator-launch.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/orchestrator-launch.md`; if the Read fails, resolve it via `${CLAUDE_SKILL_DIR}/../references/orchestrator-launch.md`) and follow the launch protocol with these skill-specific policies:
 
-Detect whether cekernel is running as a plugin or locally using file-based detection (ADR-0009).
-
-1. Read `skills/references/namespace-detection.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/namespace-detection.md`). If the Read fails (file not found), you are in plugin mode.
-2. Execute the detection Bash snippet from the reference file.
-3. Set agent names based on the result:
-   - If `CEKERNEL_NS=local`: `CEKERNEL_AGENT_ORCHESTRATOR=orchestrator`, `CEKERNEL_AGENT_WORKER=worker`, `CEKERNEL_AGENT_REVIEWER=reviewer`
-   - If `CEKERNEL_NS=plugin`: `CEKERNEL_AGENT_ORCHESTRATOR=cekernel:orchestrator`, `CEKERNEL_AGENT_WORKER=cekernel:worker`, `CEKERNEL_AGENT_REVIEWER=cekernel:reviewer`
-
-Store these values for use in subsequent steps.
-
-Also resolve the cekernel scripts path for lock checking and Orchestrator propagation:
-
-```bash
-CEKERNEL_SCRIPTS="$(cd -P "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
-```
-
-### Step 1: Lock Filter and Triage
-
-First, filter out issues already being processed by an active Worker:
-
-```bash
-source "${CEKERNEL_SCRIPTS}/shared/issue-lock.sh"
-issue_lock_check "$(git rev-parse --show-toplevel)" <issue-number>
-# exit 0 = locked (skip), exit 1 = unlocked (proceed)
-```
-
-Remove locked issues from the candidate list and report skipped issues to the user.
-
-Then, read `skills/references/triage.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/triage.md`) and follow the triage protocol for each remaining issue.
-
-After triage, delegate to the Orchestrator.
-
-### Step 1.5: Orchestrator Concurrency Guard
-
-Before launching the Orchestrator, check the current number of running orchestrators against `CEKERNEL_MAX_ORCHESTRATORS`:
-
-```bash
-ORCHCTL="${CEKERNEL_SCRIPTS}/ctl/orchctl.sh"
-CURRENT_ORCH=$(bash "$ORCHCTL" count 2>/dev/null)
-source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
-MAX_ORCH="${CEKERNEL_MAX_ORCHESTRATORS:-3}"
-echo "orchestrators: ${CURRENT_ORCH}/${MAX_ORCH}"
-```
-
-If `CURRENT_ORCH >= MAX_ORCH`:
-
-1. Report the current orchestrator count and limit to the user.
-2. Ask the user whether to **wait** for a slot to open or **cancel**.
-3. If the user chooses to **wait**:
-   - Poll `orchctl.sh count` every 30 seconds until `CURRENT_ORCH < MAX_ORCH`:
-   ```bash
-   while true; do
-     CURRENT_ORCH=$(bash "$ORCHCTL" count 2>/dev/null)
-     if [[ "$CURRENT_ORCH" -lt "$MAX_ORCH" ]]; then
-       echo "Slot available (${CURRENT_ORCH}/${MAX_ORCH}). Proceeding."
-       break
-     fi
-     echo "Waiting for slot... (${CURRENT_ORCH}/${MAX_ORCH})"
-     sleep 30
-   done
-   ```
-   - Once a slot opens, proceed to Step 2.
-4. If the user chooses to **cancel**, exit without action.
-
-If `CURRENT_ORCH < MAX_ORCH`, proceed to Step 2 directly.
-
-### Step 2: Parse `--env`, Initialize Session, and Launch Orchestrator Process
-
-If `--env <profile>` was specified, set `CEKERNEL_ENV` to the given profile name. If not specified, default to `default`.
-
-**Initialize cekernel session** — Run the following in a **single** Bash tool call. This generates `CEKERNEL_SESSION_ID` (format: `{repo}-{hex8}`) and writes repo metadata for `orchctl ls`:
-
-```bash
-# 1. Generate CEKERNEL_SESSION_ID ({repo}-{hex8} format)
-source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
-source "${CEKERNEL_SCRIPTS}/shared/session-id.sh"
-mkdir -p "$CEKERNEL_IPC_DIR"
-
-# 2. Write repo metadata for orchctl (org/repo format)
-_url="$(git config --get remote.origin.url)"
-_path="${_url#*:}"; _path="${_path#*//}"; _path="${_path%.git}"
-_REPO_SLUG="${_path#*/}"
-echo "$_REPO_SLUG" > "${CEKERNEL_IPC_DIR}/repo"
-
-# 3. Output CEKERNEL_SESSION_ID for prompt construction
-echo "CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}"
-```
-
-Capture `CEKERNEL_SESSION_ID` from the Bash output (the line `CEKERNEL_SESSION_ID=...`) and use it in the Orchestrator prompt.
-
-Note: Claude Code session ID (`orchestrator.claude-session-id`) persistence is handled by `spawn-orchestrator.sh` itself: it captures the daemon-assigned session ID from the `claude --bg` spawn and persists it deterministically (ADR-0016 Phase 2). Neither this skill nor the Orchestrator writes it.
-
-**Construct the Orchestrator prompt** from the following template. Replace `<placeholders>` with actual values determined in previous steps:
-
-```
-Process the following issues: <#N title, #M title, ...>
-<Execution order if determined in Step 1, otherwise omit this line>
-<Base branch: <branch> if specified, otherwise omit this line>
-<Issue repo: <owner/repo> — pass --repo <owner/repo> to spawn-worker.sh and to issue-related gh commands. Only for cross-repo issues, otherwise omit this line>
-
-Environment values to propagate in ALL script invocations:
-- CEKERNEL_SESSION_ID=<session-id>
-- CEKERNEL_ENV=<profile>
-- CEKERNEL_SCRIPTS=<scripts-path>
-- CEKERNEL_AGENT_WORKER=<worker-agent-name>
-- CEKERNEL_AGENT_REVIEWER=<reviewer-agent-name>
-```
-
-**IMPORTANT**: `CEKERNEL_SESSION_ID` must be `{repo}-{hex8}` format from the Bash output above, **not** the Claude Code session UUID.
-
-**MUST NOT**: Do not include Worker spawn instructions using Agent tool language (`subagent_type`, `Agent(worker)`, etc.) in the prompt. Workers are spawned by the Orchestrator via `spawn-worker.sh` (Bash); the Reviewer is invoked by the Orchestrator itself as a subagent (`Agent(reviewer)` with `isolation: worktree`), following its own agent definition.
-
-**Launch the Orchestrator as an independent OS process** via `spawn-orchestrator.sh`:
-
-```bash
-export CEKERNEL_SESSION_ID=<session-id> && \
-export CEKERNEL_ENV=<profile> && \
-export CEKERNEL_AGENT_ORCHESTRATOR=<agent-name> && \
-export CEKERNEL_AGENT_WORKER=<agent-name> && \
-export CEKERNEL_AGENT_REVIEWER=<agent-name> && \
-"${CEKERNEL_SCRIPTS}/ctl/spawn-orchestrator.sh" "<prompt>"
-```
-
-The script launches the Orchestrator as a `claude --bg --agent` background agent session that runs independently of the parent session, supervised by the on-demand daemon. The captured Claude Code session token is returned on stdout.
-
-The Orchestrator autonomously executes:
-
-1. Issue verification and triage (FAIL for ambiguous issues)
-2. Worker spawning (with `CEKERNEL_ENV` propagated)
-3. Completion monitoring
-4. Review coordination (foreground Reviewer subagent on ci-passed)
-5. Merge decision and cleanup
-
+1. **Step A** (agent names + script path): as written.
+2. **Step B** (lock filter): remove locked issues from the candidate list; report skipped issues.
+3. **Triage**: read `skills/references/triage.md` from the same directory and follow the triage protocol for each remaining issue.
+4. **Step C** (concurrency guard) — over-limit policy: report the count and limit, then ask the user whether to **wait** or **cancel**. If waiting, poll `orchctl.sh count` every 30 seconds until a slot opens, then proceed. If cancelling, exit without action.
+5. **Step D** (session init): as written.
+6. **Step E** (prompt + launch): include the base branch and cross-repo issue lines when applicable.

--- a/skills/postmortem/SKILL.md
+++ b/skills/postmortem/SKILL.md
@@ -6,15 +6,11 @@ allowed-tools: Bash, Read, Agent
 
 # /postmortem
 
-Analyzes Claude Code conversation transcripts associated with given issues to detect structural problems, protocol deviations, and anti-patterns. Based on [ADR-0013](../../docs/adr/0013-transcript-based-postmortem-analysis.md).
-
-## Usage
+Analyzes Claude Code conversation transcripts associated with given issues to detect structural problems, protocol deviations, and anti-patterns (ADR-0013). Each issue is analyzed independently; results are compiled into a single report. Opt-in by design — runs only on explicit user request.
 
 ```
 /postmortem <issue-number> [issue-number...]
 ```
-
-One or more issue numbers can be specified. Each issue is analyzed independently and results are compiled into a single report. Orchestrator transcripts are discovered via `.spawned` files in the IPC directory (session reverse lookup), or can be skipped if unavailable.
 
 Note: In plugin mode, `/cekernel:postmortem` also works.
 
@@ -22,17 +18,15 @@ Note: In plugin mode, `/cekernel:postmortem` also works.
 
 ### Step 0: Detect Namespace and Resolve Paths
 
-Detect whether cekernel is running as a plugin or locally using file-based detection (ADR-0009).
-
 1. Read `skills/references/namespace-detection.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/namespace-detection.md`). If the Read fails (file not found), you are in plugin mode.
 2. Execute the detection Bash snippet from the reference file.
-3. Set namespace based on the result:
-   - If `CEKERNEL_NS=local`: `CEKERNEL_SCRIPTS="$(git rev-parse --show-toplevel)/scripts"`
-   - If `CEKERNEL_NS=plugin`: `CEKERNEL_SCRIPTS="$(dirname "$(which spawn-worker.sh 2>/dev/null)")/../.."/scripts`
+3. Set the script path:
+   - `CEKERNEL_NS=local` → `CEKERNEL_SCRIPTS="$(git rev-parse --show-toplevel)/scripts"`
+   - `CEKERNEL_NS=plugin` → `CEKERNEL_SCRIPTS="$(dirname "$(which spawn-worker.sh 2>/dev/null)")/../.."/scripts`
 
 ### Step 1: Discover Transcripts
 
-Use `transcript-locator.sh` to find all transcripts associated with the issues. **Loop over each issue number** provided in the arguments.
+All transcript path resolution is centralized in `transcript-locator.sh` (ADR-0013). Loop over each issue number:
 
 ```bash
 source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
@@ -47,62 +41,22 @@ for ISSUE in <issue-numbers...>; do
   FOUND=$(transcript_locate_orchestrator_by_issue "$ISSUE" 2>/dev/null) || true
   ORCHESTRATOR_TRANSCRIPTS="${ORCHESTRATOR_TRANSCRIPTS:+${ORCHESTRATOR_TRANSCRIPTS}$'\n'}${FOUND}"
 done
-ALL_TRANSCRIPTS="${WORKER_TRANSCRIPTS}${WORKER_TRANSCRIPTS:+$'\n'}${ORCHESTRATOR_TRANSCRIPTS}"
 ```
 
-#### Transcript Identification
+Identify each transcript's type:
 
-Transcripts discovered by each locator function are treated as follows:
+- Found via `transcript_locate_orchestrator_by_issue` → **Orchestrator** (session reverse-lookup via IPC `.spawned` files; no inspection needed)
+- `transcript_locate_worker` returns both Worker and Reviewer transcripts (shared worktree) — distinguish by the first JSONL line's `agentSetting` field: contains `worker` → **Worker**; contains `reviewer` → **Reviewer** (matches namespaced forms too); missing/no match → **unknown** (still analyze, labeled as unknown)
 
-**Orchestrator** (`ORCHESTRATOR_TRANSCRIPTS`):
-Transcripts found via `transcript_locate_orchestrator_by_issue` are already identified as Orchestrator (session reverse-lookup via IPC `.spawned` files confirms this). No further inspection is needed.
-
-**Worker/Reviewer** (`WORKER_TRANSCRIPTS`):
-`transcript_locate_worker` returns both Worker and Reviewer transcripts (they share the same worktree). File names alone cannot distinguish them. Use the first line's `agentSetting` field in the JSONL to identify the type:
-
-```json
-{"type":"agent-setting","agentSetting":"reviewer","sessionId":"6fe286bd-..."}
-{"type":"agent-setting","agentSetting":"worker","sessionId":"82bbd747-..."}
-```
-
-- Found via `transcript_locate_orchestrator_by_issue` → **Orchestrator**
-- `agentSetting` contains `worker` → **Worker** (matches both `worker` and `cekernel:worker`)
-- `agentSetting` contains `reviewer` → **Reviewer** (matches both `reviewer` and `cekernel:reviewer`)
-- `agentSetting` line missing or no match → **unknown** (still analyze; pass as "unknown type transcript" to subagent)
-
-Report what was found:
-
-```
-## Transcript Discovery
-
-- Issues: #N, #M, ...
-- Worker/Reviewer: N transcript(s) found
-- Orchestrator: N transcript(s) found
-- Total: N transcript(s) to analyze
-
-Missing transcripts (if any):
-- <explain what was not found and why>
-```
-
-If no transcripts are found at all, report the failure to the user and stop.
+Report the discovery (issues, per-type counts, total, and any missing transcripts with reasons). If no transcripts are found at all, report the failure and stop.
 
 ### Step 2: Read Detection Patterns
 
-Read the detection patterns checklist:
-
-```
-${CEKERNEL_SCRIPTS}/../skills/references/postmortem-patterns.md
-```
-
-This file defines all detection categories, heuristics, and severities. The full content of this file will be included in each analysis subagent's prompt.
+Read `${CEKERNEL_SCRIPTS}/../skills/references/postmortem-patterns.md` — it defines all detection categories, heuristics, and severities. Its full content goes into each analysis subagent's prompt.
 
 ### Step 3: Analyze Transcripts via Subagents
 
-For **each** discovered transcript, launch an analysis subagent using the Agent tool. Transcripts routinely exceed 100K+ tokens and cannot fit in a single context window — one subagent per transcript is the expected default, not an edge-case fallback.
-
-Launch subagents in parallel when multiple transcripts exist.
-
-For each subagent:
+Launch one analysis subagent per transcript with the Agent tool (transcripts routinely exceed 100K tokens — one per transcript is the default, not a fallback). Launch in parallel when multiple transcripts exist.
 
 - **Description**: `"postmortem: analyze <transcript-basename>"`
 - **Prompt** (include all of the following):
@@ -113,9 +67,8 @@ You are analyzing a Claude Code conversation transcript for post-mortem analysis
 ## Transcript
 Read this file: <absolute-path-to-transcript.jsonl>
 
-The file is a JSONL (one JSON object per line). Each line is a conversation message
-(user/assistant turns, tool calls, tool results). Read the file in chunks if it is
-too large to read at once (use the offset/limit parameters of the Read tool).
+The file is a JSONL (one JSON object per line) of conversation messages.
+Read in chunks (Read offset/limit) if it is too large for a single call.
 
 ## Detection Patterns
 <paste the full content of postmortem-patterns.md here>
@@ -123,95 +76,44 @@ too large to read at once (use the offset/limit parameters of the Read tool).
 ## Instructions
 1. Read through the transcript systematically
 2. For each detection pattern, check whether the transcript contains matching evidence
-3. If you find a problem that does not match any existing pattern, still report it — infer the most appropriate Class (1-4) based on the root cause
+3. If you find a problem matching no existing pattern, still report it — infer the most appropriate Class (1-4) from the root cause
 4. Report ALL matches found, not just the first
 
 ## Output Format
-Report findings as a structured list. If no problems are found, report "No issues detected."
-
-For each finding:
-- **Category**: <pattern category from the checklist>
-- **Pattern**: <specific pattern name>
-- **Severity**: critical / warning / info
-- **Class**: <1 / 2 / 3 / 4 — from the pattern's Class field>
-- **Evidence**: <relevant excerpt or description of what was found in the transcript>
-- **Location**: <approximate position in the transcript — e.g., "early in session", "during CI retry phase", or line range if known>
-- **Recommendation**: <suggested action or fix>
+Report findings as a structured list ("No issues detected." if none). For each finding:
+- **Category** / **Pattern** / **Severity** (critical/warning/info) / **Class** (1-4)
+- **Evidence**: excerpt or description from the transcript
+- **Location**: approximate position (e.g., "during CI retry phase")
+- **Recommendation**: suggested action or fix
 ```
 
 ### Step 4: Compile Results
 
-After all subagents complete, compile their findings into a unified report. Group findings by their **Class** (root-cause classification):
+Compile all subagent findings into a unified report grouped by **Class**, and present it to the user. Omit sections for classes with no findings:
 
 ```
-## Post-Mortem Report: Issue #<number> [, #<number>, ...]
+## Post-Mortem Report: Issue #<number> [, ...]
 
 ### Summary
 - Transcripts analyzed: N
-- Issues found: N (X critical, Y warning, Z info)
-  - Class 1 (cekernel defect): N
-  - Class 2 (project CLAUDE.md/rules): N
-  - Class 3 (external constraint): N
-  - Class 4 (Claude Code defect): N
+- Issues found: N (X critical, Y warning, Z info), broken down by Class 1-4
 
 ### Class 1: cekernel defects / configuration issues
 > Action: consider creating issue(s) in cekernel repository
-<list findings with severity, evidence, recommendation>
-
 ### Class 2: project CLAUDE.md / rule gaps
 > Action: recommend creating issue(s) in target repository
-<list findings with severity, evidence, recommendation>
-
 ### Class 3: external constraints (GitHub API / Anthropic API etc.)
-> Action: investigate whether this is a known constraint
-<list findings with severity, evidence, recommendation>
-
 ### Class 4: Claude Code defects
-> Action: investigate whether this is a known constraint
-<list findings with severity, evidence, recommendation>
+> Class 3/4 Action: investigate whether this is a known constraint
+<each section: findings with severity, evidence, recommendation>
 ```
-
-Omit sections for classes with no findings.
-
-Present this report to the user.
 
 ### Step 5: Propose Actions by Class (User Approval Required)
 
-After presenting the report, propose actions for each class that has findings.
-
-**Class 1 — create issues in cekernel repository:**
-For each actionable Class 1 finding (critical or warning), propose a GitHub issue in cekernel:
-```
-1. **Title**: <short title>
-   **Body**: <description with evidence and suggested fix>
-```
-Ask the user which issues to create. For approved issues:
-```bash
-gh issue create --title "<title>" --body "<body>"
-```
-
-**Class 2 — create issues in target repository:**
-For each actionable Class 2 finding (critical or warning), propose a GitHub issue in the target repository.
-Creating these issues is recommended. Ask the user for approval before proceeding.
-```bash
-gh issue create --repo <owner>/<repo> --title "<title>" --body "<body>"
-```
-
-**Class 3 & 4 — investigate known constraints:**
-For Class 3 (external) and Class 4 (Claude Code) findings, do not propose issue creation.
-Instead, summarize the finding as a known constraint:
-```
-- **Finding**: <pattern name>
-  **Status**: known constraint / needs investigation
-  **Note**: <brief description of what is known and where to track it>
-```
-
 **Do not create any issues without explicit user approval.**
 
-Report the created issue numbers back to the user.
+- **Class 1** (actionable critical/warning): propose GitHub issues in cekernel (title + body with evidence and suggested fix); create approved ones with `gh issue create`
+- **Class 2**: same, targeting the target repository (`gh issue create --repo <owner>/<repo> ...`)
+- **Class 3 & 4**: no issue creation — summarize each finding as a known constraint / needs-investigation note
 
-## Notes
-
-- Transcript paths depend on Claude Code's internal implementation and may change. All path resolution is centralized in `transcript-locator.sh` (see ADR-0013).
-- If a transcript is too large for a single Read call, subagents should use `offset` and `limit` parameters to read in chunks.
-- The analysis is opt-in by design (Rule of Economy) — it only runs when the user explicitly requests it.
+Report created issue numbers back to the user.

--- a/skills/references/adr-template.md
+++ b/skills/references/adr-template.md
@@ -1,0 +1,59 @@
+# ADR Template
+
+Used by `/unix-architect adr`. Write ADRs in this format:
+
+```markdown
+# ADR-NNNN: [Title]
+
+## Status
+
+Proposed
+
+## Context
+
+[What is the problem or situation? Why does a decision need to be made?
+Include relevant technical context, constraints, and prior art.]
+
+## Decision
+
+[What is the change that we're proposing and/or doing?]
+
+### UNIX Philosophy Alignment
+
+[For each relevant principle, explain how the decision aligns with or
+intentionally deviates from it. Quote the principle, then explain.]
+
+> Rule of X: "..."
+
+[How this decision relates to the principle.]
+
+### Platform Constraints
+
+[If applicable: Which Claude Code platform constraints influenced this
+decision? How do they shape or limit the design? If none apply, omit
+this section.]
+
+## Alternatives Considered
+
+[For each alternative:]
+
+### Alternative: [Name]
+
+[Description, and why it was not chosen. Reference UNIX principles
+where they informed the rejection.]
+
+## Consequences
+
+### Positive
+
+- [Benefit 1]
+
+### Negative
+
+- [Cost or risk 1]
+
+### Trade-offs
+
+[Where did principles or goals conflict?
+What was sacrificed and why was it acceptable?]
+```

--- a/skills/references/orchestrator-launch.md
+++ b/skills/references/orchestrator-launch.md
@@ -1,0 +1,96 @@
+# Orchestrator Launch Protocol
+
+Shared protocol for skills that delegate issues to the Orchestrator (`/orchestrate`, `/dispatch`). The invoking skill defines *which* issues to process; this reference defines *how* to launch the Orchestrator for them.
+
+## Step A: Detect Agent Names and Script Path
+
+Detect plugin vs local mode with file-based detection (ADR-0009):
+
+1. Read `skills/references/namespace-detection.md` from the repository root (`$(git rev-parse --show-toplevel)/skills/references/namespace-detection.md`). If the Read fails (file not found), you are in plugin mode.
+2. Execute the detection Bash snippet from the reference file.
+3. Set agent names:
+   - `CEKERNEL_NS=local` → `CEKERNEL_AGENT_ORCHESTRATOR=orchestrator`, `CEKERNEL_AGENT_WORKER=worker`, `CEKERNEL_AGENT_REVIEWER=reviewer`
+   - `CEKERNEL_NS=plugin` → the same names prefixed with `cekernel:`
+
+Resolve the cekernel scripts path for lock checking and Orchestrator propagation:
+
+```bash
+CEKERNEL_SCRIPTS="$(cd -P "${CLAUDE_SKILL_DIR}/../../scripts" && pwd)"
+```
+
+## Step B: Lock Filter
+
+Filter out issues already being processed by an active Worker, and report skipped issues to the user:
+
+```bash
+source "${CEKERNEL_SCRIPTS}/shared/issue-lock.sh"
+issue_lock_check "$(git rev-parse --show-toplevel)" <issue-number>
+# exit 0 = locked (skip), exit 1 = unlocked (proceed)
+```
+
+## Step C: Orchestrator Concurrency Guard
+
+Check running orchestrators against the limit before launching:
+
+```bash
+ORCHCTL="${CEKERNEL_SCRIPTS}/ctl/orchctl.sh"
+CURRENT_ORCH=$(bash "$ORCHCTL" count 2>/dev/null)
+source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
+MAX_ORCH="${CEKERNEL_MAX_ORCHESTRATORS:-3}"
+echo "orchestrators: ${CURRENT_ORCH}/${MAX_ORCH}"
+```
+
+If `CURRENT_ORCH >= MAX_ORCH`, follow the invoking skill's over-limit policy. Otherwise proceed.
+
+## Step D: Initialize Session
+
+If `--env <profile>` was specified, set `CEKERNEL_ENV` to it (default: `default`).
+
+Run the following in a **single** Bash tool call — it generates `CEKERNEL_SESSION_ID` (`{repo}-{hex8}` format) and writes repo metadata for `orchctl ls`:
+
+```bash
+source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
+source "${CEKERNEL_SCRIPTS}/shared/session-id.sh"
+mkdir -p "$CEKERNEL_IPC_DIR"
+
+_url="$(git config --get remote.origin.url)"
+_path="${_url#*:}"; _path="${_path#*//}"; _path="${_path%.git}"
+echo "${_path#*/}" > "${CEKERNEL_IPC_DIR}/repo"
+
+echo "CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}"
+```
+
+Capture `CEKERNEL_SESSION_ID` from the output line. It must be the `{repo}-{hex8}` value, **not** the Claude Code session UUID. (The Claude Code session ID is captured and persisted by `spawn-orchestrator.sh` itself — neither the skill nor the Orchestrator writes it.)
+
+## Step E: Construct the Prompt and Launch
+
+Prompt template — replace `<placeholders>` with actual values:
+
+```
+Process the following issues: <#N title, #M title, ...>
+<Execution order if determined during triage, otherwise omit this line>
+<Base branch: <branch> if specified, otherwise omit this line>
+<Issue repo: <owner/repo> — pass --repo <owner/repo> to spawn-worker.sh and to issue-related gh commands. Only for cross-repo issues, otherwise omit this line>
+
+Environment values to propagate in ALL script invocations:
+- CEKERNEL_SESSION_ID=<session-id>
+- CEKERNEL_ENV=<profile>
+- CEKERNEL_SCRIPTS=<scripts-path>
+- CEKERNEL_AGENT_WORKER=<worker-agent-name>
+- CEKERNEL_AGENT_REVIEWER=<reviewer-agent-name>
+```
+
+**MUST NOT**: do not include Worker spawn instructions using Agent tool language (`subagent_type`, `Agent(worker)`, etc.) in the prompt. Workers are spawned by the Orchestrator via `spawn-worker.sh` (Bash); the Reviewer is invoked by the Orchestrator itself as a subagent, following its own agent definition.
+
+Launch the Orchestrator as an independent process:
+
+```bash
+export CEKERNEL_SESSION_ID=<session-id> && \
+export CEKERNEL_ENV=<profile> && \
+export CEKERNEL_AGENT_ORCHESTRATOR=<agent-name> && \
+export CEKERNEL_AGENT_WORKER=<agent-name> && \
+export CEKERNEL_AGENT_REVIEWER=<agent-name> && \
+"${CEKERNEL_SCRIPTS}/ctl/spawn-orchestrator.sh" "<prompt>"
+```
+
+The script launches a `claude --bg --agent` background session supervised by the on-demand daemon and returns the captured Claude Code session token on stdout. The Orchestrator then autonomously executes: triage → Worker spawning → completion monitoring → review coordination → merge decision and cleanup.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,130 +5,40 @@ allowed-tools: Bash, Read, AskUserQuestion
 
 # /setup
 
-Interactive setup for cekernel runtime environment. Creates the directory structure and writes a user profile to `~/.config/cekernel/envs/default.env`.
+Interactive setup for the cekernel runtime environment. Creates the directory structure and writes a user profile to `~/.config/cekernel/envs/default.env`.
 
 ## Workflow
 
 ### Step 1: Ask CEKERNEL_VAR_DIR and CEKERNEL_BACKEND
 
-Use `AskUserQuestion` to ask both questions at once:
+Use `AskUserQuestion` to ask both at once:
 
-1. **Runtime directory**: Use `~/.local/var/cekernel` as default. Present as "Use default?" with the default path shown. If the user selects "Other", they can provide a custom path.
-2. **Backend**: Present the three backend options.
+1. **Runtime directory** (header: "VAR_DIR"): options `~/.local/var/cekernel (Recommended)` ("User-local directory. No sudo required.") and `/usr/local/var/cekernel` ("System-wide directory. May require sudo to create."); "Other" allows a custom path.
+2. **Backend** (header: "Backend"): options `headless (Recommended)` ("No terminal required. Runs in the background."), `wezterm` ("Visualize Workers in WezTerm tabs."), `tmux` ("Run Workers in tmux sessions.").
 
-```
-Question 1: "Use ~/.local/var/cekernel as the runtime directory?"
-  header: "VAR_DIR"
-  options:
-    - label: "~/.local/var/cekernel (Recommended)"
-      description: "User-local directory. No sudo required."
-    - label: "/usr/local/var/cekernel"
-      description: "System-wide directory. May require sudo to create."
-  (User can also select "Other" to provide a custom path)
-
-Question 2: "Which backend should cekernel use?"
-  header: "Backend"
-  options:
-    - label: "headless (Recommended)"
-      description: "No terminal required. Runs in the background."
-    - label: "wezterm"
-      description: "Visualize Workers in WezTerm tabs."
-    - label: "tmux"
-      description: "Run Workers in tmux sessions."
-```
-
-Map the answers:
-- Question 1: extract the path from the selected label, or use the custom input
-- Question 2: extract the backend name (`headless`, `wezterm`, or `tmux`)
+Map the answers: the path from the selected label or custom input; the backend name (`headless`, `wezterm`, or `tmux`).
 
 ### Step 2: Additional variable configuration
 
-Present configurable variables and let the user optionally customize them.
-
-#### 2a. Display variable catalog
-
-Read `envs/README.md` using the `Read` tool and display the **User-configurable Variables** table (Variable, Default, Purpose columns). Exclude `CEKERNEL_VAR_DIR` and `CEKERNEL_BACKEND` since they were already configured in Step 1.
-
-#### 2b. Ask if the user wants to customize
-
-Use `AskUserQuestion`:
-
-```
-Question: "Would you like to customize any additional variables?"
-  header: "Additional Configuration"
-  options:
-    - label: "No, use defaults"
-      description: "Continue with default values for all other variables."
-    - label: "Yes, customize"
-      description: "Set one or more variables interactively."
-```
-
-- If **"No, use defaults"** → skip to Step 3.
-- If **"Yes, customize"** → proceed to 2c.
-
-#### 2c. Accept variable input
-
-Use `AskUserQuestion` with "Other" (free-text input):
-
-```
-Question: "Enter a variable to set (KEY=VALUE format):"
-  header: "Set Variable"
-  (User provides free-text input via "Other")
-```
-
-**Separator normalization**: The user may use any common separator between key and value (`=`, `:`, `;`, `/`, `|`, or space). Normalize the input by replacing the first occurrence of any of these separators with `=` before validation and storage. Examples — all of these are normalized to `CEKERNEL_WORKER_TIMEOUT=1800`:
-
-```
-CEKERNEL_WORKER_TIMEOUT=1800   → as-is
-CEKERNEL_WORKER_TIMEOUT:1800   → replace : with =
-CEKERNEL_WORKER_TIMEOUT 1800   → replace space with =
-```
-
-#### 2d. Validate the input
-
-1. **Variable name check**: Verify the variable name exists in the User-configurable Variables table of `envs/README.md`. If not found, show an error and ask again.
-2. **Value format check**: Validate the value against the "Valid Values" column:
-   - "Positive integer" → must match `^[1-9][0-9]*$`
-   - "`true`, `false`" → must be exactly `true` or `false`
-   - "`wezterm`, `tmux`, `headless`" → must be one of those exact strings
-   - "Directory path" → must be a non-empty path string
-   - "Any filename" → must be a non-empty string
-   - "`none`, `open`, `pbcopy`" → must be one of those exact strings
-3. If validation fails, show the expected format and ask again.
-
-#### 2e. Repeat
-
-After successfully setting a variable, store it and ask:
-
-```
-Question: "Would you like to set another variable?"
-  header: "More Variables"
-  options:
-    - label: "No, continue"
-      description: "Proceed with setup."
-    - label: "Yes"
-      description: "Set another variable."
-```
-
-Repeat from 2c until the user selects **"No, continue"**.
+1. Read `envs/README.md` (Read tool) and display the **User-configurable Variables** table (Variable, Default, Purpose), excluding `CEKERNEL_VAR_DIR` and `CEKERNEL_BACKEND`.
+2. Ask (`AskUserQuestion`, header "Additional Configuration"): "No, use defaults" → skip to Step 3 / "Yes, customize" → continue.
+3. Accept input via `AskUserQuestion` with "Other" free-text: "Enter a variable to set (KEY=VALUE format):"
+   - **Separator normalization**: the user may separate key and value with `=`, `:`, `;`, `/`, `|`, or space — replace the first occurrence with `=` before validation (e.g. `CEKERNEL_WORKER_TIMEOUT 1800` → `CEKERNEL_WORKER_TIMEOUT=1800`).
+4. Validate:
+   - The variable name must exist in the User-configurable Variables table; otherwise show an error and ask again.
+   - The value must match the "Valid Values" column: "Positive integer" → `^[1-9][0-9]*$`; enumerations (e.g. `true`/`false`, backend names, `none`/`open`/`pbcopy`) → exact match; "Directory path" / "Any filename" → non-empty string. On failure, show the expected format and ask again.
+5. After each successful variable, ask (header "More Variables"): "No, continue" → Step 3 / "Yes" → repeat from 3.
 
 ### Step 3: Create directory structure
 
-Run the following commands using the chosen `VAR_DIR`:
-
 ```bash
-mkdir -p "${VAR_DIR}/ipc"
-mkdir -p "${VAR_DIR}/locks"
-mkdir -p "${VAR_DIR}/logs"
-mkdir -p "${VAR_DIR}/runners"
+mkdir -p "${VAR_DIR}/ipc" "${VAR_DIR}/locks" "${VAR_DIR}/logs" "${VAR_DIR}/runners"
 if [ ! -f "${VAR_DIR}/schedules.json" ]; then
   echo '[]' > "${VAR_DIR}/schedules.json"
 fi
 ```
 
 ### Step 4: Write user profile
-
-Write `~/.config/cekernel/envs/default.env`:
 
 ```bash
 mkdir -p "$HOME/.config/cekernel/envs"
@@ -141,34 +51,16 @@ ${ADDITIONAL_VARS}
 EOF
 ```
 
-Where `${ADDITIONAL_VARS}` is the list of `KEY=VALUE` lines collected in Step 2 (one per line). If no additional variables were set, omit the comment and the blank section.
+`${ADDITIONAL_VARS}` is the `KEY=VALUE` lines from Step 2 (one per line); omit the comment and section if none.
 
-**Important**: `VAR_DIR` must be written as an absolute path (e.g., `/Users/alice/.local/var/cekernel`), not with `~`. Tilde is not expanded inside variable values read by `load-env.sh`. If the user specifies `~/.local/var/cekernel`, expand it to `$HOME/.local/var/cekernel` before writing.
+**Important**: write `VAR_DIR` as an absolute path — tilde is not expanded inside values read by `load-env.sh`. Expand `~/...` to `$HOME/...` before writing.
 
 ### Step 5: Summary
 
-Display the result and guide the user to further configuration:
-
-```
-Setup complete:
-  Runtime directory: ${VAR_DIR}
-  Backend: ${BACKEND}
-  Additional variables: ${COUNT} configured  (or "none" if skipped)
-  User profile: ~/.config/cekernel/envs/default.env
-
-See envs/README.md for other configuration options.
-```
-
-If the user selected `wezterm`, also mention:
-
-```
-For WezTerm backend, see config/README.md to install the WezTerm plugin.
-```
-
-Read these files using the Read tool to provide the actual content path relative to the plugin directory.
+Display: runtime directory, backend, count of additional variables (or "none"), profile path — and point to `envs/README.md` for other options. If the user selected `wezterm`, also point to `config/README.md` for the WezTerm plugin installation (read these files to give the actual path relative to the plugin directory).
 
 ## Important
 
-- Do NOT run `sudo` at any point. The purpose of this skill is to avoid `sudo` by using user-local paths.
-- If `~/.config/cekernel/envs/default.env` already exists, show the current content and ask the user whether to overwrite.
-- Use `~` expansion correctly in bash (use `$HOME` in scripts).
+- Do NOT run `sudo` at any point — the purpose of this skill is to avoid it via user-local paths.
+- If `~/.config/cekernel/envs/default.env` already exists, show the current content and ask whether to overwrite.
+- Use `$HOME` (not `~`) inside scripts.

--- a/skills/unix-architect/SKILL.md
+++ b/skills/unix-architect/SKILL.md
@@ -9,14 +9,7 @@ Architecture Decision Records and architectural reviews, from a senior architect
 
 ## Persona
 
-You are a senior software architect who:
-
-- Has deep knowledge of the **UNIX philosophy** — the 17 principles from Eric S. Raymond's *The Art of Unix Programming* are your primary evaluation lens
-- Is well-versed in **computer science fundamentals** — algorithms, data structures, distributed systems, operating systems, concurrency, and systems design
-- Is aware of **platform constraints** — cekernel runs on Claude Code, whose execution model (turn-based, single-threaded, context-limited) directly shapes what architectures are feasible
-- Thinks in **trade-offs**, not absolutes — every decision has costs and benefits
-- Values **simplicity and composability** above all — complexity must justify itself
-- Documents decisions rigorously so future maintainers understand not just *what* was decided, but *why*
+You are a senior software architect: the 17 UNIX principles (Eric S. Raymond) are your primary evaluation lens; you are well-versed in CS fundamentals (algorithms, distributed systems, OS, concurrency); you account for Claude Code's platform constraints (turn-based, single-threaded, context-limited); you think in trade-offs, value simplicity and composability above all, and document not just *what* was decided but *why*.
 
 ## Usage
 
@@ -25,181 +18,76 @@ You are a senior software architect who:
 /unix-architect review <target>
 ```
 
-### Modes
+- **`adr`** — write an Architecture Decision Record for a proposal or topic
+- **`review`** — review a target from a UNIX philosophy perspective: a PR number (`review #81`), an ADR path (`review adr/0001`), or an issue number (`review #74`)
 
-- **`adr`** — Write an Architecture Decision Record for a proposal
-- **`review`** — Review a PR, ADR, or issue from a UNIX philosophy perspective
-
-The `<target>` can be:
-- A proposal or topic: `adr session memory for IPC` — write a new ADR
-- A PR number: `review #81` — review the PR diff
-- An ADR path: `review adr/0001` — review an existing ADR
-- An issue number: `review #74` — evaluate an idea/proposal on the issue
-
-If no mode is specified, infer from context: if the input references an existing artifact to evaluate, use `review`; if it describes a new decision to document, use `adr`.
-
-Output destination (file, issue/PR comment, conversation only) is determined interactively in Phase 7.
+If no mode is specified, infer: an existing artifact to evaluate → `review`; a new decision to document → `adr`.
 
 ## Workflow — Common Phases
 
 ### Phase 1: Load Knowledge Base
 
-Read the following documents from the repository:
-
-1. **UNIX philosophy** — `docs/unix-philosophy.md`. Internalize all 17 principles. These are your primary evaluation criteria.
-2. **Claude Code platform constraints** — `docs/claude-code-constraints.md`. Internalize the execution model, agent architecture, and concurrency characteristics. These inform what designs are feasible on the platform cekernel runs on.
+Read from the repository: `docs/unix-philosophy.md` (internalize all 17 principles — your primary evaluation criteria) and `docs/claude-code-constraints.md` (execution model, agent architecture, concurrency — what designs are feasible on the platform).
 
 ### Phase 2: Understand the Target
 
-1. Parse the user's input to identify the mode (`adr` or `review`) and subject
-2. If an issue number is given, read its content via `gh issue view`
-3. If a PR number is given, read the PR description and diff via `gh pr view` and `gh pr diff`
-4. If an ADR path is given, read the file
-5. Ask clarifying questions if the input is ambiguous — do not proceed with assumptions
+Identify the mode and subject. Read the referenced artifact (`gh issue view` / `gh pr view` + `gh pr diff` / the ADR file). Ask clarifying questions if the input is ambiguous — do not proceed with assumptions.
 
 ### Phase 3: Analyze Current State
 
-Investigate the relevant parts of the codebase:
-
-1. Use `Glob`, `Grep`, and `Read` to understand existing architecture
-2. Identify current patterns, conventions, and constraints
-3. Note technical debt or prior decisions that influence this one
-
-For broad exploration, use `Task(Explore)` to investigate efficiently.
+Investigate the relevant codebase with `Glob`/`Grep`/`Read` (use `Task(Explore)` for broad exploration): existing patterns, conventions, constraints, and prior decisions that influence this one.
 
 ### Phase 4: Evaluate Through UNIX Principles
 
-For the proposal, decision, or changes under review:
-
-1. Identify which UNIX principles are **most relevant** (typically 3-5 per decision)
-2. Assess alignment or tension with each relevant principle
-3. Consider CS fundamentals: algorithmic complexity, concurrency implications, failure modes, scalability characteristics
-4. Identify trade-offs explicitly — where principles conflict (e.g., Simplicity vs. Extensibility), acknowledge the tension and justify the choice
-
-Do NOT force-fit all 17 principles. Only cite those that genuinely inform the evaluation.
+Identify the **most relevant** principles (typically 3-5 — do NOT force-fit all 17). Assess alignment or tension with each; consider CS fundamentals (complexity, concurrency, failure modes, scalability); make trade-offs explicit — where principles conflict, acknowledge the tension and justify the choice.
 
 ### Phase 5: Evaluate Against Platform Constraints
 
-Assess whether the proposal, decision, or changes are **feasible and sound** given Claude Code's platform constraints (loaded in Phase 1). This phase is unique to cekernel — most projects do not need it, but cekernel's deep dependency on Claude Code internals makes it essential.
+Assess feasibility against Claude Code's constraints (unique to cekernel — its deep platform dependency makes this essential):
 
-For each relevant constraint:
+1. **Applicability**: does the design touch execution flow, agent coordination, background tasks, context management, or inter-session communication?
+2. **Feasibility**: does it assume capabilities the platform does not provide (mid-turn interruption, shared memory between sessions, real-time events)?
+3. **Constraint-driven trade-offs**: document compromises imposed by the runtime — distinct from philosophically chosen ones.
+4. **Staleness risks**: flag dependencies on constraints marked "Evolving" — the design should be revisited when they change.
 
-1. **Identify applicability**: Does the design touch execution flow, agent coordination, background tasks, context management, or inter-session communication? If not, this phase may be brief or skipped entirely.
-2. **Check feasibility**: Does the design assume capabilities the platform does not provide? (e.g., mid-turn interruption, shared memory between sessions, real-time event handling)
-3. **Note constraint-driven trade-offs**: Where a platform limitation forces a design compromise, document it explicitly. These are distinct from UNIX-principle trade-offs — they are imposed by the runtime, not chosen for philosophical reasons.
-4. **Flag staleness risks**: If the design depends on a constraint marked "Evolving" in the reference document, note that the constraint may change and the design should be revisited when it does.
-
-Do NOT repeat constraints that are irrelevant to the current proposal. Only surface those that materially affect the design.
-
-**When to skip**: If the proposal is purely about data formats, naming conventions, documentation, or other aspects that do not interact with Claude Code's execution model, state "No platform constraints apply" and move on.
+Only surface constraints that materially affect the design. If none interact with the execution model (data formats, naming, documentation), state "No platform constraints apply" and move on.
 
 ## Workflow — ADR Mode
 
 ### Phase 6a: Write the ADR
 
-Determine the next ADR number by checking existing files in `docs/adr/`:
-
-```bash
-ls docs/adr/*.md 2>/dev/null | sort -V | tail -1
-```
-
-If no ADR directory exists, start at `0001`. Create the directory if needed.
-
-Write the ADR in the following format:
-
-```markdown
-# ADR-NNNN: [Title]
-
-## Status
-
-Proposed
-
-## Context
-
-[What is the problem or situation? Why does a decision need to be made?
-Include relevant technical context, constraints, and prior art.]
-
-## Decision
-
-[What is the change that we're proposing and/or doing?]
-
-### UNIX Philosophy Alignment
-
-[For each relevant principle, explain how the decision aligns with or
-intentionally deviates from it. Quote the principle, then explain.]
-
-> Rule of X: "..."
-
-[How this decision relates to the principle.]
-
-### Platform Constraints
-
-[If applicable: Which Claude Code platform constraints influenced this
-decision? How do they shape or limit the design? If none apply, omit
-this section.]
-
-## Alternatives Considered
-
-[For each alternative:]
-
-### Alternative: [Name]
-
-[Description, and why it was not chosen. Reference UNIX principles
-where they informed the rejection.]
-
-## Consequences
-
-### Positive
-
-- [Benefit 1]
-- [Benefit 2]
-
-### Negative
-
-- [Cost or risk 1]
-- [Cost or risk 2]
-
-### Trade-offs
-
-[Where did principles or goals conflict?
-What was sacrificed and why was it acceptable?]
-```
+Determine the next number (`ls docs/adr/*.md 2>/dev/null | sort -V | tail -1`; start at `0001` if none, creating the directory if needed). Read `skills/references/adr-template.md` (relative to this skill: `${CLAUDE_SKILL_DIR}/../references/adr-template.md`) and write the ADR in that format.
 
 ## Workflow — Review Mode
 
 ### Phase 6b: Conduct the Review
 
-Evaluate the target through the UNIX philosophy lens and CS fundamentals. Structure the review as:
+Structure the review as:
 
-1. **Summary**: One-paragraph understanding of what is being proposed or changed
-2. **UNIX Philosophy Assessment**: For each relevant principle, state whether the target aligns, partially aligns, or conflicts — with specific evidence from the code/proposal
-3. **Platform Constraint Assessment** (if applicable): Flag any design aspects that interact with Claude Code's execution model. Note feasibility issues, constraint-driven trade-offs, or assumptions about platform behavior. Omit if no constraints apply.
-4. **Technical Observations**: Concrete issues, risks, or improvements spotted — reference specific files, lines, or design choices
-5. **Verdict**: One of:
-   - **Approve** — Sound architecture, aligns well with principles
-   - **Approve with suggestions** — Fundamentally sound, minor improvements recommended
-   - **Request changes** — Architectural concerns that should be addressed before proceeding
-6. **Suggestions** (if any): Actionable, specific recommendations
+1. **Summary**: one-paragraph understanding of the proposal or change
+2. **UNIX Philosophy Assessment**: per relevant principle — aligns / partially aligns / conflicts, with specific evidence
+3. **Platform Constraint Assessment** (omit if none apply): feasibility issues, constraint-driven trade-offs, platform-behavior assumptions
+4. **Technical Observations**: concrete issues, risks, or improvements — reference specific files, lines, design choices
+5. **Verdict**: **Approve** / **Approve with suggestions** / **Request changes**
+6. **Suggestions** (if any): actionable and specific
 
 ## Workflow — Output (shared)
 
 ### Phase 7: Present and Publish
 
-First, present the output (ADR or review) directly to the user in the conversation. Then ask where else to publish:
+Present the output in the conversation first, then ask where else to publish (multiple selections allowed):
 
-1. **Save to file** — Write to `docs/adr/NNNN-short-title.md` (ADR mode) or a path the user specifies
-2. **Post to issue/PR** — Post as a comment via `gh issue comment` or `gh pr comment`
-3. **Conversation only** — No additional output
+1. **Save to file** — `docs/adr/NNNN-short-title.md` (ADR mode) or a user-specified path
+2. **Post to issue/PR** — `gh issue comment` / `gh pr comment` (suggest by default if the invocation referenced an issue or PR)
+3. **Conversation only**
 
-Multiple options can be selected (e.g., save to file AND post to issue). If the user provided `--issue <number>` or a PR number in the invocation, suggest posting there by default.
-
-If the user requests changes, iterate on the content and update all previously published destinations.
+If the user requests changes, iterate and update all previously published destinations.
 
 ## Guidelines
 
-- **Be opinionated but honest**: State your recommendation clearly, but always present alternatives fairly
-- **Cite principles precisely**: Quote the exact principle name and maxim from the philosophy document
-- **Quantify when possible**: Prefer "O(n) lookup vs O(1) with hash map" over "slower vs faster"
-- **Consider the human**: Rule of Economy reminds us that programmer time matters — factor in cognitive load, learning curve, and maintenance burden
-- **Respect Rule of Diversity**: Never claim there is only one right answer. Acknowledge when reasonable people could disagree
-- **Keep it concise**: An ADR that nobody reads serves nobody. A review that buries its key point in noise serves nobody. Aim for clarity over thoroughness
+- **Be opinionated but honest**: state your recommendation clearly, present alternatives fairly
+- **Cite principles precisely**: quote the exact principle name and maxim
+- **Quantify when possible**: "O(n) vs O(1)" over "slower vs faster"
+- **Consider the human** (Rule of Economy): cognitive load, learning curve, maintenance burden
+- **Respect Rule of Diversity**: acknowledge when reasonable people could disagree
+- **Keep it concise**: an ADR nobody reads serves nobody — clarity over thoroughness

--- a/tests/orchestrator/test-spawn-cwd-drift.sh
+++ b/tests/orchestrator/test-spawn-cwd-drift.sh
@@ -23,7 +23,6 @@ CLEANUP_SH="${CEKERNEL_DIR}/scripts/orchestrator/cleanup-worktree.sh"
 SPAWN_ORCH_SH="${CEKERNEL_DIR}/scripts/ctl/spawn-orchestrator.sh"
 PROCESS_STATUS_SH="${CEKERNEL_DIR}/scripts/orchestrator/process-status.sh"
 NOTIFY_COMPLETE_SH="${CEKERNEL_DIR}/scripts/process/notify-complete.sh"
-ORCH_MD="${CEKERNEL_DIR}/agents/orchestrator.md"
 
 # ── Test 1: spawn.sh sources resolve-repo-root.sh ──
 if file_contains 'resolve-repo-root.sh' "$SPAWN_SH"; then
@@ -97,25 +96,9 @@ else
   TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
-# ── Test 9: orchestrator.md documents CWD convention ──
-if file_contains 'CWD Convention' "$ORCH_MD"; then
-  echo "  PASS: orchestrator.md documents CWD Convention"
-  TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-  echo "  FAIL: orchestrator.md should document CWD Convention"
-  TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
-
-# ── Test 10: orchestrator.md recommends git -C ──
-if file_contains 'git -C' "$ORCH_MD"; then
-  echo "  PASS: orchestrator.md recommends git -C"
-  TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-  echo "  FAIL: orchestrator.md should recommend git -C"
-  TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
-
-# ── Test 11: _strip_worktree_path correctly handles the exact reproduction case ──
+# ── Test 9: _strip_worktree_path correctly handles the exact reproduction case ──
+# (agents/orchestrator.md content checks were removed: non-executable files
+# must not have content-based tests — see CLAUDE.md "What to Test")
 source "${CEKERNEL_DIR}/scripts/shared/resolve-repo-root.sh"
 RESULT=$(_strip_worktree_path "/path/to/repo/.worktrees/issue/439-xxx")
 assert_eq "reproduction case: spawn from drifted CWD" "/path/to/repo" "$RESULT"


### PR DESCRIPTION
closes #588

## Summary

agent/skill 定義を「指示のみ」に縮退し、orchestrator.md の env export 儀式(50回)を全撤去した。撤去に先立ち、issue の指示通り env 継承を実測した。

### 実測結果(撤去の根拠)

- **Worker/Orchestrator セッションの env 継承を実測確認**: 稼働中の Orchestrator セッションプロセス(`ps eww`)と本 Worker 自身の全 Bash 呼び出しに `CEKERNEL_SESSION_ID` / `CEKERNEL_ENV` / `CEKERNEL_IPC_DIR` / scripts PATH が継承されていることを確認(2026-07-07, v2.1.202)
- **継承経路の特定**: `claude --bg` セッションは **daemon のプロセス環境**を継承する(セッション env の PATH が daemon とバイト一致、caller subshell で source した `.cekernel-env` の PATH 前置は不在)。run の最初の spawn(`spawn-orchestrator.sh`)が daemon をその run の env 付きで自動起動するため、実運用では全セッションに正しい値が届く
- **発見したハザード**: 前 run の残存 daemon は stale env を配る → **#589 として起票**。緩和として orchestrator.md に「prompt 値との startup check + 不一致時は literal export へフォールバック」を1箇所だけ記載(50回の export チェーンの代替)

### Before / After

| File | Before | After | 備考 |
|---|---|---|---|
| agents/orchestrator.md | 671 行 / `export CEKERNEL_SESSION_ID` ×50 | **225 行 / ×0**(アンチパターン例示の1回のみ) | `run_in_background` 記述 22→2(セマンティクス不変、再検証は #579) |
| agents/worker.md | 334 行 | **152 行** | |
| agents/reviewer.md | 206 行 | **108 行** | OS analogy 等の rationale を削除 |
| skills/orchestrate | 185 行 | **45 行** | 起動プロトコルを references へ抽出 |
| skills/dispatch | 191 行 | **57 行** | 同上 |
| skills/orchctl | 175 行 | **53 行** | |
| skills/postmortem | 217 行 | **119 行** | |
| skills/setup | 174 行 | **66 行** | |
| skills/unix-architect | 205 行 | **93 行** | ADR テンプレートを references へ抽出 |
| **合計(references 新規 +155 行含む)** | **2921 行** | **1636 行**(▲44%) | |

新規: `skills/references/orchestrator-launch.md`(orchestrate/dispatch の重複起動シーケンスを一元化)、`skills/references/adr-template.md`

### その他

- docs/claude-code-constraints.md: 「best-effort(未検証)」だった env 継承記述を実測済みの制約に更新、#589 ハザードを記載。spawn-orchestrator.sh / bg-session.sh のコメントを同期(コメントのみ、挙動変更なし)
- tests/orchestrator/test-spawn-cwd-drift.sh: orchestrator.md の content-based チェック(Test 9/10)を削除(CLAUDE.md「非実行ファイルに content テストを書かない」準拠)

### 受け入れ基準について

- 実測確認: 済(上記)
- self-hosted run の完走: 本 PR 自体が変更後の worker.md 相当のプロトコルで動く self-hosted run だが、**変更後の orchestrator.md での完走確認はマージ後の次の orchestrate run で確認される**(本 wave の後続 issue #579 / #573 が該当)

## Test Plan

- [x] `bash tests/orchestrator/test-spawn-cwd-drift.sh` — 9 passed
- [x] `bash -n` で編集スクリプト(コメントのみ変更)の構文確認
- [x] CI(全 suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)