### PR TITLE
feat: ADR-0018 実装 — claude CLI 契約層の確立(#591/#589 を契約内で修正)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ Assess whether changes follow these UNIX philosophy principles:
 
 ### Platform Constraints
 
+- **claude CLI ownership (ADR-0018)**: `scripts/shared/claude-bg.sh` is the sole
+  owner of the claude CLI surface (`claude --bg` invocation and spawn-line
+  parsing, `claude agents --json` parsing, `claude stop`). A direct claude CLI
+  parse or invocation outside `claude-bg.sh`, or a new implicit cross-boundary
+  assumption (ADR-0018 boundary ownership table), is grounds for
+  changes-requested. Consumers use the verdict predicates and keep their
+  degradation policy (what to do on `query-failed` / `unknown-value`) explicit
+  at the call site.
 - **zsh compatibility**: Scripts `source`d in Claude Code must use `${BASH_SOURCE[0]:-${(%):-%x}}` fallback.
 - **bash 3.2 compatibility**: No `declare -A` (associative arrays). Use temp files with `grep -qxF` instead.
 - **Arithmetic safety**: Use `var=$((var + 1))` instead of `((var++))` (fails under `set -e` when var=0).

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -197,7 +197,8 @@ Unverified (check before relying on them):
 
 ### Background Agent Sessions (`--bg` / on-demand daemon)
 
-**Confidence: Evolving** (research preview; observed on claude v2.1.201, 2026-07-06)
+**Confidence: Evolving** (research preview; observed on claude v2.1.201,
+2026-07-06; matrix re-verified on v2.1.202, 2026-07-07)
 
 `claude --bg` starts a session as a background agent and returns
 immediately; sessions are supervised by an on-demand daemon and managed
@@ -249,29 +250,67 @@ Verified 2026-07-07 (Phase 1 probe, #546, session `971e554a`):
   — cwd-based matching must normalize with `pwd -P` first.
 - `claude stop <short-id>` accepts the short ID as the stop token.
 
-Verified 2026-07-07 (#581, live-session field split; claude v2.1.x):
-- **Live and terminal sessions report their state in different fields.**
-  Live sessions carry `status: "busy"` plus `state: "working"` — or no
-  `state` field at all; terminal sessions carry `state: done|stopped`
-  and no `status`. Earlier builds reported live states directly in
-  `state` (`state: busy`). Observed distribution on a real roster:
-  `busy/working`, `busy/(absent)`, `(absent)/done`, `(absent)/stopped`.
-  `blocked` is expected to appear in `status` like `busy` (not yet
-  re-observed in the split shape).
-- Liveness consumers must read `(.status // .state)` — status preferred,
-  state fallback. The fallback keeps the pre-split shape resolving
-  unchanged. Reading `.state` alone evaluates every live session as
-  `working` and mis-reports it dead (#581: watch.sh crash-flagged all
-  spawned Workers and deleted their FIFOs).
+Verified 2026-07-07 (#581 field split, #591 terminal conflation, #593
+roster observation; claude v2.1.202):
+- **Live and terminal sessions report their state in different fields**:
+  liveness lives in `status`, terminality in `state`. Reading `.state`
+  alone evaluates every live session as `working` and mis-reports it
+  dead (#581: watch.sh crash-flagged all spawned Workers). Reading
+  `(.status // .state)` breaks the other direction: `done` sessions
+  carry `status: "idle"`, so the expression returns "idle" and terminal
+  detection never fires (#591).
+- **Observed (status, state) matrix** (ADR-0018 — this table is the
+  contract; it is mirrored in `scripts/shared/claude-bg.sh` and
+  `tests/helpers/mock-claude.bash`):
+
+  | `status` | `state` | Verdict |
+  |----------|---------|---------|
+  | `busy` | `working` | alive |
+  | `busy` | (absent) | alive |
+  | (absent) | `busy` | alive (pre-split legacy shape) |
+  | `blocked` | `working` | blocked (v2.1.201 shape) |
+  | `idle` | `blocked` | blocked (v2.1.202 shape) |
+  | (absent) | `blocked` | blocked (pre-split legacy shape) |
+  | `idle` | `done` | terminal (`done`) |
+  | (absent) | `done` | terminal (`done`; `--all`, daemon-restart rows) |
+  | `idle` | `stopped` | terminal (`stopped`) |
+  | (absent) | `stopped` | terminal (`stopped`; `--all`, daemon-restart rows) |
+  | — session absent — | | not-listed |
+  | any pair not above | | unknown-value |
+
+  Real roster tally (2026-07-07, v2.1.202): `busy/working`,
+  `busy/(absent)` (interactive), `idle/blocked`, `idle/done`,
+  `(absent)/done`, `(absent)/stopped`. Note `blocked` appeared in
+  `state` with `status: "idle"` — NOT in `status` as ADR-0018
+  originally predicted from v2.1.201.
+- **`agents --json` does not resurrect the daemon** (isolated-HOME
+  probe, v2.1.202, #593): with no daemon running, `claude agents
+  --json` (and `--all`) returns `[]` with exit 0, starts no `claude
+  daemon run` process, and writes no daemon.json. Predicates are
+  side-effect-free observers. Implication: a stopped daemon is
+  indistinguishable from an empty roster — it surfaces as `not-listed`,
+  NOT as `query-failed`.
+- **The daemon's inherited environment is unspecified** (#589, ADR-0018
+  Decision 3): the on-demand daemon keeps the env of whichever client
+  auto-started it, and sessions inherit the DAEMON's env, not their
+  spawner's (verified 2026-07-07, v2.1.202). No cekernel code may rely
+  on it. Session env is guaranteed by the spawner: Workers source the
+  worktree's `.cekernel-env` per Bash call (normative), Orchestrators
+  receive explicit exports from `spawn-orchestrator.sh` plus prompt-
+  embedded values.
 
 **Implications for cekernel**:
 - ADR-0016 delegates spawn/supervision to `--bg`; session IDs are captured
   (never injected); `blocked` must be surfaced by supervision; cleanup
   must `claude stop` lingering `done` sessions
-- All `agents --json` liveness reads go through `(.status // .state)`
-  (`shared/claude-bg.sh`, `shared/issue-lock.sh`);
-  `tests/helpers/mock-claude.bash` emits the split shape (STALENESS
-  COUPLING: update the mock in the same PR as this section)
+- `scripts/shared/claude-bg.sh` is the SOLE owner of this surface
+  (ADR-0018): all `--bg` invocation, spawn-line parsing, `agents --json`
+  parsing, and `claude stop` live there; consumers use its verdict
+  predicates and keep their own degradation policies. A direct parse
+  anywhere else is a review-blocking violation (CLAUDE.md § Review)
+- `tests/helpers/mock-claude.bash` emits the matrix shapes (STALENESS
+  COUPLING: update the mock and claude-bg.sh in the same PR as this
+  section)
 
 ### Subagent Information Propagation
 

--- a/envs/README.md
+++ b/envs/README.md
@@ -12,6 +12,7 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_MAX_ORCHESTRATORS` | `3` | Positive integer | `dispatch`, `orchestrate` | Maximum number of concurrently running orchestrators |
 | `CEKERNEL_MAX_ORCH_CHILDREN` | `5` | Positive integer | `spawn.sh` | Maximum concurrent children (workers + reviewers) per orchestrator |
 | `CEKERNEL_WORKER_TIMEOUT` | `3600` | Positive integer (seconds) | `watch.sh` | Worker timeout before auto-termination |
+| `CEKERNEL_WATCH_QUERY_RETRY_MAX` | `3` | Positive integer | `watch.sh` | Consecutive unverifiable liveness polls (`query-failed` / `unknown-value` verdicts, ADR-0018) tolerated before watch escalates an `error` result. The escalation detail warns the Worker may still be running — do not clean up on this result alone |
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Any filename | `checkpoint-file.sh` | Checkpoint file name in worktree |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Any filename | `task-file.sh` | Task file name in worktree |
 | `CEKERNEL_CI_MAX_RETRIES` | `3` | Positive integer | `worker.md` (Phase 3) | Maximum CI retry attempts before Worker reports failure |

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -295,11 +295,14 @@ cmd_ls() {
 }
 
 # ── ps: agents --json view layer (ADR-0016 Phase 4) ──
-# `claude agents --json` is fetched ONCE per invocation; every registered
-# token (orchestrator.claude-session-id, handle-{issue}.{type}) is
-# prefix-matched against that single body. States print as-is so `blocked`
-# (permission-dialog stall) is surfaced distinctly; an unlisted token shows
-# as `missing`. Worker/Reviewer rows join the cekernel-specific columns —
+# `claude agents --json` is fetched ONCE per invocation (the body is an
+# OPAQUE snapshot — only claude-bg.sh predicates parse it, ADR-0018);
+# every registered token (orchestrator.claude-session-id,
+# handle-{issue}.{type}) is resolved against that single snapshot. The
+# ADR-0018 verdict tokens print as-is so `blocked` (permission-dialog
+# stall) is surfaced distinctly; an absent token shows as `not-listed`,
+# schema drift as `unknown-value` — a view reports honestly, it does not
+# interpret. Worker/Reviewer rows join the cekernel-specific columns —
 # issue, phase (state-file detail), priority — per the ADR-0015 boundary:
 # the view adds only what `claude agents` cannot know. Sessions without an
 # orchestrator token (interactive orchestrators) still list their workers.
@@ -352,7 +355,7 @@ cmd_ps() {
         fi
 
         local state
-        state=$(claude_bg_state_from_json "$agents_json" "$token") || state="missing"
+        state=$(claude_bg_token_verdict_from_json "$agents_json" "$token") || true
 
         found=$((found + 1))
         echo "orchestrator  claude=${token}  session=${sid}  elapsed=${elapsed}  ${state}"
@@ -374,7 +377,7 @@ cmd_ps() {
       [[ -n "$mtoken" ]] || continue
 
       local mstate
-      mstate=$(claude_bg_state_from_json "$agents_json" "$mtoken") || mstate="missing"
+      mstate=$(claude_bg_token_verdict_from_json "$agents_json" "$mtoken") || true
 
       # Join cekernel-specific columns from state/priority files.
       # CEKERNEL_IPC_DIR is scoped to each command substitution (subshell)
@@ -502,17 +505,28 @@ cmd_recover() {
       ;;
   esac
 
-  # Check if Worker process is alive
+  # Check if Worker process is alive.
+  # Degradation policy (ADR-0018): recover writes TERMINATED/crashed — a
+  # destructive verdict — so query-failed / unknown-value must ERROR OUT
+  # instead of being coerced to dead (never declare a crash on doubt).
   local backend is_alive=0
   backend=$(detect_backend "$CEKERNEL_IPC_DIR" "$RESOLVED_ISSUE")
 
   if [[ "$backend" != "unknown" ]]; then
-    # Source backend adapter to get backend_worker_alive
+    # Source backend adapter to get backend_worker_status
     export CEKERNEL_BACKEND="$backend"
     source "${SCRIPT_DIR}/../shared/backend-adapter.sh"
-    if backend_worker_alive "$RESOLVED_ISSUE" 2>/dev/null; then
-      is_alive=1
-    fi
+    local wverdict
+    wverdict=$(backend_worker_status "$RESOLVED_ISSUE" 2>/dev/null) || true
+    case "$wverdict" in
+      alive|blocked) is_alive=1 ;;
+      query-failed|unknown-value)
+        echo "Error: cannot verify worker #${RESOLVED_ISSUE} (${wverdict})." \
+          "Refusing to mark it crashed — retry when the agents query recovers." >&2
+        return 1
+        ;;
+      *) ;;  # done | stopped | not-listed | missing — verifiably dead
+    esac
   fi
   # If backend is "unknown" (no handle, no metadata), worker is dead (is_alive stays 0)
 
@@ -582,7 +596,7 @@ cmd_kill() {
     [[ -f "$handle_file" ]] || continue
     local handle_content
     handle_content=$(tr -d '[:space:]' < "$handle_file")
-    claude stop "$handle_content" >/dev/null 2>&1 || true
+    claude_bg_stop "$handle_content"
   done
 
   # Terminal backends: also close the attach-only visualization pane/window
@@ -718,9 +732,11 @@ cmd_gc() {
       # tmux pane target (session:window.pane), a numeric wezterm pane ID,
       # or a headless PID.
       # Heuristic: numeric → kill -0; tmux target → has-session; anything
-      # else is a session token → alive iff busy/blocked in
-      # `claude agents --json` (single lazy fetch per gc run, #573); a
-      # failed query stays conservative (assume alive, never gc on doubt)
+      # else is a session token resolved via the ADR-0018 verdict against
+      # a single lazy `agents --json` fetch per gc run (#573).
+      # Degradation policy (ADR-0018 — gc refuses to reap on doubt):
+      # query-failed and unknown-value both count as ALIVE; only a
+      # verifiable done/stopped/not-listed verdict marks the handle dead.
       if [[ "$handle_content" =~ ^[0-9]+$ ]]; then
         if kill -0 "$handle_content" 2>/dev/null; then
           has_live_handle=1
@@ -739,10 +755,15 @@ cmd_gc() {
           has_live_handle=1
           break
         fi
-        if claude_bg_token_alive_from_json "$gc_agents_json" "$handle_content"; then
-          has_live_handle=1
-          break
-        fi
+        local gc_verdict
+        gc_verdict=$(claude_bg_token_verdict_from_json "$gc_agents_json" "$handle_content") || true
+        case "$gc_verdict" in
+          done|stopped|not-listed) ;;  # verifiably dead
+          *)
+            has_live_handle=1
+            break
+            ;;
+        esac
       fi
     done
 
@@ -905,11 +926,13 @@ cmd_gc() {
   }
 
   # ── 3. Clean stale orchestrator sessions (ADR-0016 Phase 2) ──
-  # Liveness is session-ID based: a session whose captured token is not
-  # busy/blocked in `claude agents --json` is dead. Dead sessions are
-  # reaped via `claude stop` (done sessions linger until explicitly
-  # stopped — ADR-0016) and their metadata files removed. Legacy
-  # orchestrator.pid files (pre-v2) are swept unconditionally.
+  # Liveness is session-ID based via the ADR-0018 verdict: only a
+  # verifiable done/stopped/not-listed verdict is dead — query-failed
+  # and unknown-value stay conservative (gc refuses to reap on doubt).
+  # Dead sessions are reaped via the stop primitive (done sessions
+  # linger until explicitly stopped — ADR-0016) and their metadata files
+  # removed. Legacy orchestrator.pid files (pre-v2) are swept
+  # unconditionally.
   if [[ -d "$IPC_BASE" ]]; then
     for session_dir in "$IPC_BASE"/*/; do
       [[ -d "$session_dir" ]] || continue
@@ -922,10 +945,16 @@ cmd_gc() {
         orch_token=$(tr -d '[:space:]' < "$orch_sid_file")
       fi
 
-      # Skip if the orchestrator session is still alive (busy/blocked).
-      # A legacy pid file without a token is always stale under v2.
-      if [[ -n "$orch_token" ]] && claude_bg_token_alive "$orch_token" 2>/dev/null; then
-        continue
+      # Skip unless the orchestrator session is verifiably dead
+      # (done/stopped/not-listed). A legacy pid file without a token is
+      # always stale under v2.
+      if [[ -n "$orch_token" ]]; then
+        local orch_verdict
+        orch_verdict=$(claude_bg_token_verdict "$orch_token" 2>/dev/null) || true
+        case "$orch_verdict" in
+          done|stopped|not-listed) ;;  # verifiably dead — reap below
+          *) continue ;;               # alive/blocked or cannot verify
+        esac
       fi
 
       # Orchestrator session is dead — reap it and clean up metadata
@@ -934,9 +963,7 @@ cmd_gc() {
           echo "[dry-run] would stop dead orchestrator session: $orch_token" >&2
         fi
       else
-        if [[ -n "$orch_token" ]]; then
-          claude stop "$orch_token" >/dev/null 2>&1 || true
-        fi
+        claude_bg_stop "$orch_token"
       fi
 
       for meta_file in "$orch_sid_file" "$orch_legacy_pid_file" \
@@ -995,11 +1022,13 @@ cmd_gc() {
 }
 
 # ── count: Count running orchestrators (internal, ADR-0014) ──
-# Session-ID based (ADR-0016 Phase 2): a session counts when its captured
-# token is alive (busy/blocked) per claude_bg_token_alive_from_json — the
-# liveness vocabulary lives in claude-bg.sh, not here (Rule of Separation).
-# Single fetch per invocation (Phase 4): all tokens resolve against one
-# `agents --json` response.
+# Session-ID based (ADR-0016 Phase 2): a session counts on an alive or
+# blocked verdict — the vocabulary lives in claude-bg.sh, not here (Rule
+# of Separation). Single fetch per invocation (Phase 4): all tokens
+# resolve against one opaque snapshot.
+# Degradation policy (ADR-0018 — the consumer decides): unknown-value
+# counts as alive. For a concurrency guard, over-counting refuses a spawn
+# (safe); under-counting spawns a duplicate orchestrator (not safe).
 cmd_count() {
   local count=0
 
@@ -1017,9 +1046,11 @@ cmd_count() {
       token=$(tr -d '[:space:]' < "$sid_file")
       [[ -n "$token" ]] || continue
 
-      if claude_bg_token_alive_from_json "$agents_json" "$token"; then
-        count=$((count + 1))
-      fi
+      local verdict
+      verdict=$(claude_bg_token_verdict_from_json "$agents_json" "$token") || true
+      case "$verdict" in
+        alive|blocked|unknown-value) count=$((count + 1)) ;;
+      esac
     done
   fi
 

--- a/scripts/ctl/spawn-orchestrator.sh
+++ b/scripts/ctl/spawn-orchestrator.sh
@@ -52,40 +52,35 @@ CEKERNEL_PROCESS_SCRIPTS="$(cd "${SCRIPT_DIR}/../process" && pwd)"
 CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
 
 # ── Launch Orchestrator as a background agent session ──
-# `claude --bg` returns immediately after printing `backgrounded ·
-# <short-id>`; the on-demand daemon supervises the session.
-# Unset Claude Code session markers to avoid nested-session detection.
-# Sessions inherit the DAEMON's env: these exports reach the session only
-# when this call auto-starts the daemon; a pre-existing daemon keeps its
-# own environment (verified 2026-07-07, v2.1.202 — #589). The reliable
-# channel for CEKERNEL_* values is the prompt, which the orchestrate/
-# dispatch skills populate; the Orchestrator verifies env at startup.
+# The --bg invocation and spawn-line parsing live in claude_bg_spawn
+# (ADR-0018 Decision 1); this spawner injects the session env explicitly
+# (ADR-0018 Decision 3, #589 — the daemon's inherited environment is
+# UNSPECIFIED: these exports reach the session only when this call
+# auto-starts the daemon; a pre-existing daemon keeps its own env. The
+# reliable channel for CEKERNEL_* values is the prompt, which the
+# orchestrate/dispatch skills populate; the Orchestrator verifies env at
+# startup).
 # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 stays for now: under --bg an
 # auto-detached Bash call no longer kills the process (#558), but whether
 # a background-task completion re-invokes a `done` session is unverified —
 # without re-invocation the Orchestrator would stall silently.
-# stderr discarded — analysis uses transcripts; stdout is parsed for the
-# short-ID token only (structured data comes from `agents --json`).
-SPAWN_OUT=$(
-  cd "$REPO_ROOT" && \
-  unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
+# stderr discarded — analysis uses transcripts.
+SHORT_ID=$(
   export CEKERNEL_SESSION_ID="${CEKERNEL_SESSION_ID}" && \
   export CEKERNEL_IPC_DIR="${CEKERNEL_IPC_DIR}" && \
   export CEKERNEL_ENV="${CEKERNEL_ENV}" && \
   export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 && \
   export PATH="${CEKERNEL_ORCHESTRATOR_SCRIPTS}:${CEKERNEL_PROCESS_SCRIPTS}:${CEKERNEL_SHARED_SCRIPTS}:${PATH}" && \
-  claude --bg "${CEKERNEL_BARE_FLAGS[@]}" --agent "$AGENT_NAME" "$PROMPT" 2>/dev/null
+  claude_bg_spawn "$REPO_ROOT" "${CEKERNEL_BARE_FLAGS[@]}" --agent "$AGENT_NAME" "$PROMPT" 2>/dev/null
 ) || {
   echo "Error: claude --bg spawn failed for Orchestrator" >&2
   exit 1
 }
 
 # ── Capture the daemon-assigned session ID (ADR-0016 normative order) ──
-# Primary: short ID from the human-oriented spawn line, prefix-matched
-# against agents --json. Fallback: newest background session at the
-# repo-root cwd (kind filter excludes interactive sessions — #571).
-SHORT_ID=$(printf '%s\n' "$SPAWN_OUT" | awk '/backgrounded/ {print $NF; exit}')
-[[ "$SHORT_ID" =~ ^[0-9a-f]{8}$ ]] || SHORT_ID=""
+# Primary: short ID from the spawn line, prefix-matched against the
+# roster. Fallback: newest background session at the repo-root cwd (kind
+# filter excludes interactive sessions — #571).
 
 # agents --json reports realpath'd cwd (e.g. /tmp → /private/tmp)
 CWD_REAL=$(cd "$REPO_ROOT" && pwd -P)

--- a/scripts/orchestrator/health-check.sh
+++ b/scripts/orchestrator/health-check.sh
@@ -55,29 +55,53 @@ check_worker() {
     return 0
   fi
 
-  # 1. Backend liveness check (handle file managed by backend)
-  if backend_available; then
+  # 1. Backend verdict check (handle file managed by backend, ADR-0018).
+  # Degradation policy: query-failed / unknown-value are INCONCLUSIVE —
+  # reported as "unknown" without counting the worker unhealthy (a
+  # zombie flag triggers recovery; never declare a crash on doubt).
+  local backend_conclusive=0
+  if backend_available && declare -F backend_worker_status >/dev/null 2>&1; then
+    local wstatus
+    wstatus=$(backend_worker_status "$issue" 2>/dev/null) || true
+    case "$wstatus" in
+      alive)
+        backend_conclusive=1
+        status="healthy"
+        detail="worker alive"
+        ;;
+      blocked)
+        # alive but stalled on a permission dialog — surfaced distinctly
+        # (ADR-0016 MUST)
+        backend_conclusive=1
+        status="blocked"
+        detail="session waiting on a permission dialog"
+        ;;
+      query-failed|unknown-value)
+        backend_conclusive=1
+        status="unknown"
+        detail="cannot verify session (${wstatus}) — inconclusive, not treated as zombie"
+        ;;
+      done|stopped|not-listed|missing)
+        backend_conclusive=1
+        status="zombie"
+        detail="worker dead (verdict: ${wstatus})"
+        ;;
+    esac
+  elif backend_available; then
+    # Backend without a status function: boolean liveness only
     if backend_worker_alive "$issue"; then
+      backend_conclusive=1
       status="healthy"
       detail="worker alive"
-      # blocked = alive but stalled on a permission dialog — surface it
-      # distinctly when the backend provides a status (ADR-0016)
-      if declare -F backend_worker_status >/dev/null 2>&1; then
-        local wstatus
-        wstatus=$(backend_worker_status "$issue" 2>/dev/null) || wstatus=""
-        if [[ "$wstatus" == "blocked" ]]; then
-          status="blocked"
-          detail="session waiting on a permission dialog"
-        fi
-      fi
     else
+      backend_conclusive=1
       status="zombie"
       detail="worker dead"
     fi
   fi
 
-  # 2. If backend check was inconclusive, fallback to process-based detection
-  if [[ "$status" == "unknown" ]]; then
+  # 2. If no backend was available, fallback to process-based detection
+  if [[ "$backend_conclusive" -eq 0 ]]; then
     local worktree=""
     worktree=$(git worktree list --porcelain 2>/dev/null \
       | grep "issue/${issue}-" \

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -296,8 +296,8 @@ backend_spawn_worker "$ISSUE_NUMBER" "$AGENT_TYPE" "$WORKTREE" "$PROMPT" "$AGENT
 # spawn.sh ($$) is short-lived and exits after launching the process.
 # Without this update, stale detection would always see a dead holder,
 # causing false stale-lock recovery and potential duplicate spawns.
-# All backends return an opaque session token verified via
-# `claude agents --json` (ADR-0005 Amendment 1, ADR-0016 Phase 5);
+# All backends return an opaque session token verified via the
+# claude-bg session verdict (ADR-0005 Amendment 1, ADR-0016 Phase 5, ADR-0018);
 # issue-lock also still handles numeric PIDs (kill -0).
 BACKEND_HANDLE=$(backend_get_handle "$ISSUE_NUMBER" "$AGENT_TYPE" 2>/dev/null) || true
 if [[ -n "$BACKEND_HANDLE" && "$BACKEND_HANDLE" != "null" ]]; then

--- a/scripts/orchestrator/watch.sh
+++ b/scripts/orchestrator/watch.sh
@@ -6,11 +6,14 @@
 # Environment:
 #   CEKERNEL_WORKER_TIMEOUT — Process timeout in seconds (default: 3600)
 #   CEKERNEL_POLL_INTERVAL  — State file poll interval in seconds (default: 30)
+#   CEKERNEL_WATCH_QUERY_RETRY_MAX — Consecutive unverifiable polls
+#     (query-failed / unknown-value) tolerated before escalating an
+#     "error" result (default: 3; ADR-0018 degradation policy)
 #
 # Monitors each process via triple-path detection:
 #   1. FIFO (primary, sub-second latency)
 #   2. State file polling (fallback, up to POLL_INTERVAL latency)
-#   3. Process crash detection (backend status / liveness check);
+#   3. Process crash detection (backend verdict, ADR-0018);
 #      blocked sessions (permission-dialog stall) are surfaced as a
 #      distinct "blocked" result (ADR-0016)
 # Outputs results to stdout as JSON Lines.
@@ -30,6 +33,7 @@ RESULT_DIR=$(mktemp -d)
 PIDS=()
 TIMEOUT="${CEKERNEL_WORKER_TIMEOUT:-3600}"
 POLL_INTERVAL="${CEKERNEL_POLL_INTERVAL:-30}"
+QUERY_RETRY_MAX="${CEKERNEL_WATCH_QUERY_RETRY_MAX:-3}"
 
 # ── Helper: build result JSON from state file (fallback path) ──
 build_result_from_state() {
@@ -54,6 +58,7 @@ watch_one() {
   local has_fifo=1
   local result=""
   local elapsed=0
+  local query_failures=0
 
   log_event "$issue" "FIFO_WATCH_START" "issue=#${issue} timeout=${TIMEOUT} poll_interval=${POLL_INTERVAL}"
 
@@ -101,10 +106,14 @@ watch_one() {
     fi
 
     # Crash/blocked detection: only when a handle file is present (without
-    # it, we can't verify the worker). When the backend provides a status
-    # (headless: `claude agents --json` state, ADR-0016), `blocked`
-    # (permission-dialog stall) MUST be surfaced as a distinct result —
-    # nobody approves a dialog in a headless session, so it is terminal.
+    # it, we can't verify the worker). The backend reports the ADR-0018
+    # verdict vocabulary; `blocked` (permission-dialog stall) MUST be
+    # surfaced as a distinct result — nobody approves a dialog in a
+    # headless session, so it is terminal.
+    # Degradation policy (ADR-0018 — the consumer decides): query-failed
+    # and unknown-value are retried, then ESCALATED after
+    # QUERY_RETRY_MAX consecutive unverifiable polls — never coerced
+    # into a crash (#573, #581).
     local has_handle=0
     for _hf in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
       [[ -f "$_hf" ]] && has_handle=1 && break
@@ -113,23 +122,41 @@ watch_one() {
       local worker_dead=0 worker_detail="Worker process died without completing"
       if declare -F backend_worker_status >/dev/null 2>&1; then
         local wstatus
-        wstatus=$(backend_worker_status "$issue" 2>/dev/null || true)
+        wstatus=$(backend_worker_status "$issue" 2>/dev/null) || true
         [[ -n "$wstatus" ]] || wstatus="missing"
-        if [[ "$wstatus" == "unknown" ]]; then
-          # Transient agents-query failure (daemon restarting) — not
-          # evidence of a crash; keep polling (#573).
-          :
-        elif [[ "$wstatus" == "blocked" ]]; then
-          result="{\"issue\":${issue},\"result\":\"blocked\",\"detail\":\"Worker session is waiting on a permission dialog\"}"
-          echo "Error: issue #${issue} Worker session is blocked (permission dialog)." >&2
-          log_event "$issue" "WORKER_BLOCKED" "issue=#${issue} state=${state}"
-          [[ $has_fifo -eq 1 ]] && exec 3>&-
-          rm -f "$fifo"
-          break
-        elif [[ "$wstatus" != "busy" ]]; then
-          worker_dead=1
-          worker_detail="Worker session ended without completing (session state: ${wstatus})"
-        fi
+        case "$wstatus" in
+          alive)
+            query_failures=0
+            ;;
+          blocked)
+            query_failures=0
+            result="{\"issue\":${issue},\"result\":\"blocked\",\"detail\":\"Worker session is waiting on a permission dialog\"}"
+            echo "Error: issue #${issue} Worker session is blocked (permission dialog)." >&2
+            log_event "$issue" "WORKER_BLOCKED" "issue=#${issue} state=${state}"
+            [[ $has_fifo -eq 1 ]] && exec 3>&-
+            rm -f "$fifo"
+            break
+            ;;
+          query-failed|unknown-value)
+            # Unverifiable — retry, escalate when persistent.
+            query_failures=$((query_failures + 1))
+            if [[ "$query_failures" -ge "$QUERY_RETRY_MAX" ]]; then
+              result="{\"issue\":${issue},\"result\":\"error\",\"detail\":\"agents query unverifiable (${wstatus}) for ${query_failures} consecutive polls — worker may still be running, do not clean up on this result alone\"}"
+              echo "Error: issue #${issue} agents query unverifiable (${wstatus}) ${query_failures} times — escalating." >&2
+              log_event "$issue" "WATCH_QUERY_ESCALATED" "issue=#${issue} report=${wstatus} failures=${query_failures}"
+              [[ $has_fifo -eq 1 ]] && exec 3>&-
+              rm -f "$fifo"
+              break
+            fi
+            log_event "$issue" "WATCH_QUERY_RETRY" "issue=#${issue} report=${wstatus} failures=${query_failures}"
+            ;;
+          *)
+            # done | stopped | not-listed | missing — verifiably ended
+            query_failures=0
+            worker_dead=1
+            worker_detail="Worker session ended without completing (verdict: ${wstatus})"
+            ;;
+        esac
       elif ! backend_worker_alive "$issue" 2>/dev/null; then
         worker_dead=1
       fi

--- a/scripts/scheduler/registry.sh
+++ b/scripts/scheduler/registry.sh
@@ -12,8 +12,8 @@
 #
 # Field semantics (ADR-0016 Phase 3):
 #   last_run_status — "success" | "error", recorded by the generated runner
-#     from the final `claude agents --json` state of the spawned background
-#     session: done → success; blocked/stopped/poll-timeout/spawn-failure →
+#     from the final session verdict (claude-bg.sh, ADR-0018) of the spawned
+#     background session: done → success; blocked/stopped/poll-timeout/spawn-failure →
 #     error. Fidelity note: "success" means the SESSION reached `done`
 #     (terminated) — NOT that the job inside it succeeded. Job-level
 #     outcomes stay in transcripts and desktop notifications.

--- a/scripts/scheduler/wrapper.sh
+++ b/scripts/scheduler/wrapper.sh
@@ -8,7 +8,8 @@
 #
 # ADR-0016 Phase 3: the generated runner spawns `claude --bg` (prompt path —
 # the hidden/unstable `--exec` flag is NOT used) and supervises the run by
-# polling `agents --json` to a terminal state. `--bg` returns immediately,
+# polling the session verdict (claude-bg.sh, ADR-0018) to a terminal
+# state. `--bg` returns immediately,
 # so exit-code-based success/error recording is impossible; instead:
 #
 #   done                         → registry status "success"

--- a/scripts/scheduler/wrapper.sh
+++ b/scripts/scheduler/wrapper.sh
@@ -86,24 +86,21 @@ source "\${CEKERNEL_DIR}/scripts/shared/claude-bg.sh"
 echo "\$(date '+%Y-%m-%dT%H:%M:%S%z') cekernel[\$ID]: START prompt=\"${prompt}\" repo=\"${repo}\"" >> "\$SYSLOG_FILE"
 SECONDS=0
 
-# Spawn as a \`claude --bg\` background agent session (ADR-0016 Phase 3).
+# Spawn as a \`claude --bg\` background agent session (ADR-0016 Phase 3)
+# via claude_bg_spawn — the --bg invocation, nested-session marker
+# unsetting, and spawn-line parsing live in claude-bg.sh (ADR-0018).
 # --bg returns immediately; the outcome is supervised by polling below.
-# Session markers are unset in case the runner is invoked manually from
-# inside a Claude Code session (nested-session detection).
 STATUS=error
 FINAL_STATE=spawn-failed
 TOKEN=""
-if cd "${repo}" && SPAWN_OUT=\$(
-  unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN
-  claude --bg ${bare_flags} "${prompt}" 2>> "\$RUN_LOG"
+if cd "${repo}" && SHORT_ID=\$(
+  claude_bg_spawn "${repo}" ${bare_flags} "${prompt}" 2>> "\$RUN_LOG"
 ); then
-  printf '%s\n' "\$SPAWN_OUT" >> "\$RUN_LOG"
+  echo "spawned short-id=\${SHORT_ID:-none}" >> "\$RUN_LOG"
 
   # Session-ID capture (ADR-0016 normative order): short ID from the
-  # human-oriented spawn line first, then kind+cwd+startedAt fallback
-  # (agents --json reports realpath'd cwd).
-  SHORT_ID=\$(printf '%s\n' "\$SPAWN_OUT" | awk '/backgrounded/ {print \$NF; exit}')
-  [[ "\$SHORT_ID" =~ ^[0-9a-f]{8}\$ ]] || SHORT_ID=""
+  # spawn line first, then kind+cwd+startedAt fallback (the roster
+  # reports realpath'd cwd).
   if TOKEN=\$(claude_bg_capture_session_id "\$SHORT_ID" "\$(pwd -P)"); then
     FINAL_STATE=\$(claude_bg_wait_terminal "\$TOKEN" "\$POLL_INTERVAL" "\$POLL_TIMEOUT")
     # done = the SESSION terminated, not that the job inside it succeeded
@@ -113,7 +110,7 @@ if cd "${repo}" && SPAWN_OUT=\$(
     # unblocks unattended. On timeout the session may still be doing
     # real work — record error but leave it running.
     if [[ "\$FINAL_STATE" != "timeout" ]]; then
-      claude stop "\$TOKEN" >/dev/null 2>&1 || true
+      claude_bg_stop "\$TOKEN"
     fi
   else
     FINAL_STATE=capture-failed

--- a/scripts/shared/backend-adapter.sh
+++ b/scripts/shared/backend-adapter.sh
@@ -15,10 +15,12 @@
 #   backend_spawn_worker    — Start a Worker process (issue, type, worktree, prompt, agent-name)
 #   backend_get_handle      — Get the opaque worker token (issue): the
 #                             `claude --bg` session token on all backends
-#   backend_worker_alive    — Check if Worker is alive (issue): maps to
-#                             `claude agents --json` state (busy|blocked)
-#   backend_worker_status   — Echo the session state (busy|blocked|done|...)
-#   backend_kill_worker     — Terminate a Worker (issue): claude stop +
+#   backend_worker_alive    — Check if Worker is alive (issue): exit 0 on
+#                             an alive/blocked verdict (ADR-0018)
+#   backend_worker_status   — Echo the ADR-0018 verdict vocabulary
+#                             (alive|blocked|done|stopped|not-listed|
+#                             query-failed|unknown-value|missing)
+#   backend_kill_worker     — Terminate a Worker (issue): session stop +
 #                             visualization cleanup on terminal backends
 #
 # All backends spawn through the shared --bg session core (bg-session.sh).

--- a/scripts/shared/backends/tmux.sh
+++ b/scripts/shared/backends/tmux.sh
@@ -6,9 +6,10 @@
 # visualization layer: a 3-pane window whose main pane runs
 # `claude attach <session-id>` (ADR-0001 Amendment 1).
 #
-# Pane close = detach, NOT session termination: liveness maps to
-# `claude agents --json` state, never pane existence. Killing the worker
-# stops the session (claude stop) and closes the window.
+# Pane close = detach, NOT session termination: liveness maps to the
+# ADR-0018 session verdict, never pane existence. Killing the worker
+# stops the session (via the claude-bg stop primitive) and closes the
+# window.
 #
 # Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains the
 # opaque session token (see bg-session.sh).
@@ -94,7 +95,7 @@ backend_worker_alive() {
 }
 
 # backend_kill_worker <issue> [type]
-# Stops the session(s) via `claude stop`, closes the visualization
+# Stops the session(s) via the claude-bg stop primitive, closes the visualization
 # window(s), and cleans up pane files. No error if handle missing.
 backend_kill_worker() {
   local issue="$1"

--- a/scripts/shared/backends/wezterm.sh
+++ b/scripts/shared/backends/wezterm.sh
@@ -6,9 +6,10 @@
 # visualization layer: a 3-pane window whose main pane runs
 # `claude attach <session-id>` (ADR-0001 Amendment 1).
 #
-# Pane close = detach, NOT session termination: liveness maps to
-# `claude agents --json` state, never pane existence. Killing the worker
-# stops the session (claude stop) and closes the window.
+# Pane close = detach, NOT session termination: liveness maps to the
+# ADR-0018 session verdict, never pane existence. Killing the worker
+# stops the session (via the claude-bg stop primitive) and closes the
+# window.
 #
 # Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains the
 # opaque session token (see bg-session.sh).
@@ -101,7 +102,7 @@ backend_worker_alive() {
 }
 
 # backend_kill_worker <issue> [type]
-# Stops the session(s) via `claude stop`, closes the visualization
+# Stops the session(s) via the claude-bg stop primitive, closes the visualization
 # window(s), and cleans up pane/payload files. No error if handle missing.
 backend_kill_worker() {
   local issue="$1"

--- a/scripts/shared/bg-session.sh
+++ b/scripts/shared/bg-session.sh
@@ -5,12 +5,16 @@
 #
 # The single spawn/supervision path for all backends. Worker sessions are
 # spawned as `claude --bg` background agents supervised by the on-demand
-# daemon; cekernel keeps only an opaque session token as the handle:
+# daemon; cekernel keeps only an opaque session token as the handle.
 #
-#   spawn       → claude --bg --agent <name> (returns immediately)
-#   liveness    → claude agents --json state (busy|blocked = alive)
-#   status      → claude agents --json state (blocked surfaced distinctly)
-#   termination → claude stop <token> (also reaps lingering done sessions)
+# Layer position (ADR-0018): this is the lifecycle core ABOVE the CLI
+# surface — it consumes claude-bg.sh predicates only and never parses
+# `agents --json` output or invokes the claude CLI itself:
+#
+#   spawn       → claude_bg_spawn + claude_bg_capture_session_id
+#   liveness    → claude_bg_token_verdict (alive|blocked = alive)
+#   status      → claude_bg_token_verdict (verdict vocabulary passthrough)
+#   termination → claude_bg_stop (also reaps lingering done sessions)
 #
 # Terminal backends (wezterm/tmux) layer an attach-only visualization pane
 # on top of this core (ADR-0001 Amendment 1); headless uses it as-is.
@@ -18,11 +22,7 @@
 # Handle file: ${CEKERNEL_IPC_DIR}/handle-{issue}.{type} contains an opaque
 # session token — the full session UUID when capture succeeds, or the short
 # ID (first 8 hex chars) as a degraded fallback. All lookups prefix-match
-# the token against `agents --json` sessionId, so both forms work.
-#
-# Session-ID capture follows the ADR-0016 normative order implemented in
-# claude-bg.sh (claude_bg_capture_session_id): short-ID prefix match first,
-# then kind == "background" + cwd + newest startedAt as fallback.
+# the token against the session roster, so both forms work.
 #
 # The captured token is also persisted to
 # ${CEKERNEL_IPC_DIR}/{type}-{issue}.claude-session-id for post-mortem
@@ -35,17 +35,21 @@
 #   bg_session_get_handle <issue> [type]
 #     Echoes the opaque session token from the handle file.
 #   bg_session_status <issue> [type]
-#     Echoes the agents --json state (busy|blocked|done|...); "missing"
-#     with exit 1 when the handle or session is verifiably absent;
-#     "unknown" with exit 1 when the agents query fails (transient).
+#     Echoes the ADR-0018 verdict vocabulary with matching exit codes:
+#     alive|blocked|done|stopped (exit 0), not-listed (exit 3),
+#     query-failed (exit 4 — transient, callers must NOT treat it as a
+#     crash, #573), unknown-value (exit 5); plus "missing" (exit 1) when
+#     no handle file exists for the issue.
 #   bg_session_alive <issue> [type]
-#     exit 0 iff a session for the issue is busy or blocked.
+#     exit 0 iff a session for the issue is alive or blocked. Boolean
+#     projection — callers that need a degradation policy for
+#     query-failed / unknown-value must use bg_session_status instead.
 #   bg_session_stop <issue> [type]
-#     Stops the session(s) via `claude stop`. Never fails.
+#     Stops the session(s) via the claude-bg stop primitive. Never fails.
 
 # ── Dependencies ──
-# Session query / token state / capture primitives live in shared/claude-bg.sh
-# (ADR-0016 Phase 2 extraction) — shared with ctl/spawn-orchestrator.sh and
+# The claude CLI surface (spawn/query/stop) is owned by shared/claude-bg.sh
+# (ADR-0018 Decision 1) — shared with ctl/spawn-orchestrator.sh and
 # ctl/orchctl.sh. This file layers the Worker handle-file lifecycle on top.
 _BG_SESSION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
 source "${_BG_SESSION_DIR}/bare-mode.sh"
@@ -69,32 +73,25 @@ bg_session_spawn() {
   # paths branch instead of hard-failing — only cron/at keeps preflight.
   bare_mode_prepare "$worktree"
 
-  # Launch the session. `claude --bg` returns immediately after printing
-  # `backgrounded · <short-id>`; the on-demand daemon supervises it.
-  # Source .cekernel-env so the daemon (when auto-started here) inherits
-  # PATH and cekernel env vars. Sessions inherit the DAEMON's env, not
-  # this subshell's (verified 2026-07-07, v2.1.202) — a pre-existing
-  # daemon serves its own (possibly stale) env (#589); Workers fall back
-  # to sourcing .cekernel-env per Bash call when commands are missing.
-  # Unset Claude Code session markers to avoid nested-session detection.
+  # Session env is guaranteed by the SPAWNER, not the daemon (ADR-0018
+  # Decision 3, #589): source .cekernel-env in the spawn subshell so a
+  # daemon auto-started by this call inherits PATH and CEKERNEL_* values.
+  # A PRE-EXISTING daemon serves its own (possibly stale) env — its
+  # inherited environment is declared unspecified — so Workers also
+  # source .cekernel-env per Bash call (the normative mechanism).
   # `--bg --bare` with a prompt composes without warnings (verified
-  # v2.1.201, 2026-07-07 — unlike the hidden --exec path).
-  local spawn_out
-  spawn_out=$(
+  # v2.1.201, 2026-07-07 — unlike the hidden --exec path). stderr is
+  # discarded — analysis uses transcripts.
+  local short_id
+  short_id=$(
     cd "$worktree" && \
-    unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
     source .cekernel-env && \
-    claude --bg "${CEKERNEL_BARE_FLAGS[@]}" --agent "$agent_name" "$prompt" 2>/dev/null
+    claude_bg_spawn "$worktree" "${CEKERNEL_BARE_FLAGS[@]}" \
+      --agent "$agent_name" "$prompt" 2>/dev/null
   ) || {
     echo "Error: claude --bg spawn failed for issue #${issue}" >&2
     return 1
   }
-
-  # Primary capture: short ID from the human-oriented spawn line. Parsed
-  # solely to extract the token — structured data comes from agents --json.
-  local short_id
-  short_id=$(printf '%s\n' "$spawn_out" | awk '/backgrounded/ {print $NF; exit}')
-  [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || short_id=""
 
   # agents --json reports realpath'd cwd (e.g. /tmp → /private/tmp)
   local cwd_real
@@ -144,13 +141,12 @@ bg_session_get_handle() {
 }
 
 # bg_session_status <issue> [type]
-# Echoes the session state from `claude agents --json` (busy|blocked|done|
-# stopped|...). blocked means the session is waiting on a permission dialog
-# — supervision MUST surface it distinctly (ADR-0016).
-# Echoes "missing" and returns 1 when no handle exists or the session is
-# verifiably not listed. Echoes "unknown" and returns 1 when the agents
-# query itself fails (daemon restarting) — a transient condition callers
-# must NOT treat as a crash (#573).
+# Echoes the ADR-0018 verdict for the session (see header). "missing"
+# (exit 1) means no handle file exists — distinct from not-listed, where a
+# handle exists but no session matches it. blocked means the session is
+# waiting on a permission dialog — supervision MUST surface it distinctly
+# (ADR-0016). query-failed (exit 4) is transient (daemon restarting) —
+# callers must NOT treat it as a crash (#573).
 bg_session_status() {
   local issue="$1"
   local type="${2:-}"
@@ -161,30 +157,23 @@ bg_session_status() {
     return 1
   fi
 
-  local json
-  if ! json=$(claude_bg_agents_json); then
-    echo "unknown"
-    return 1
-  fi
-  local state
-  if ! state=$(claude_bg_state_from_json "$json" "$token"); then
-    echo "missing"
-    return 1
-  fi
-  echo "$state"
+  claude_bg_token_verdict "$token"
 }
 
 # bg_session_alive <issue> [type]
-# exit 0 if the session is alive (busy or blocked), exit 1 otherwise.
-# If type is omitted, checks any handle-{issue}.* file.
+# exit 0 if the session is alive (alive or blocked verdict), exit 1
+# otherwise. If type is omitted, checks any handle-{issue}.* file.
+# Boolean projection: non-verdict reports (query-failed, unknown-value)
+# count as not-confirmably-alive here — callers needing a degradation
+# policy must branch on bg_session_status.
 bg_session_alive() {
   local issue="$1"
   local type="${2:-}"
 
   if [[ -n "$type" ]]; then
-    local state
-    state=$(bg_session_status "$issue" "$type" 2>/dev/null) || return 1
-    [[ "$state" == "busy" || "$state" == "blocked" ]]
+    local verdict
+    verdict=$(bg_session_status "$issue" "$type" 2>/dev/null) || return 1
+    [[ "$verdict" == "alive" || "$verdict" == "blocked" ]]
   else
     local handle_file
     for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
@@ -200,27 +189,23 @@ bg_session_alive() {
 }
 
 # bg_session_stop <issue> [type]
-# Stops the session via `claude stop`. Sessions linger in `done` state
-# until explicitly stopped (ADR-0016), so cleanup paths rely on this to
-# reap them. No error if handle missing or session already gone.
+# Stops the session via the claude-bg stop primitive. Sessions linger in a
+# done state until explicitly stopped (ADR-0016), so cleanup paths rely on
+# this to reap them. No error if handle missing or session already gone.
 # If type is omitted, stops all handle-{issue}.* handles.
 bg_session_stop() {
   local issue="$1"
   local type="${2:-}"
 
+  local handle_file
   if [[ -n "$type" ]]; then
-    local handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
+    handle_file="${CEKERNEL_IPC_DIR}/handle-${issue}.${type}"
     [[ -f "$handle_file" ]] || return 0
-    local token
-    token=$(cat "$handle_file")
-    [[ -n "$token" ]] && claude stop "$token" >/dev/null 2>&1 || true
+    claude_bg_stop "$(cat "$handle_file")"
   else
-    local handle_file
     for handle_file in "${CEKERNEL_IPC_DIR}"/handle-"${issue}".*; do
       [[ -f "$handle_file" ]] || continue
-      local token
-      token=$(cat "$handle_file")
-      [[ -n "$token" ]] && claude stop "$token" >/dev/null 2>&1 || true
+      claude_bg_stop "$(cat "$handle_file")"
     done
   fi
   return 0

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -1,14 +1,59 @@
 #!/usr/bin/env bash
-# claude-bg.sh — Shared helpers for `claude --bg` background agent sessions
+# claude-bg.sh — Sole owner of the claude CLI surface (ADR-0018 Decision 1)
 #
 # ADR-0016: cekernel delegates process spawn and supervision to `claude --bg`
-# and the on-demand daemon. These helpers implement the pieces every --bg
-# consumer needs: querying `claude agents --json`, resolving an opaque
-# session token to its state, and the normative session-ID capture order.
+# and the on-demand daemon. ADR-0018: ALL invocation and parsing of the
+# claude CLI surface — `claude --bg` spawn output, `claude agents --json`,
+# `claude stop` — lives in this module. Raw platform JSON never crosses the
+# module boundary: consumers hold `claude_bg_agents_json` output only as an
+# OPAQUE snapshot to pass back into the `*_from_json` predicates (single
+# fetch, many joins — ADR-0016 Phase 4); parsing it anywhere else is a
+# review-blocking violation (CLAUDE.md § Review).
 #
-# Consumers: backends/headless.sh (Worker spawn/liveness),
-# ctl/spawn-orchestrator.sh (Orchestrator spawn), ctl/orchctl.sh
-# (count/ps/gc orchestrator liveness).
+# Layer hierarchy (ADR-0018):
+#   claude-bg.sh   — CLI surface: the ONLY parser of platform output
+#   bg-session.sh  — lifecycle core, predicates only
+#   backends / watch / orchctl / wrapper / issue-lock — verdict consumers
+#
+# ── Observed (status, state) matrix — v2.1.202, 2026-07-07 (ADR-0018) ──
+#
+#   | `status`  | `state`   | Verdict            |
+#   |-----------|-----------|--------------------|
+#   | busy      | working   | alive              |
+#   | busy      | (absent)  | alive              |
+#   | (absent)  | busy      | alive   (pre-split legacy shape)      |
+#   | blocked   | working   | blocked (v2.1.201 shape)              |
+#   | idle      | blocked   | blocked (v2.1.202 shape)              |
+#   | (absent)  | blocked   | blocked (pre-split legacy shape)      |
+#   | idle      | done      | done               |
+#   | (absent)  | done      | done    (--all, daemon-restart rows)  |
+#   | idle      | stopped   | stopped            |
+#   | (absent)  | stopped   | stopped (--all, daemon-restart rows)  |
+#   | — session absent —    | not-listed         |
+#   | anything else         | unknown-value      |
+#
+# Liveness lives in `status`, terminality in `state` (#591: reading
+# `.status // .state` returned "idle" for done sessions and broke terminal
+# detection; #581: reading `.state` alone returned "working" for live
+# sessions and killed healthy Workers). This table is the contract — it is
+# mirrored in docs/claude-code-constraints.md § Background Agent Sessions
+# and tests/helpers/mock-claude.bash (STALENESS COUPLING: update all three
+# in the same PR).
+#
+# ── Report contract (ADR-0018) ──
+# Verdict functions echo a token and exit with a matching code. The three
+# non-verdict reports are NEVER coerced into alive/dead — degradation
+# policy belongs to each consumer (Rule of Separation):
+#
+#   exit 0 — verdict: alive | blocked | done | stopped
+#   exit 3 — not-listed    (no session matches the token; also the shape
+#                           of a NOT-RUNNING daemon: `agents --json`
+#                           returns [] exit 0 without starting one —
+#                           verified v2.1.202, isolated-HOME probe, #593)
+#   exit 4 — query-failed  (CLI error / daemon unreachable / malformed body)
+#   exit 5 — unknown-value ((status, state) pair not in the matrix; a
+#                           stderr warning makes the drift visible —
+#                           Rule of Repair)
 #
 # Usage: source claude-bg.sh
 #
@@ -18,47 +63,53 @@
 #       (e.g. --all to include finished sessions — the daemon exits after
 #       its sessions complete, and only --all keeps a finished session
 #       visible across a daemon restart). Fails when the claude CLI is
-#       unavailable or errors (Rule of Repair: callers decide how to
-#       surface it).
+#       unavailable or errors. The returned body is an OPAQUE snapshot:
+#       consumers may only pass it to the *_from_json predicates below.
 #
-#   claude_bg_state_from_json <json> <token>
-#     — Echo the state of the session whose sessionId starts with <token>,
-#       resolved against a pre-fetched `agents --json` body. Lets view
-#       layers (orchctl ps/count) fetch once and join many tokens
-#       (ADR-0016 Phase 4).
-#     — Returns 1 (echoing nothing) when no session matches.
+#   claude_bg_token_verdict_from_json <json> <token>
+#     — Resolve <token> (sessionId prefix) against a pre-fetched snapshot
+#       and echo the verdict per the report contract above.
 #
-#   claude_bg_state_for_token <token> [extra-args...]
-#     — Echo the logical state (busy|blocked|done|stopped|...) of the session
-#       whose sessionId starts with <token>. Live sessions report it in
-#       `status` (with `state: "working"` or no state); terminal sessions in
-#       `state` — the query reads `(.status // .state)` to serve both, plus
-#       the legacy pre-split shape (#581). Tokens are opaque: the full UUID
-#       when capture succeeded, or the short ID (first 8 hex chars) as a
-#       degraded fallback — prefix matching serves both. Extra args pass
-#       through to the agents query (e.g. --all).
-#     — Returns 1 (echoing nothing) when no session matches or the query fails.
+#   claude_bg_token_verdict <token> [extra-args...]
+#     — Fetching variant: queries `agents --json` itself (extra args pass
+#       through, e.g. --all), then delegates. Adds the query-failed report
+#       when the fetch fails.
 #
 #   claude_bg_token_alive_from_json <json> <token>
-#     — exit 0 when the session state is busy or blocked (alive), 1
-#       otherwise, resolved against a pre-fetched `agents --json` body.
-#       blocked means the session waits on a permission dialog — alive but
-#       stalled; supervision surfaces it distinctly (ADR-0016). This is the
-#       single home of the busy/blocked liveness vocabulary — view layers
-#       (orchctl count) delegate here instead of comparing states inline.
-#
 #   claude_bg_token_alive <token>
-#     — Fetching variant of claude_bg_token_alive_from_json: queries
-#       `agents --json` itself, then delegates.
+#     — Boolean projection of the verdict: exit 0 when alive or blocked
+#       (blocked = waiting on a permission dialog — alive but stalled,
+#       surfaced distinctly by supervision); exit 1 when VERIFIABLY not
+#       alive (done, stopped, not-listed). Non-verdict reports propagate
+#       unchanged (exit 4 / 5) — callers with a degradation policy must
+#       branch on them instead of `if`-coercing.
+#
+#   claude_bg_spawn <cwd> [claude-args...]
+#     — Invoke `claude --bg <claude-args...>` in <cwd> with the nested-
+#       session markers unset, and echo the short ID (first 8 hex chars)
+#       parsed from the human-oriented `backgrounded · <short-id>` line —
+#       or an empty string when the line is unparseable (degraded capture:
+#       follow up with claude_bg_capture_session_id). Exit 1 when the
+#       spawn itself fails. stdout of claude is consumed here; stderr
+#       passes through for the caller to route.
+#       Session env is guaranteed by the SPAWNER, not the daemon
+#       (ADR-0018 Decision 3, #589): export CEKERNEL_* / PATH before
+#       calling — the daemon's inherited environment is unspecified.
+#
+#   claude_bg_stop <token>
+#     — Stop the session via `claude stop`. Never fails; empty token is a
+#       no-op (reap semantics: done sessions linger until stopped).
 #
 #   claude_bg_wait_terminal <token> <interval> <timeout>
-#     — Poll `agents --json --all` until the session reaches a state that is
-#       terminal for UNATTENDED supervision (ADR-0016 Phase 3, cron/at):
-#       done, stopped, or blocked — blocked means a permission dialog that
-#       no one will ever approve, so waiting longer cannot help. Echoes the
-#       final state, or "timeout" when <timeout> seconds elapse first.
-#       A transiently missing session (daemon restart window) keeps polling.
-#       Always exits 0 — callers map the echoed state to their own outcome.
+#     — Poll `agents --json --all` until the verdict is terminal for
+#       UNATTENDED supervision (ADR-0016 Phase 3, cron/at): done, stopped,
+#       or blocked — blocked means a permission dialog that no one will
+#       ever approve, so waiting longer cannot help. Echoes the final
+#       verdict, or "timeout" when <timeout> seconds elapse first.
+#       not-listed and query-failed are transient here (daemon restart
+#       window) and keep polling; so does unknown-value (drift is not
+#       evidence of termination — its stderr warning still surfaces).
+#       Always exits 0 — callers map the echoed verdict to their outcome.
 #
 #   claude_bg_capture_session_id <short-id> <cwd>
 #     — Echo the full session UUID (ADR-0016 normative capture order):
@@ -75,41 +126,127 @@ claude_bg_agents_json() {
   claude agents --json "$@" 2>/dev/null
 }
 
-# claude_bg_state_from_json <json> <token>
-claude_bg_state_from_json() {
+# claude_bg_token_verdict_from_json <json> <token>
+claude_bg_token_verdict_from_json() {
   local json="$1"
   local token="$2"
-  local state
-  state=$(echo "$json" | jq -r --arg p "$token" \
-    '[.[] | select(.sessionId | startswith($p))][0] | (.status // .state) // empty')
-  [[ -n "$state" ]] || return 1
-  echo "$state"
+
+  # Resolve the record; a jq failure means the snapshot body itself is
+  # unusable (malformed platform output) — that is a query failure, not
+  # an absence observation.
+  local rec
+  if ! rec=$(printf '%s\n' "$json" | jq -c --arg p "$token" \
+    '[.[] | select(.sessionId | startswith($p))][0] // empty' 2>/dev/null); then
+    echo "query-failed"
+    return 4
+  fi
+  if [[ -z "$rec" ]]; then
+    echo "not-listed"
+    return 3
+  fi
+
+  local status state
+  status=$(printf '%s\n' "$rec" | jq -r '.status // "-"')
+  state=$(printf '%s\n' "$rec" | jq -r '.state // "-"')
+
+  # The observed (status, state) matrix — see the header table. Liveness
+  # lives in `status`, terminality in `state` (#581, #591).
+  case "${status}/${state}" in
+    busy/working|busy/-|-/busy)
+      echo "alive"
+      return 0
+      ;;
+    blocked/working|blocked/-|idle/blocked|-/blocked)
+      echo "blocked"
+      return 0
+      ;;
+    idle/done|-/done)
+      echo "done"
+      return 0
+      ;;
+    idle/stopped|-/stopped)
+      echo "stopped"
+      return 0
+      ;;
+    *)
+      # Schema drift: report it, loudly, without guessing (Rule of
+      # Repair — coercing an unknown status to "dead" is how #581
+      # killed healthy Workers).
+      echo "Warning: unknown (status, state) pair (${status}, ${state})" \
+        "for session token ${token} — claude CLI schema drift?" \
+        "(ADR-0018: update the matrix in claude-bg.sh," \
+        "claude-code-constraints.md, and mock-claude.bash together)" >&2
+      echo "unknown-value"
+      return 5
+      ;;
+  esac
 }
 
-# claude_bg_state_for_token <token> [extra-args...]
-claude_bg_state_for_token() {
+# claude_bg_token_verdict <token> [extra-args...]
+claude_bg_token_verdict() {
   local token="$1"
   shift
   local json
-  json=$(claude_bg_agents_json "$@") || return 1
-  claude_bg_state_from_json "$json" "$token"
+  if ! json=$(claude_bg_agents_json "$@"); then
+    echo "query-failed"
+    return 4
+  fi
+  claude_bg_token_verdict_from_json "$json" "$token"
 }
 
 # claude_bg_token_alive_from_json <json> <token>
 claude_bg_token_alive_from_json() {
-  local json="$1"
-  local token="$2"
-  local state
-  state=$(claude_bg_state_from_json "$json" "$token") || return 1
-  [[ "$state" == "busy" || "$state" == "blocked" ]]
+  local verdict rc=0
+  verdict=$(claude_bg_token_verdict_from_json "$1" "$2") || rc=$?
+  case "$rc" in
+    0) [[ "$verdict" == "alive" || "$verdict" == "blocked" ]] ;;
+    3) return 1 ;;      # not-listed — verifiably not alive
+    *) return "$rc" ;;  # query-failed / unknown-value — never coerced
+  esac
 }
 
 # claude_bg_token_alive <token>
 claude_bg_token_alive() {
-  local token="$1"
-  local json
-  json=$(claude_bg_agents_json) || return 1
-  claude_bg_token_alive_from_json "$json" "$token"
+  local verdict rc=0
+  verdict=$(claude_bg_token_verdict "$1") || rc=$?
+  case "$rc" in
+    0) [[ "$verdict" == "alive" || "$verdict" == "blocked" ]] ;;
+    3) return 1 ;;      # not-listed — verifiably not alive
+    *) return "$rc" ;;  # query-failed / unknown-value — never coerced
+  esac
+}
+
+# claude_bg_spawn <cwd> [claude-args...]
+claude_bg_spawn() {
+  local cwd="${1:?Usage: claude_bg_spawn <cwd> [claude-args...]}"
+  shift
+
+  # Launch the session. `claude --bg` returns immediately after printing
+  # `backgrounded · <short-id>`; the on-demand daemon supervises it.
+  # Claude Code session markers are unset to avoid nested-session
+  # detection. Env injection is the caller's responsibility (ADR-0018
+  # Decision 3): exported variables reach the daemon only when this call
+  # auto-starts it — a pre-existing daemon serves its own env (#589).
+  local spawn_out
+  spawn_out=$(
+    cd "$cwd" && \
+    unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ACCESS_TOKEN && \
+    claude --bg "$@"
+  ) || return 1
+
+  # Parse the human-oriented spawn line solely to extract the short-ID
+  # token — structured data comes from `agents --json` (capture below).
+  local short_id
+  short_id=$(printf '%s\n' "$spawn_out" | awk '/backgrounded/ {print $NF; exit}')
+  [[ "$short_id" =~ ^[0-9a-f]{8}$ ]] || short_id=""
+  echo "$short_id"
+}
+
+# claude_bg_stop <token>
+claude_bg_stop() {
+  local token="${1:-}"
+  [[ -n "$token" ]] || return 0
+  claude stop "$token" >/dev/null 2>&1 || true
 }
 
 # claude_bg_wait_terminal <token> <interval> <timeout>
@@ -121,14 +258,15 @@ claude_bg_wait_terminal() {
   # Wall-clock deadline via SECONDS: safe with interval=0 (no elapsed
   # arithmetic that would never advance).
   local deadline=$((SECONDS + timeout))
-  local state
+  local verdict
   while :; do
-    # --all keeps finished sessions visible across a daemon restart; a
-    # failed/empty query (daemon restarting) is transient — keep polling.
-    state=$(claude_bg_state_for_token "$token" --all) || state=""
-    case "$state" in
+    # --all keeps finished sessions visible across a daemon restart.
+    # not-listed / query-failed (daemon restart window) and unknown-value
+    # (drift ≠ termination) are transient here — keep polling.
+    verdict=$(claude_bg_token_verdict "$token" --all) || verdict=""
+    case "$verdict" in
       done|stopped|blocked)
-        echo "$state"
+        echo "$verdict"
         return 0
         ;;
     esac

--- a/scripts/shared/issue-lock.sh
+++ b/scripts/shared/issue-lock.sh
@@ -22,6 +22,7 @@ if [[ ! -f "${_ISSUE_LOCK_DIR}/load-env.sh" && -n "${CEKERNEL_SCRIPTS:-}" ]]; th
   _ISSUE_LOCK_DIR="${CEKERNEL_SCRIPTS}/shared"
 fi
 source "${_ISSUE_LOCK_DIR}/load-env.sh"
+source "${_ISSUE_LOCK_DIR}/claude-bg.sh"
 
 CEKERNEL_VAR_DIR="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"
 
@@ -37,19 +38,20 @@ issue_lock_repo_hash() {
 # _issue_lock_holder_alive <holder>
 # exit 0 when the lock holder is alive, exit 1 when it is verifiably dead.
 # Numeric holders are PIDs (kill -0). Non-numeric holders are opaque
-# session tokens (ADR-0005 Amendment 1): alive iff a session whose
-# sessionId starts with the token is busy or blocked in
-# `claude agents --json` — read via `(.status // .state)` since live
-# sessions report liveness in `status` (#581). When the query fails,
-# assume alive —
-# never steal a lock on doubt (duplicate Workers are worse than a
-# lock held until explicit release).
+# session tokens (ADR-0005 Amendment 1) resolved via the claude-bg.sh
+# verdict predicate (ADR-0018 — this module never parses agents --json).
+#
+# Degradation policy (ADR-0018 — the consumer decides): query-failed and
+# unknown-value both count as ALIVE. Never steal a lock on doubt —
+# duplicate Workers are worse than a lock held until explicit release,
+# and schema drift (unknown-value) is not evidence of death.
 _issue_lock_holder_alive() {
   local holder="$1"
 
   # Empty holder = corrupt/partial write (pid files are always written
   # with content). Guard it here: an empty token would fall into the
-  # session path below where startswith("") matches EVERY session (#573).
+  # session path below where a prefix match on "" matches EVERY session
+  # (#573).
   if [[ -z "$holder" ]]; then
     return 1
   fi
@@ -59,13 +61,12 @@ _issue_lock_holder_alive() {
     return $?
   fi
 
-  local json state
-  if ! json=$(claude agents --json 2>/dev/null); then
-    return 0
-  fi
-  state=$(echo "$json" | jq -r --arg p "$holder" \
-    '[.[] | select(.sessionId | startswith($p))][0] | (.status // .state) // empty' 2>/dev/null) || return 0
-  [[ "$state" == "busy" || "$state" == "blocked" ]]
+  local verdict
+  verdict=$(claude_bg_token_verdict "$holder" 2>/dev/null) || true
+  case "$verdict" in
+    alive|blocked|query-failed|unknown-value) return 0 ;;
+    *) return 1 ;;  # done | stopped | not-listed — verifiably dead
+  esac
 }
 
 issue_lock_acquire() {

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -431,6 +431,23 @@ worker_state() {
   assert_file_exists "token handle preserved" "${session_dir}/handle-575.worker"
 }
 
+@test "gc refuses to reap on an unknown (status, state) pair (ADR-0018)" {
+  # Degradation policy: schema drift is not evidence of death — gc must
+  # never reap on doubt.
+  mock_claude
+  local session_dir="${IPC_BASE}/session-gc-token4"
+  mkdir -p "$session_dir"
+  mkfifo "${session_dir}/worker-576"
+  echo "RUNNING:2026-02-28T10:00:00Z:working" > "${session_dir}/worker-576.state"
+  echo "$SESSION_TOKEN" > "${session_dir}/handle-576.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record_pair "$SESSION_TOKEN" background /tmp/wt 1700000000000 idle working)]"
+  run bash "$ORCHCTL" gc
+  assert_fifo_exists "FIFO preserved (unknown-value → assume alive)" \
+    "${session_dir}/worker-576"
+  assert_file_exists "token handle preserved" "${session_dir}/handle-576.worker"
+}
+
 # ── gc: --dry-run ──
 
 @test "gc --dry-run reports stale resources without removing them" {

--- a/tests/ctl/orchctl-read.bats
+++ b/tests/ctl/orchctl-read.bats
@@ -272,14 +272,14 @@ make_handle() {
   assert_eq "ps no session token" "no orchestrators." "$output"
 }
 
-@test "ps shows session, claude token, and busy state" {
+@test "ps shows session, claude token, and the alive verdict" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
   assert_match "shows session" "$SESSION_A" "$output"
   assert_match "shows claude token" "$ORCH_TOKEN_A" "$output"
-  assert_match "shows busy state" "busy" "$output"
+  assert_match "shows alive verdict" "alive" "$output"
 }
 
 @test "ps surfaces a blocked session distinctly (ADR-0016)" {
@@ -290,11 +290,11 @@ make_handle() {
   assert_match "shows blocked state" "blocked" "$output"
 }
 
-@test "ps shows missing when the session is not listed" {
+@test "ps shows not-listed when the session is absent (ADR-0018 vocabulary)" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   # queue empty → agents --json replies []
   run bash "$ORCHCTL" ps
-  assert_match "shows missing" "missing" "$output"
+  assert_match "shows not-listed" "not-listed" "$output"
 }
 
 @test "ps elapsed reads from orchestrator.spawned" {
@@ -365,7 +365,7 @@ make_handle() {
   assert_match "row shows claude token" "claude=${WORKER_TOKEN}" "$worker_line"
   assert_match "row joins phase from state file" "phase=phase1:implement" "$worker_line"
   assert_match "row joins priority from priority file" "priority=10" "$worker_line"
-  assert_match "row shows busy state" "busy" "$worker_line"
+  assert_match "row shows alive verdict" "alive" "$worker_line"
 }
 
 @test "ps surfaces a blocked worker session distinctly (ADR-0016 MUST)" {
@@ -380,14 +380,14 @@ make_handle() {
   assert_match "worker row shows blocked" "blocked" "$(echo "$output" | grep "#10")"
 }
 
-@test "ps shows missing for a worker token not listed in agents --json" {
+@test "ps shows not-listed for a worker token absent from the roster" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   make_worker "$IPC_A" 10
   make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "worker row shows missing" "missing" "$(echo "$output" | grep "#10")"
+  assert_match "worker row shows not-listed" "not-listed" "$(echo "$output" | grep "#10")"
 }
 
 @test "ps shows worker rows in a session without an orchestrator token" {
@@ -399,7 +399,7 @@ make_handle() {
     "[$(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy)]"
   run bash "$ORCHCTL" ps
   assert_match "worker row shown" "#10" "$output"
-  assert_match "worker row shows busy" "busy" "$(echo "$output" | grep "#10")"
+  assert_match "worker row shows alive" "alive" "$(echo "$output" | grep "#10")"
   if [[ "$output" == *"no orchestrators."* ]]; then
     echo "FAIL: worker rows found — must not print 'no orchestrators.'" >&2
     return 1
@@ -494,6 +494,17 @@ make_handle() {
   run bash "$ORCHCTL" count
   assert_eq "busy + blocked counted, stopped ignored" "2" "$output"
   assert_match "output is a plain integer" '^[0-9]+$' "$output"
+}
+
+@test "count counts an unknown-value session conservatively (ADR-0018)" {
+  # Degradation policy: for a concurrency guard, over-counting is safe
+  # (refuses a spawn) and under-counting is not (duplicate orchestrators)
+  # — schema drift counts as alive.
+  make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record_pair "$ORCH_TOKEN_A" background /repo 1700000000000 idle working)]"
+  run --separate-stderr bash "$ORCHCTL" count
+  assert_eq "unknown-value counted as alive" "1" "$output"
 }
 
 @test "count fetches agents --json exactly once per invocation (single-fetch view)" {

--- a/tests/helpers/mock-claude.bash
+++ b/tests/helpers/mock-claude.bash
@@ -1,17 +1,39 @@
 # mock-claude.bash — canonical `claude` CLI shim for v2 spawn-path tests
-# (ADR-0017 Decision 2, emulating the ADR-0016 delegated-spawn contract)
+# (ADR-0017 Decision 2, emulating the ADR-0016 delegated-spawn contract;
+# executable specification of the ADR-0018 platform interface contract)
 #
 # Contract source: docs/claude-code-constraints.md
 #   § Background Agent Sessions (`--bg` / on-demand daemon)
-# Observed claude version: v2.1.201 (2026-07-06; re-verified 2026-07-07,
-# #546 probe: `--bg --bare` + prompt composes; real `agents --json`
-# records carry extra fields — pid, id, name, status — and a numeric
-# epoch-millis startedAt, with a realpath'd cwd).
+# Observed claude version: v2.1.202 (2026-07-07, #593 roster observation;
+# earlier probes: v2.1.201 #546 — `--bg --bare` + prompt composes; real
+# `agents --json` records carry extra fields — pid, id, name — and a
+# numeric epoch-millis startedAt, with a realpath'd cwd).
 #
-# STALENESS COUPLING (ADR-0017 follow-up): any PR that updates the
-# "Background Agent Sessions" section of docs/claude-code-constraints.md
-# MUST update this mock in the same PR. This file is the single point of
-# update when the real `claude --bg` surface changes.
+# ── Observed (status, state) matrix — v2.1.202, 2026-07-07 (ADR-0018) ──
+#
+#   | `status`  | `state`   | Verdict            |
+#   |-----------|-----------|--------------------|
+#   | busy      | working   | alive              |
+#   | busy      | (absent)  | alive              |
+#   | (absent)  | busy      | alive   (pre-split legacy shape)      |
+#   | blocked   | working   | blocked (v2.1.201 shape)              |
+#   | idle      | blocked   | blocked (v2.1.202 shape)              |
+#   | (absent)  | blocked   | blocked (pre-split legacy shape)      |
+#   | idle      | done      | done               |
+#   | (absent)  | done      | done    (--all, daemon-restart rows)  |
+#   | idle      | stopped   | stopped            |
+#   | (absent)  | stopped   | stopped (--all, daemon-restart rows)  |
+#   | — session absent —    | not-listed         |
+#   | anything else         | unknown-value      |
+#
+# The same table lives in scripts/shared/claude-bg.sh (the sole parser)
+# and docs/claude-code-constraints.md § Background Agent Sessions.
+#
+# STALENESS COUPLING (ADR-0017 follow-up, ADR-0018 Decision 2): any PR
+# that updates the "Background Agent Sessions" section of
+# docs/claude-code-constraints.md MUST update this mock in the same PR.
+# This file is the single point of update when the real `claude --bg`
+# surface changes.
 #
 # Requires mock-bin.bash (PATH shim layer). Function overrides are banned
 # — see mock-bin.bash header.
@@ -48,15 +70,33 @@
 #     kind+cwd+startedAt fallback including the interactive-session
 #     mis-match regression at repo root.
 #     The <state> argument is the LOGICAL session state (busy|blocked|
-#     done|stopped|...). It is emitted in the observed field split
-#     (verified 2026-07-07, #581): live states (busy, blocked) become
-#     `"status":"<state>","state":"working"`; terminal states are
-#     emitted as `"state":"<state>"` with NO status field.
+#     done|stopped). It is emitted in the canonical v2.1.202 field pair
+#     from the matrix above: busy → status:"busy",state:"working";
+#     blocked → status:"idle",state:"blocked"; done → status:"idle",
+#     state:"done"; stopped → status:"idle",state:"stopped".
+#     Non-canonical / legacy / out-of-matrix pairs are emitted with
+#     mock_claude_agent_record_pair below.
 #     Real records carry ADDITIONAL fields (pid, id, name) and a
 #     realpath'd cwd (verified 2026-07-07) — consumers MUST NOT assume
 #     an exclusive field set.
 #     <startedAt> is emitted UNQUOTED to match the real numeric
 #     epoch-millis shape — pass numeric values (e.g. 1700000000000).
+#
+#   mock_claude_agent_record_pair <sessionId> <kind> <cwd> <startedAt> \
+#                                 <status|-> <state|->
+#     Prints one FULL agents record with an EXPLICIT (status, state)
+#     pair; "-" omits the field. Covers the non-canonical matrix rows
+#     (busy/-, -/done, blocked/working, pre-split legacy -/busy) and
+#     out-of-matrix pairs for unknown-value contract tests (ADR-0018).
+#
+#   mock_claude_fail_agents
+#     Makes every subsequent `claude agents --json` call fail (exit 1,
+#     no output) — the query-failed contract report (ADR-0018: CLI
+#     error / daemon unreachable).
+#     NOTE: a NOT-RUNNING daemon is NOT a query failure — the real CLI
+#     returns `[]` exit 0 without starting a daemon (verified v2.1.202,
+#     2026-07-07, isolated-HOME probe, #593). Model that case with an
+#     empty queue instead.
 #
 # Recorded state (files under MOCK_CLAUDE_STATE_DIR):
 #   bg-argv.log   one line per `--bg` call: the full argv, space-joined
@@ -81,6 +121,10 @@ mock_claude() {
   local shim_template
   shim_template=$(cat <<'SHIM'
 if [[ "${1:-}" == "agents" ]]; then
+  # query-failed mode (ADR-0018 contract): CLI error / daemon unreachable
+  if [[ -f "$STATE_DIR/agents-fail" ]]; then
+    exit 1
+  fi
   # Replay the enqueued response sequence: one response per call,
   # repeating the last response after the queue is exhausted.
   n=0
@@ -143,13 +187,38 @@ mock_claude_agent_record() {
   local cwd="${3:?missing <cwd>}"
   local started_at="${4:?missing <startedAt>}"
   local state="${5:?missing <state>}"
-  # Observed field split (#581): live sessions carry status (busy|blocked)
-  # plus state:"working"; terminal sessions carry state only, no status.
-  if [[ "$state" == "busy" || "$state" == "blocked" ]]; then
-    printf '{"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":%s,"status":"%s","state":"working"}' \
-      "$session_id" "$kind" "$cwd" "$started_at" "$state"
-  else
-    printf '{"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":%s,"state":"%s"}' \
-      "$session_id" "$kind" "$cwd" "$started_at" "$state"
-  fi
+  # Canonical v2.1.202 field pairs from the (status, state) matrix above
+  # (#591: liveness lives in `status`, terminality in `state`; blocked
+  # observed as idle/blocked on v2.1.202).
+  case "$state" in
+    busy)
+      mock_claude_agent_record_pair "$session_id" "$kind" "$cwd" "$started_at" busy working ;;
+    blocked)
+      mock_claude_agent_record_pair "$session_id" "$kind" "$cwd" "$started_at" idle blocked ;;
+    done|stopped)
+      mock_claude_agent_record_pair "$session_id" "$kind" "$cwd" "$started_at" idle "$state" ;;
+    *)
+      echo "mock_claude_agent_record: unknown logical state '$state'" \
+        "(use mock_claude_agent_record_pair for out-of-matrix pairs)" >&2
+      return 1 ;;
+  esac
+}
+
+mock_claude_agent_record_pair() {
+  local session_id="${1:?Usage: mock_claude_agent_record_pair <sessionId> <kind> <cwd> <startedAt> <status|-> <state|->}"
+  local kind="${2:?missing <kind>}"
+  local cwd="${3:?missing <cwd>}"
+  local started_at="${4:?missing <startedAt>}"
+  local status="${5:?missing <status|->}"
+  local state="${6:?missing <state|->}"
+  local fields
+  fields=$(printf '"sessionId":"%s","kind":"%s","cwd":"%s","startedAt":%s' \
+    "$session_id" "$kind" "$cwd" "$started_at")
+  [[ "$status" != "-" ]] && fields="${fields},\"status\":\"${status}\""
+  [[ "$state" != "-" ]] && fields="${fields},\"state\":\"${state}\""
+  printf '{%s}' "$fields"
+}
+
+mock_claude_fail_agents() {
+  touch "${MOCK_CLAUDE_STATE_DIR:?call mock_claude first}/agents-fail"
 }

--- a/tests/helpers/mock-claude.bats
+++ b/tests/helpers/mock-claude.bats
@@ -75,21 +75,49 @@ setup() {
   assert_match "state" '"state":"working"' "$output"
 }
 
-@test "agent records split live status/state; terminal records carry state only" {
-  # Observed shape (verified 2026-07-07, #581): live → status:busy|blocked
-  # + state:"working"; terminal → state:done|stopped, no status field.
+@test "agent records emit the canonical (status, state) matrix pairs (ADR-0018)" {
+  # Observed shapes (verified 2026-07-07, v2.1.202, #593): blocked →
+  # idle/blocked; terminal → idle/done, idle/stopped; busy → busy/working.
   run mock_claude_agent_record \
     "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 blocked
-  assert_match "live status" '"status":"blocked"' "$output"
-  assert_match "live state is working" '"state":"working"' "$output"
+  assert_match "blocked status is idle" '"status":"idle"' "$output"
+  assert_match "blocked state is blocked" '"state":"blocked"' "$output"
 
   run mock_claude_agent_record \
     "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 stopped
-  assert_match "terminal state" '"state":"stopped"' "$output"
-  if [[ "$output" == *'"status"'* ]]; then
-    echo "terminal record must not carry a status field: $output" >&2
+  assert_match "stopped status is idle" '"status":"idle"' "$output"
+  assert_match "stopped state" '"state":"stopped"' "$output"
+}
+
+@test "agent record with an unknown logical state fails noisily" {
+  run mock_claude_agent_record \
+    "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 exploded
+  assert_eq "exit status" "1" "$status"
+}
+
+@test "record_pair emits explicit pairs; '-' omits the field" {
+  run mock_claude_agent_record_pair \
+    "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 busy -
+  assert_match "status present" '"status":"busy"' "$output"
+  if [[ "$output" == *'"state"'* ]]; then
+    echo "record with state '-' must not carry a state field: $output" >&2
     return 1
   fi
+
+  run mock_claude_agent_record_pair \
+    "cafe0001-0000-4000-8000-000000000001" background /tmp/wt 1700000000000 - done
+  assert_match "state present" '"state":"done"' "$output"
+  if [[ "$output" == *'"status"'* ]]; then
+    echo "record with status '-' must not carry a status field: $output" >&2
+    return 1
+  fi
+}
+
+@test "mock_claude_fail_agents makes agents --json fail (query-failed contract)" {
+  mock_claude_fail_agents
+  run claude agents --json
+  assert_eq "exit status" "1" "$status"
+  assert_eq "no output" "" "$output"
 }
 
 @test "agent records emit startedAt as a JSON number (real epoch-millis shape)" {

--- a/tests/orchestrator/health-check.bats
+++ b/tests/orchestrator/health-check.bats
@@ -66,3 +66,24 @@ _active_worker() {
   assert_eq "exit 1 (zombie)" "1" "$status"
   assert_match "status zombie" '"status":"zombie"' "$output"
 }
+
+@test "health-check does not zombie-flag on a failing agents query (ADR-0018)" {
+  # Degradation policy: query-failed is inconclusive, not evidence of a
+  # crash — report "unknown" without counting the worker unhealthy.
+  _active_worker 93
+  mock_bin claude 'exit 1'
+
+  run bash "$HEALTH_SCRIPT" 93
+  assert_eq "exit 0 (inconclusive is not unhealthy)" "0" "$status"
+  assert_match "status unknown" '"status":"unknown"' "$output"
+}
+
+@test "health-check does not zombie-flag on an unknown (status, state) pair (ADR-0018)" {
+  _active_worker 94
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 idle working)]"
+
+  run bash "$HEALTH_SCRIPT" 94
+  assert_eq "exit 0 (inconclusive is not unhealthy)" "0" "$status"
+  assert_match "status unknown" '"status":"unknown"' "$output"
+}

--- a/tests/orchestrator/watch.bats
+++ b/tests/orchestrator/watch.bats
@@ -110,6 +110,43 @@ teardown() {
     "detected-via-state-fallback" "$(cat "$out")"
 }
 
+@test "watch escalates after repeated consecutive agents query failures (ADR-0018)" {
+  # Degradation policy: query-failed is retried, but a PERSISTENT failure
+  # must escalate to the caller instead of silently polling to the
+  # generic timeout — the detail warns the worker may still be running.
+  worker_state_write 593 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-593.worker"
+  mock_bin claude 'exit 1'
+  export CEKERNEL_WATCH_QUERY_RETRY_MAX=2
+
+  run bash "$WATCH_SCRIPT" 593
+  assert_eq "watch exits non-zero" "1" "$status"
+  assert_match "result is error" '"result":"error"' "$output"
+  assert_match "detail names the query failure" "query" "$output"
+  assert_match "detail warns the worker may still be running" \
+    "may still be running" "$output"
+}
+
+@test "watch retries an unknown (status, state) pair instead of crash-flagging (ADR-0018)" {
+  # Schema drift (unknown-value) is not evidence of death — watch keeps
+  # polling and completion arrives via the state-file fallback.
+  worker_state_write 594 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-594.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 idle working)]"
+  export CEKERNEL_WATCH_QUERY_RETRY_MAX=10
+
+  local out="${BATS_TEST_TMPDIR}/watch-out.json"
+  bash "$WATCH_SCRIPT" 594 > "$out" 2>/dev/null &
+  local watch_pid=$!
+  sleep 2
+  worker_state_write 594 TERMINATED "merged:#999"
+  wait "$watch_pid"
+
+  assert_match "completion detected via state fallback" \
+    "detected-via-state-fallback" "$(cat "$out")"
+}
+
 @test "watch resolves the headless backend from the env profile (#182 regression)" {
   worker_state_write 183 RUNNING "phase1:implement"
   echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-183.worker"

--- a/tests/scheduler/wrapper-preflight-registry.bats
+++ b/tests/scheduler/wrapper-preflight-registry.bats
@@ -182,7 +182,8 @@ enqueue_session() {
     "END status=success state=done" "$syslog"
   assert_match "END line records the poll-window duration" "duration=" "$syslog"
 
-  assert_match "spawn line captured in run.log" "backgrounded" "$(cat "$W_RUN_LOG")"
+  assert_match "captured short ID logged in run.log" \
+    "spawned short-id=aaaa1111" "$(cat "$W_RUN_LOG")"
 }
 
 @test "wrapper: runner reaps the done session via claude stop" {

--- a/tests/shared/backend-headless.bats
+++ b/tests/shared/backend-headless.bats
@@ -261,38 +261,57 @@ FULL_UUID="aaaa1111-2222-4333-8444-555566667777"
   assert_eq "short-ID handle matches by prefix" "0" "$status"
 }
 
-# ── status: blocked surfacing (ADR-0016) ──
+# ── status: ADR-0018 verdict vocabulary (blocked surfacing, ADR-0016) ──
 
-@test "backend_worker_status echoes the session state" {
+@test "backend_worker_status echoes the alive verdict for a busy session" {
+  echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$FULL_UUID" background "$WORKTREE_REAL" 1700000000000 busy)]"
+  run backend_worker_status 500
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "alive" "$output"
+}
+
+@test "backend_worker_status echoes the blocked verdict distinctly" {
   echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$FULL_UUID" background "$WORKTREE_REAL" 1700000000000 blocked)]"
   run backend_worker_status 500
   assert_eq "exit status" "0" "$status"
-  assert_eq "state" "blocked" "$output"
+  assert_eq "verdict" "blocked" "$output"
 }
 
-@test "backend_worker_status echoes missing and fails when the session is not listed" {
+@test "backend_worker_status echoes not-listed when the session is absent" {
   echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
   run backend_worker_status 500
-  assert_eq "exit status" "1" "$status"
-  assert_eq "state" "missing" "$output"
+  assert_eq "exit status" "3" "$status"
+  assert_eq "report" "not-listed" "$output"
 }
 
-@test "backend_worker_status fails for a non-existent handle" {
+@test "backend_worker_status echoes missing and fails for a non-existent handle" {
   run backend_worker_status 99999
   assert_eq "exit status" "1" "$status"
+  assert_eq "report" "missing" "$output"
 }
 
-@test "backend_worker_status echoes unknown when the agents query fails (transient)" {
+@test "backend_worker_status echoes query-failed when the agents query fails (transient)" {
   # A failed `claude agents --json` (daemon restarting) must be
   # distinguishable from a session verifiably not listed — supervision
-  # must not treat the former as a crash (PR #572 follow-up, #573).
+  # must not treat the former as a crash (#573, ADR-0018).
   echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
   mock_bin claude 'exit 1'
   run backend_worker_status 500
-  assert_eq "exit status" "1" "$status"
-  assert_eq "state" "unknown" "$output"
+  assert_eq "exit status" "4" "$status"
+  assert_eq "report" "query-failed" "$output"
+}
+
+@test "backend_worker_status propagates unknown-value (never coerced)" {
+  echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record_pair "$FULL_UUID" background "$WORKTREE_REAL" 1700000000000 idle working)]"
+  run --separate-stderr backend_worker_status 500
+  assert_eq "exit status" "5" "$status"
+  assert_eq "report" "unknown-value" "$output"
 }
 
 # ── termination: claude stop ──

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -1,10 +1,17 @@
 #!/usr/bin/env bats
-# claude-bg.bats — tests for scripts/shared/claude-bg.sh
+# claude-bg.bats — contract tests for scripts/shared/claude-bg.sh
 #
-# Shared `claude --bg` session helpers (ADR-0016): agents --json query,
-# token → state resolution, aliveness, and the normative session-ID
-# capture order. Consumers (headless.sh, spawn-orchestrator.sh, orchctl.sh)
-# are covered by their own suites; this file pins the helper contract.
+# ADR-0018: claude-bg.sh is the sole owner of the claude CLI surface.
+# These tests exercise the predicate contract against EVERY row of the
+# observed (status, state) matrix AND the three non-verdict reports
+# (not-listed / query-failed / unknown-value) — each must surface as a
+# distinct echoed token + exit code, never a coerced alive/dead.
+#
+# Exit-code contract (mirrored in the claude-bg.sh header):
+#   0 — verdict (alive | blocked | done | stopped)
+#   3 — not-listed
+#   4 — query-failed
+#   5 — unknown-value (+ stderr warning: drift must be visible)
 
 load '../helpers/assertions'
 load '../helpers/mock-bin'
@@ -18,34 +25,135 @@ setup() {
   source "${CEKERNEL_DIR}/scripts/shared/claude-bg.sh"
 }
 
-# ── claude_bg_state_for_token ──
-
-@test "state_for_token echoes the state for a full-UUID token" {
+# Enqueue a single-record roster with an explicit (status, state) pair
+enqueue_pair() {
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy)]"
-  run claude_bg_state_for_token "$FULL_UUID"
+    "[$(mock_claude_agent_record_pair "$FULL_UUID" background /tmp/x 1700000000000 "$1" "$2")]"
+}
+
+# ── claude_bg_token_verdict: matrix rows (verdicts, exit 0) ──
+
+@test "verdict matrix: busy/working is alive" {
+  enqueue_pair busy working
+  run claude_bg_token_verdict "$FULL_UUID"
   assert_eq "exit status" "0" "$status"
-  assert_eq "state" "busy" "$output"
+  assert_eq "verdict" "alive" "$output"
 }
 
-@test "state_for_token prefix-matches a short-ID token" {
-  mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 blocked)]"
-  run claude_bg_state_for_token "aaaa1111"
+@test "verdict matrix: busy with absent state is alive" {
+  enqueue_pair busy -
+  run claude_bg_token_verdict "$FULL_UUID"
   assert_eq "exit status" "0" "$status"
-  assert_eq "state" "blocked" "$output"
+  assert_eq "verdict" "alive" "$output"
 }
 
-@test "state_for_token fails when no session matches" {
-  # queue empty → []
-  run claude_bg_state_for_token "$FULL_UUID"
-  assert_eq "exit status" "1" "$status"
-  assert_eq "no output" "" "$output"
+@test "verdict matrix: legacy pre-split state:busy (no status) is alive" {
+  enqueue_pair - busy
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "alive" "$output"
 }
 
-# ── claude_bg_token_alive ──
+@test "verdict matrix: idle/blocked is blocked (v2.1.202 shape)" {
+  enqueue_pair idle blocked
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "blocked" "$output"
+}
 
-@test "token_alive: busy and blocked are alive; done and missing are not" {
+@test "verdict matrix: blocked/working is blocked (v2.1.201 shape)" {
+  enqueue_pair blocked working
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "blocked" "$output"
+}
+
+@test "verdict matrix: legacy pre-split state:blocked (no status) is blocked" {
+  enqueue_pair - blocked
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "blocked" "$output"
+}
+
+@test "verdict matrix: idle/done is done (#591 — terminality reads state)" {
+  # The #591 regression: `.status // .state` read "idle" here and broke
+  # terminal detection. The verdict must be done.
+  enqueue_pair idle done
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "done" "$output"
+}
+
+@test "verdict matrix: absent-status/done is done (--all daemon-restart row)" {
+  enqueue_pair - done
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "done" "$output"
+}
+
+@test "verdict matrix: idle/stopped and absent/stopped are stopped" {
+  enqueue_pair idle stopped
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "idle/stopped exit" "0" "$status"
+  assert_eq "idle/stopped verdict" "stopped" "$output"
+
+  enqueue_pair - stopped
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "absent/stopped exit" "0" "$status"
+  assert_eq "absent/stopped verdict" "stopped" "$output"
+}
+
+# ── Non-verdict reports: distinct, never coerced ──
+
+@test "verdict: absent session reports not-listed with exit 3" {
+  mock_claude_enqueue_agents "[]"
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "3" "$status"
+  assert_eq "report" "not-listed" "$output"
+}
+
+@test "verdict: failing CLI reports query-failed with exit 4" {
+  mock_claude_fail_agents
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "4" "$status"
+  assert_eq "report" "query-failed" "$output"
+}
+
+@test "verdict: out-of-matrix pair reports unknown-value with exit 5 and stderr warning" {
+  enqueue_pair idle working
+  run --separate-stderr claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "5" "$status"
+  assert_eq "report" "unknown-value" "$output"
+  assert_match "stderr warning names the pair" "idle" "$stderr"
+  assert_match "stderr warning names the pair" "working" "$stderr"
+}
+
+@test "verdict_from_json: malformed body reports query-failed" {
+  run claude_bg_token_verdict_from_json "not json at all" "$FULL_UUID"
+  assert_eq "exit status" "4" "$status"
+  assert_eq "report" "query-failed" "$output"
+}
+
+@test "verdict prefix-matches a short-ID token" {
+  enqueue_pair busy working
+  run claude_bg_token_verdict "aaaa1111"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "alive" "$output"
+}
+
+@test "verdict_from_json: does not call the claude CLI" {
+  local json
+  json="[$(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy)]"
+  run claude_bg_token_verdict_from_json "$json" "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "alive" "$output"
+  assert_not_exists "no agents --json call recorded" \
+    "${MOCK_CLAUDE_STATE_DIR}/agents-calls"
+}
+
+# ── claude_bg_token_alive: boolean projection of the verdict ──
+
+@test "token_alive: busy and blocked are alive; done and not-listed are not" {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy)]"
   run claude_bg_token_alive "$FULL_UUID"
@@ -63,33 +171,26 @@ setup() {
 
   mock_claude_enqueue_agents "[]"
   run claude_bg_token_alive "$FULL_UUID"
-  assert_eq "missing is dead" "1" "$status"
+  assert_eq "not-listed is dead" "1" "$status"
 }
 
-@test "token_alive: live record with status but no state field is alive" {
-  # Observed live shape variant (#581): status:"busy" with NO state field.
-  mock_claude_enqueue_agents \
-    "[{\"sessionId\":\"$FULL_UUID\",\"kind\":\"background\",\"cwd\":\"/tmp/x\",\"startedAt\":1700000000000,\"status\":\"busy\"}]"
+@test "token_alive: query-failed and unknown-value propagate — never coerced to dead" {
+  mock_claude_fail_agents
   run claude_bg_token_alive "$FULL_UUID"
-  assert_eq "status-only busy is alive" "0" "$status"
+  assert_eq "query-failed propagates as 4" "4" "$status"
 }
 
-@test "token_alive: legacy record shape (state:busy, no status) stays alive" {
-  # Backward compat (#581): the pre-split shape put the live state in
-  # `state` with no `status` field. The status-preferring query must
-  # still fall back to `state`.
-  mock_claude_enqueue_agents \
-    "[{\"sessionId\":\"$FULL_UUID\",\"kind\":\"background\",\"cwd\":\"/tmp/x\",\"startedAt\":1700000000000,\"state\":\"busy\"}]"
-  run claude_bg_token_alive "$FULL_UUID"
-  assert_eq "legacy busy is alive" "0" "$status"
+@test "token_alive_from_json: unknown-value propagates as exit 5" {
+  local json
+  json="[$(mock_claude_agent_record_pair "$FULL_UUID" background /tmp/x 1700000000000 idle working)]"
+  run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
+  assert_eq "unknown-value propagates as 5" "5" "$status"
 }
-
-# ── claude_bg_token_alive_from_json ──
 
 @test "token_alive_from_json: busy and blocked are alive; done and missing are not" {
   # Pre-fetched body — no CLI call. Single-fetch views (orchctl ps/count)
   # resolve every token against one response (ADR-0016 Phase 4); the
-  # busy/blocked liveness vocabulary lives HERE, not in the view layers.
+  # verdict vocabulary lives HERE, not in the view layers.
   local json
   json="[
     $(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy),
@@ -111,22 +212,56 @@ setup() {
 }
 
 @test "token_alive_from_json: real live shape (status:busy + state:working) is alive" {
-  # Real CLI live records carry the normative state in `status` while
-  # `state` reads "working" (#581). The raw literal pins the shape
-  # independently of the mock helper.
+  # Raw literal pins the real v2.1.202 live shape independently of the
+  # mock helper.
   local json
   json="[{\"sessionId\":\"$FULL_UUID\",\"kind\":\"background\",\"cwd\":\"/tmp/x\",\"startedAt\":1700000000000,\"status\":\"busy\",\"state\":\"working\"}]"
   run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
   assert_eq "status busy + state working is alive" "0" "$status"
 }
 
-@test "token_alive_from_json: does not call the claude CLI" {
-  local json
-  json="[$(mock_claude_agent_record "$FULL_UUID" background /tmp/x 1700000000000 busy)]"
-  run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
+# ── claude_bg_spawn (ADR-0018 Decision 1: --bg invocation + spawn-line
+#    parsing live in this module) ──
+
+@test "spawn: invokes claude --bg with the given args and echoes the short ID" {
+  mock_claude_enqueue_short_id "abcd1234"
+  run claude_bg_spawn /tmp --agent myagent "do the thing"
   assert_eq "exit status" "0" "$status"
-  assert_not_exists "no agents --json call recorded" \
-    "${MOCK_CLAUDE_STATE_DIR}/agents-calls"
+  assert_eq "short id" "abcd1234" "$output"
+  assert_file_exists "bg argv recorded" "${MOCK_CLAUDE_STATE_DIR}/bg-argv.log"
+  local argv
+  argv=$(cat "${MOCK_CLAUDE_STATE_DIR}/bg-argv.log")
+  assert_match "argv has --agent" "--agent myagent" "$argv"
+  assert_match "argv has the prompt" "do the thing" "$argv"
+}
+
+@test "spawn: echoes empty when the spawn line is unparseable (degraded capture)" {
+  mock_claude_enqueue_short_id "NOTHEX!!"
+  run claude_bg_spawn /tmp "prompt"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "no short id" "" "$output"
+}
+
+@test "spawn: fails when claude --bg fails" {
+  # Replace the shim with one that always fails (mock_bin re-registers)
+  mock_bin claude 'exit 1'
+  run claude_bg_spawn /tmp "prompt"
+  assert_eq "exit status" "1" "$status"
+}
+
+# ── claude_bg_stop ──
+
+@test "stop: delegates to claude stop and never fails" {
+  run claude_bg_stop "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_file_exists "stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
+  assert_eq "stopped token" "$FULL_UUID" "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
+}
+
+@test "stop: empty token is a no-op success" {
+  run claude_bg_stop ""
+  assert_eq "exit status" "0" "$status"
+  assert_not_exists "no stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
 }
 
 # ── claude_bg_capture_session_id ──
@@ -159,9 +294,9 @@ setup() {
 }
 
 # ── claude_bg_wait_terminal (ADR-0016 Phase 3) ──
-# Polls to a terminal-for-unattended-supervision state. blocked is terminal
-# here: an unattended (cron/at) session waiting on a permission dialog will
-# never be approved, so waiting longer cannot help.
+# Polls to a terminal-for-unattended-supervision verdict. blocked is
+# terminal here: an unattended (cron/at) session waiting on a permission
+# dialog will never be approved, so waiting longer cannot help.
 
 @test "wait_terminal: echoes done when the session completes" {
   mock_claude_enqueue_agents \

--- a/tests/shared/issue-lock.bats
+++ b/tests/shared/issue-lock.bats
@@ -230,6 +230,17 @@ lock_with_token() {
   assert_eq "acquire fails (cannot verify → assume alive)" "1" "$status"
 }
 
+@test "acquire fails on an unknown (status, state) pair (conservative)" {
+  # ADR-0018 degradation policy: unknown-value is schema drift, not
+  # evidence of death — never steal a lock on doubt.
+  mock_claude
+  lock_with_token
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 idle working)]"
+  run issue_lock_acquire "$REPO_A" "$ISSUE"
+  assert_eq "acquire fails (unknown-value → assume alive)" "1" "$status"
+}
+
 @test "check reports locked while the token holder session is busy" {
   mock_claude
   lock_with_token


### PR DESCRIPTION
closes #593
refs #591, refs #589(2.0-dev 宛てのため auto-close は発火しない — マージ後に手動 close)

## Summary

ADR-0018 (Accepted) の実装。`claude-bg.sh` を claude CLI 表面の唯一の所有者とし、既知バグ2件(#591 terminal 検出破損、#589 daemon 継承 env)をパッチではなく契約の内側で修正した。

### 1. claude-bg.sh の契約化(ADR-0018 Decision 1)
- **verdict 述語**: `claude_bg_token_verdict{,_from_json}` が観測マトリクスに基づき `alive|blocked|done|stopped`(exit 0)/ `not-listed`(exit 3)/ `query-failed`(exit 4)/ `unknown-value`(exit 5 + stderr 警告)を区別して報告。未知値を alive/dead に強制変換しない
- **#591 修正**: liveness は `status`、terminality は `state` を読む。`(.status // .state)` 併合式(done セッションが `status:"idle"` を持つため terminal 検出が永久に失敗)を全廃
- **CLI 表面の集約**: `claude --bg` 起動 + spawn 行パース(`claude_bg_spawn`)、`claude stop`(`claude_bg_stop`)も所有。raw state を漏らす `claude_bg_state_{from_json,for_token}` は削除
- **観測マトリクスの3点同期**: claude-bg.sh ヘッダ / constraints doc / mock-claude.bash(ADR-0017 staleness 結合)

### 2. 階層の確立(9ファイル移行)
bg-session.sh は述語のみ消費。wrapper.sh / registry.sh / issue-lock.sh / backend-adapter.sh / spawn-orchestrator.sh / backends/{tmux,wezterm}.sh / orchctl.sh から claude CLI 直接パース・起動を排除。

### 3. 劣化ポリシーは消費者に明示(Rule of Separation)
- issue-lock: query-failed / unknown-value → alive 扱い(疑わしきはロックを奪わない)
- watch: リトライ後 `CEKERNEL_WATCH_QUERY_RETRY_MAX`(default 3)連続でエスカレーション(detail に「worker はまだ動作中の可能性あり」を明記)
- gc / count: reap しない / alive として数える(保守側)
- health-check / recover: 判定不能を zombie / crashed に coerce しない

### 4. #589 修正(ADR-0018 Decision 3)
daemon 継承 env を「無規定」と constraints doc に宣言。全 spawn パスで `CEKERNEL_*` の明示注入を normative 化(Worker: `.cekernel-env` source、Orchestrator: spawn-orchestrator.sh の export)。

### 5. mock-claude = 実行可能仕様(ADR-0018 Decision 2)
canonical record がマトリクスの実ペアを emit(`idle/done` 等)。`mock_claude_agent_record_pair`(任意ペア)+ `mock_claude_fail_agents`(query-failed)を追加。contract test は全マトリクス行 + 非判定3種をカバー。

### 6. 実測(v2.1.202, 2026-07-07)
- **daemon 蘇生副作用なし**: 隔離 HOME プローブで `claude agents --json`(`--all` 含む)は daemon 不在時に `[]` exit 0 を返し、daemon を起動しない → 述語は副作用フリーな観測者。停止中 daemon は `not-listed` として現れる(constraints doc に記録)
- **マトリクス修正**: v2.1.202 の blocked は `status:"idle", state:"blocked"`(ADR-0018 の予測 `status:"blocked"` と異なる)— 実ロスターで確認しマトリクスに反映

### 7. CLAUDE.md レビュー基準
claude-bg.sh 外での claude CLI 直接パース・起動は changes-requested。

### #573 指摘2との整合
transient(query-failed)vs not-listed の区別は #573 で先行導入済みの挙動を再実装せず、ADR-0018 語彙に照らして検証・改名(`unknown`→`query-failed`、`missing`→`not-listed` + handle 無しの `missing` を分離)。

## Test Plan
- [x] `tests/shared/claude-bg.bats`: contract test 34件(全マトリクス行、非判定3種の exit code / echo トークン / stderr 警告、spawn/stop、TDD RED→GREEN)
- [x] `tests/shared/backend-headless.bats`: verdict 語彙 + unknown-value 伝播
- [x] `tests/shared/issue-lock.bats`: unknown-value → alive(保守)
- [x] `tests/ctl/orchctl-{read,mutating}.bats`: ps の not-listed 表示、count の unknown-value 保守カウント、gc の reap 拒否、recover の判定不能エラー
- [x] `tests/orchestrator/watch.bats`: エスカレーション + unknown-value リトライ
- [x] `tests/orchestrator/health-check.bats`: query-failed / unknown-value を zombie 化しない
- [x] `tests/scheduler/wrapper-preflight-registry.bats`: runner の claude_bg_spawn/stop 移行
- [x] 関連 legacy lane(watch / health-check / backend-dispatch / json-output / timeout / rollback / standalone-commands)全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)