### PR TITLE
docs: --bg での worktree cleanup 発火ギャップを記録 (#602)

### DIFF
--- a/docs/adr/0012-worker-review-separation.md
+++ b/docs/adr/0012-worker-review-separation.md
@@ -452,6 +452,28 @@ assumptions; CLAUDE.md feasibility-check rule applies):
    is retained because rules auto-loading inside agent worktrees is still
    not guaranteed.
 
+**Correction (2026-07-08, #602): results #1 and #2 hold only in interactive
+sessions.** Both verifications above were done interactively / by binary
+inspection of the removal code path — they confirmed *what the routine does
+when it runs*, not *whether it runs* in cekernel's actual execution mode. A
+controlled `claude -p` test (#602) showed that under non-interactive parents
+(`claude --bg` / `-p`, the Orchestrator's default per ADR-0016), **neither**
+mechanism fires on subagent completion: the `.claude/worktrees/agent-*`
+worktree is not auto-removed (#1) and the `.git/info/exclude` runtime marker
+is not written (#2, so `git status` shows `?? .claude/worktrees/`). The test
+isolated firing from config-load — a `SessionEnd` control hook fired while
+`WorktreeRemove` did not. Consequently the `isolation: worktree` sub-choice
+of this amendment **leaks worktrees under `--bg`**. Amendment 2's core
+decision (Reviewer as a subagent) is sound and stays; only the
+platform-managed worktree is the defect. The root fix — keep the subagent but
+move its worktree onto a cekernel-managed path (`.worktrees/reviewer-*` via
+`cleanup-worktree.sh`, restoring cekernel ownership of the lifecycle) — is
+tracked in #602 and is post-2.0. For 2.0, the leftover worktrees are cleaned
+manually and documented as a Known Issue; `.claude/worktrees/` is
+deliberately **not** gitignored so the untracked entry stays a visible
+cleanup signal (Rule of Transparency). This is the same mode-blindspot class
+as #600 (Amendment 5).
+
 ### Amendment 3: `CEKERNEL_KEEP_WORKTREE` — Optional Worktree Retention After Approval (2026-07)
 
 The Worktree Lifetime table above mandates immediate worktree removal on

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -152,6 +152,24 @@ Related observations (claude v2.1.201, 2026-07-06):
   is removed automatically
 - Relative symlinks (e.g., `.claude/rules/*.md` → `../../docs/*.md`) resolve
   correctly inside a full worktree checkout
+
+**Interactive-only: worktree cleanup does NOT fire under `--bg` / `-p`**
+(verified 2026-07-08, #602). The two mechanisms above — auto-removal and the
+`.git/info/exclude` auto-ignore — only run in **interactive** sessions. In a
+non-interactive parent (`claude --bg` / `-p`, cekernel's default execution
+mode for the Orchestrator), an `isolation: worktree` subagent's
+`.claude/worktrees/agent-*` is **not** removed on completion, and the
+`# claude-code-runtime` exclude marker is **not** written — so leftover
+worktrees accumulate and show as untracked `?? .claude/worktrees/` in
+`git status`. A controlled `-p` test confirmed this is a firing gap, not a
+config-load gap: a `SessionEnd` control hook fired (project `settings.json`
+loads under `-p`) while a `WorktreeRemove` hook did **not**. The docs describe
+`WorktreeRemove` as firing "at session exit or when a subagent finishes", but
+that firing is interactive-only. **Implication**: a plugin/hook-based root fix
+is not viable for cekernel's `--bg` Orchestrator; the worktree lifecycle must
+be owned by cekernel (tracked in #602). This is a mode-blindspot of the same
+class as #600 — a mechanism verified in one execution mode but broken in the
+one cekernel actually uses.
 - A main-thread agent can restrict spawnable subagent types with the
   `Agent(agent_type)` allowlist syntax in its `tools` frontmatter
 


### PR DESCRIPTION
## 概要

`--bg`/`-p`(Orchestrator の既定実行モード)では、`isolation: worktree` subagent の worktree 自動クリーンアップと `.git/info/exclude` auto-ignore が**発火しない**ことを検証したので、一次情報として記録する。

## 変更

- `docs/claude-code-constraints.md`: Subagent Nesting の worktree 観測に「interactive 限定・`--bg` では非発火」の注記を追加。制御テスト(`SessionEnd` は発火・`WorktreeRemove` は非発火 = settings ロードは OK で発火のみ欠落)を明記。
- `docs/adr/0012-*.md`: Amendment 2 の検証結果 #1/#2 に「interactive 限定」の訂正注記。Amendment 2 の subagent 決定自体は維持(健全)、leak するのは `isolation: worktree` の一点。根治(cekernel 管理 worktree)は #602・post-2.0。**新 amendment は作らない**。

doc のみの変更のためテストなし(CLAUDE.md 規約)。

Refs #602