### PR TITLE
feat: Worker spawn 前の粗い permission preflight(ADR-0012 Amendment 4 層1)

### DIFF
--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -255,6 +255,36 @@ fi
 echo "worktree: $WORKTREE" >&2
 echo "branch:   $BRANCH" >&2
 
+# ── Permission preflight (ADR-0012 Amendment 4, layer 1) ──
+# Coarse check only: warn when the target repo checkout lacks a
+# .claude/settings.json with a non-empty permissions.allow, because the
+# spawned process may then stall silently on a permission prompt
+# ("blocked"). Full resolution (settings hierarchy, Bash(cmd) globs, the
+# safety classifier) is an explicit Non-Goal — there is no platform query
+# API, and reimplementing the engine would fail worse than the gap it
+# closes. Per-tool permit/deny is caught at layer 3 via bg_is_blocked
+# (ADR-0018). The preflight warns noisily and never aborts the spawn.
+permission_preflight() {
+  local settings="${1}/.claude/settings.json"
+  local gap=""
+  if [[ ! -f "$settings" ]]; then
+    gap="no .claude/settings.json in the target repo"
+  elif ! jq -e '.permissions.allow | length > 0' "$settings" >/dev/null 2>&1; then
+    gap="permissions.allow in .claude/settings.json is empty, missing, or unparsable"
+  fi
+  [[ -n "$gap" ]] || return 0
+  cat >&2 <<EOF
+Warning: permission preflight: ${gap}.
+  The spawned process may stall silently (blocked) waiting for tool
+  permission. To avoid this, either:
+    - add an allowlist to the target repo's .claude/settings.json, e.g.
+        {"permissions": {"allow": ["Bash", "Edit", "Write", "Read"]}}
+    - or launch with an explicit --permission-mode acceptEdits.
+  Proceeding anyway (coarse check only — ADR-0012 Amendment 4).
+EOF
+}
+permission_preflight "$WORKTREE"
+
 # ── Compute cekernel script paths for process PATH ──
 CEKERNEL_WORKER_SCRIPTS="$(cd "${SCRIPT_DIR}/../process" && pwd)"
 CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -59,6 +59,14 @@ EOF
 
 Display: runtime directory, backend, count of additional variables (or "none"), profile path — and point to `envs/README.md` for other options. If the user selected `wezterm`, also point to `config/README.md` for the WezTerm plugin installation (read these files to give the actual path relative to the plugin directory).
 
+Also present the **recommended target-repo allowlist** (ADR-0012 Amendment 4). Workers run headless in the target repository's checkout; without a pre-configured allowlist they may stall silently (`blocked`) on permission prompts. Recommend that each target repository ships a `.claude/settings.json` containing a non-empty `permissions.allow`, e.g.:
+
+```json
+{"permissions": {"allow": ["Bash", "Edit", "Write", "Read"]}}
+```
+
+Do NOT create or modify the target repo's settings — this is a recommendation only; permission configuration is the operator's decision (`spawn.sh` warns at spawn time when it is missing, and `--permission-mode acceptEdits` is the alternative escape).
+
 ## Important
 
 - Do NOT run `sudo` at any point — the purpose of this skill is to avoid it via user-local paths.

--- a/tests/orchestrator/spawn.bats
+++ b/tests/orchestrator/spawn.bats
@@ -184,6 +184,45 @@ run_spawn() {
     "$(cat "${ipc_dir}/handle-42.worker")"
 }
 
+# ── Permission preflight (ADR-0012 Amendment 4, layer 1) ──
+# Coarse check: warn when the target repo lacks a usable permissions.allow,
+# but never abort the spawn.
+
+# commit_settings <json> — commit .claude/settings.json to upstream so the
+# worktree checkout (created from origin/main) contains it
+commit_settings() {
+  mkdir -p "${TMP}/upstream/.claude"
+  printf '%s\n' "$1" > "${TMP}/upstream/.claude/settings.json"
+  git -C "${TMP}/upstream" add .claude/settings.json
+  git -C "${TMP}/upstream" -c user.email=test@test -c user.name=test \
+    commit -q -m "add settings"
+}
+
+@test "spawn.sh warns but proceeds when target repo has no .claude/settings.json" {
+  run_spawn
+  assert_eq "spawn exits 0 (preflight never aborts)" "0" "$status"
+  assert_match "warns about missing settings" "permission preflight" "$output"
+  wait_for_file "$ARGS_FILE"
+}
+
+@test "spawn.sh does not warn when permissions.allow is non-empty" {
+  commit_settings '{"permissions": {"allow": ["Bash", "Edit", "Write", "Read"]}}'
+  run_spawn
+  assert_eq "spawn exits 0" "0" "$status"
+  if [[ "$output" == *"permission preflight"* ]]; then
+    echo "FAIL: no preflight warning expected with non-empty allow: ${output}" >&2
+    return 1
+  fi
+}
+
+@test "spawn.sh warns but proceeds when permissions.allow is empty" {
+  commit_settings '{"permissions": {"allow": []}}'
+  run_spawn
+  assert_eq "spawn exits 0 (preflight never aborts)" "0" "$status"
+  assert_match "warns about empty allow" "permission preflight" "$output"
+  wait_for_file "$ARGS_FILE"
+}
+
 @test "spawn.sh without --repo keeps current-repo behavior" {
   run_spawn
   assert_eq "spawn exits 0" "0" "$status"


### PR DESCRIPTION
closes #594

## Summary
ADR-0012 Amendment 4(層1)の実装。target repo に有効な `permissions.allow` がない場合、Worker が permission プロンプトで無音 `blocked` 停止する盲点を、spawn 前の**粗い検査 + noisy warn** で可視化する。

- `scripts/orchestrator/spawn.sh`: `backend_spawn_worker` 呼び出し前に `permission_preflight` を実行。worktree の `.claude/settings.json` が (1) 不在、または (2) `permissions.allow` が空・欠落・パース不能 の場合に stderr へ警告(推奨 allow 例 `Bash, Edit, Write, Read` / `--permission-mode acceptEdits` の案内付き)。**spawn は決して止めない**
- 完全な権限解決(settings 階層・`Bash(cmd)` glob・classifier)は Non-Goal — 照会 API がなく再実装は元より悪い失敗を生むため。個々のツール許否は層3 `bg_is_blocked`(ADR-0018)に委譲
- jq は spawn.sh の既存依存(`claude-json-helper.sh` 経由)のため新規依存なし
- `skills/setup/SKILL.md`: Step 5 で target repo 向け推奨 allowlist を提示(強制しない・operator 裁量、target repo の settings には触れない)

## Test Plan
- [x] TDD(RED → GREEN)。`tests/orchestrator/spawn.bats` に3ケース追加:
  - settings 無し → warn あり、かつ exit 0(spawn 継続)
  - `permissions.allow` 非空 → warn なし(self-hosted 相当。cekernel 自身の `.claude/settings.json` は非空 allow)
  - `permissions.allow` 空 → warn あり、かつ exit 0
- [x] `bats tests/orchestrator/spawn.bats` 15/15 pass(base merge 後に再実行)
- SKILL.md は非実行ファイルのためテストなし(CLAUDE.md Testing ポリシー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)