### PR TITLE
fix: Reviewer subagent grant を plugin モード対応に(namespace-agnostic)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,10 @@ See [README.md](./README.md) for architecture details.
 When implementing something, always check existing patterns first.
 
 - **Feasibility check before implementation**: When adopting an approach different from existing patterns, verify technical constraints first (e.g., tool availability, API limitations, call depth restrictions). Do not start implementation without confirming feasibility.
+- **Verify feasibility in BOTH local and plugin modes**: cekernel runs both as a local checkout (self-hosting) and as a distributed plugin (`--plugin-dir`). **Local self-hosting systematically hides plugin-mode failures** — agent namespacing (`reviewer` vs `cekernel:reviewer`), hook loading (`${CLAUDE_PLUGIN_ROOT}`), env delivery, and Agent-tool subagent allowlists all differ. Any change touching agent spawn, hooks, env, or subagents MUST be feasibility-checked in a **foreign repo via `--plugin-dir`**, not local-only. Dogfood via `--plugin-dir` in a foreign repo before every release.
 - **Document deviations in ADR**: When choosing not to use an existing pattern, record the reason in an ADR. See the [ADRs](#adrs) section for how to create one.
 
-> **Background**: When designing the Reviewer, an existing spawn pattern was overlooked and a subagent-based approach was implemented instead, requiring a rework. The technical constraint (skill → agent → agent is not allowed) could have been discovered with prior investigation.
+> **Background**: When designing the Reviewer, an existing spawn pattern was overlooked and a subagent-based approach was implemented instead, requiring a rework. The `skill → agent → agent` nesting constraint **was true at the time (2026-03)** and could have been discovered with prior investigation. Nested subagents were later unlocked in claude **v2.1.172 (2026-06-10)**, so ADR-0012 Amendment 2 (2026-07) moved the Reviewer back to a subagent — a sound call, but it reused the 2026-03 `Agent(reviewer)` grant unchanged, which broke in plugin mode (#600: the grant did not permit the plugin-namespaced `cekernel:reviewer`). The durable lesson is not the constraint (now lifted) but the both-modes feasibility check above.
 
 ## Philosophy
 

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: orchestrator
 description: Orchestrator agent that manages issue lifecycle in the main working tree. Handles issue intake, worktree creation, Worker spawning, completion monitoring, review coordination, and cleanup.
-tools: Read, Edit, Write, Bash, Agent(reviewer)
+tools: Read, Edit, Write, Bash, Agent
 ---
 
 # Orchestrator Agent
@@ -166,6 +166,8 @@ the final output line.
 ```
 
 The Reviewer's temporary worktree is auto-removed by Claude Code (detached, read-only checkout). It inherits your session's tool permissions — a permission gap stalls the review silently (`blocked`).
+
+**Never review the PR yourself.** The verdict comes only from the Reviewer subagent's final output line. If the Agent tool errors (e.g. the reviewer agent type is not found), or the subagent returns no recognizable verdict, treat it as **escalation** below — do NOT run `gh pr review` / `gh api .../reviews` yourself, and do NOT send an `approved` notification. Send `approved` (and merge, if `CEKERNEL_AUTO_MERGE=true`) only when the Reviewer returned the `approved` verdict.
 
 ### Handling the Verdict (final output line)
 

--- a/docs/adr/0012-worker-review-separation.md
+++ b/docs/adr/0012-worker-review-separation.md
@@ -536,6 +536,36 @@ guidance are 2.0-sized. Layer-2 verification and goal-loop permission
 policy are post-2.0 (v2.1). **2.0 release is not blocked on this
 Amendment.**
 
+### Amendment 5: Reviewer Subagent Grant Must Be Namespace-Agnostic (2026-07-07)
+
+Amendment 2 is **kept** — the Reviewer stays an Orchestrator subagent. But
+its first plugin-mode run (#600) exposed a latent defect: the Orchestrator's
+`tools: ... Agent(reviewer)` allowlist only permits the bare name `reviewer`.
+That name exists in **local** self-hosting (`.claude/agents/reviewer.md`), so
+23 spawns succeeded during the Waves; under **plugin** distribution the
+Reviewer is the namespaced `cekernel:reviewer`, which `Agent(reviewer)`
+silently blocks (the Agent tool reports "not found" with an empty available
+list). The Orchestrator then improvised a self-review via `gh pr review
+--approve` — which fails on an author's own PR — and still sent an `approved`
+notification (a Rule of Repair violation: success reported on a broken state).
+
+The grant was itself a fossil: it was added 2026-03 for the *first* subagent
+attempt, went vestigial when Amendment 1 moved the Reviewer to spawn + FIFO,
+and was silently reactivated by Amendment 2 (2026-07) without updating for
+plugin namespacing. Live testing confirmed plugin agents **can** be
+subagents (a `--plugin-dir` session spawned `cekernel:probe`); the sole
+cause was the grant name.
+
+**Decision**: grant the Orchestrator unrestricted `Agent` (no parentheses),
+which permits the subagent under either namespace. Plugin-namespaced
+allowlist entries (`Agent(cekernel:reviewer)`) are undocumented, so an
+allowlist is not a reliable cross-mode option; the Orchestrator is
+first-party and spawns Workers as processes (not subagents), so dropping the
+allowlist costs nothing. The Orchestrator must **never review the PR itself**
+and must gate the `approved` notification on the Reviewer's actual verdict
+(orchestrator.md). The durable lesson — verify feasibility in both local and
+plugin modes — is recorded in CLAUDE.md (Design Decisions).
+
 ## Alternatives Considered
 
 ### Alternative: Human-Only Review

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -94,9 +94,13 @@ the spawned process's environment keeps Bash calls truly in the foreground.
 **Confidence: Stable**
 
 Each Claude Code session runs a single agent. There is no built-in mechanism
-for an agent to spawn peer agents within the same session. Multi-agent
+for an agent to spawn *peer* agents within the same session. Multi-agent
 coordination requires external orchestration (separate terminal sessions,
-separate processes).
+separate processes). (This concerns *peer* agents sharing one context;
+**subagents**, which each get their own context window, are a distinct
+mechanism and *are* supported — see [Subagent Nesting](#subagent-nesting)
+below. cekernel uses both: Workers are peer processes, the Reviewer is a
+subagent.)
 
 **Implications for cekernel**:
 - The Orchestrator/Worker separation maps correctly to separate sessions
@@ -150,6 +154,18 @@ Related observations (claude v2.1.201, 2026-07-06):
   correctly inside a full worktree checkout
 - A main-thread agent can restrict spawnable subagent types with the
   `Agent(agent_type)` allowlist syntax in its `tools` frontmatter
+
+**Plugin-mode note (verified 2026-07-07, #600)**: plugin-provided agents
+**can** be spawned as Agent-tool subagents — a `--plugin-dir` session
+successfully spawned `cekernel:probe` as a subagent. The catch is the
+parent agent's `Agent(...)` allowlist: it must permit the name actually
+used, which is plugin-namespaced (`cekernel:reviewer`) in plugin mode but
+bare (`reviewer`) in local mode. A grant of `Agent(reviewer)` silently
+blocks `cekernel:reviewer` (the tool reports "not found" with an empty
+available list) — this is how #600 broke the Reviewer under plugin
+distribution. Plugin-namespaced allowlist entries (`Agent(cekernel:reviewer)`)
+are **undocumented**; for an agent that must spawn a sibling in both modes,
+use unrestricted `Agent` (no parentheses).
 
 **Implications for cekernel**:
 - The Reviewer runs as an Orchestrator subagent with `isolation: worktree`


### PR DESCRIPTION
## 概要

plugin モードで Reviewer subagent が spawn できず、Orchestrator が self-review を improvise して失敗し PR にレビューが残らない + `approved` 誤通知が飛ぶ不具合(#600)の修正。

真因は **grant 名不一致**: `agents/orchestrator.md` の `Agent(reviewer)` allowlist はリテラル `reviewer` のみ許可。local 自己ホストでは `.claude/agents/reviewer.md` が実在するため 23 spawn 成功していたが、plugin 配布では実体が `cekernel:reviewer` で弾かれていた(live テストで plugin agent は subagent 化**可能**と確認済み=H1)。

## 変更

- **agents/orchestrator.md**
  - grant `Agent(reviewer)` → **`Agent`(無制限)** — 両 namespace で spawn 可(namespaced allowlist は未文書化ゆえ賭けない)
  - **improvise 禁止 + verdict-gating**: 自分でレビューしない(`gh pr review` を叩かない)、`approved` 通知は Reviewer が `approved` を返した時だけ(Rule of Repair)
- **docs/adr/0012** — Amendment 5(A2 維持、namespace-agnostic grant 修正、grant の出自を記録)
- **CLAUDE.md** — local/plugin 両モード feasibility guardrail + Background 注記を訂正(v2.1.172=2026-06-10 で解禁済み、履歴は保持)
- **docs/claude-code-constraints.md** — Subagent Nesting に検証済み注記 + peer/subagent クロスリファレンス

## 検証

- 非実行ファイル(agent 定義・docs)のみの変更のため content-based テストは追加しない(CLAUDE.md 方針)
- マージ前に **plugin モードで live 検証**(Orchestrator が `cekernel:reviewer` を spawn しレビューが実際に PR へ post されること)を実施する

Refs #600(2.0-dev マージのため closes は発火せず、検証後に手動クローズ)