### PR TITLE
docs: 2.0 --bg 移行で残った claude -p 記述の更新漏れを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ normal behavior testing and is fine.)
 **Assert behavior, never text** (ADR-0017). Tests verify executed effects
 and recorded argv — not the text of generated scripts, and not the source
 text of scripts either. Grep-testing a generated runner for strings like
-`exec claude -p`, or grepping `spawn.sh` source for `resolve_repo_root`,
+`claude --bg`, or grepping `spawn.sh` source for `resolve_repo_root`,
 is the same anti-pattern as `.md`-grep — it breaks on mechanism or wording
 changes even when behavior is preserved.
 

--- a/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
+++ b/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
@@ -4,6 +4,14 @@
 
 Accepted
 
+> **Superseded in part by ADR-0016 (2.0.0)**: the spawn mechanism described
+> throughout this ADR — wrapper scripts invoking `claude -p` — was replaced by
+> `claude --bg` background sessions (`claude_bg_spawn` /
+> `claude_bg_wait_terminal`, ADR-0016 Phase 3). The scheduling architecture
+> (OS-native schedulers, registry, wrapper generation, log layout) remains
+> current. The `claude -p` references below are preserved as the historical
+> record of this decision.
+
 ## Context
 
 cekernel currently operates in a pull model — a human runs `/dispatch` or `/orchestrate` to trigger issue processing. There is no automated scheduling capability.

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -52,9 +52,10 @@ Known characteristics:
 Additionally (observed 2026-07-07, claude v2.1.201): **the harness may
 auto-detach a long-running foreground Bash call into a background task**
 even when the agent intended a blocking call. In `claude -p` execution this
-is fatal in combination with turn-end process exit: the agent believes it
+was fatal in combination with turn-end process exit: the agent believes it
 will be re-invoked on completion, ends its turn, and the process dies with
-its watchers (#558). Setting `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in
+its watchers (#558) — the failure class that motivated ADR-0016's move to
+`claude --bg`. Setting `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in
 the spawned process's environment keeps Bash calls truly in the foreground.
 
 **Implications for cekernel**:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -215,7 +215,9 @@ $CEKERNEL_VAR_DIR/              # default: ~/.local/var/cekernel (user-specified
 `scripts/scheduler/wrapper.sh` generates runner scripts at `runners/<id>.sh`. Each wrapper:
 
 1. Sets `PATH` (registration-time snapshot)
-2. Executes `claude -p` with `if/else` pattern (`set -e` safe)
+2. Spawns a `claude --bg` background session via `claude_bg_spawn`, then polls
+   it to a terminal state with `claude_bg_wait_terminal` (ADR-0016 Phase 3;
+   `if/else` pattern, `set -e` safe)
 3. Updates registry status (`success` / `error`)
 4. Sends OS-native notification on failure (best-effort)
 


### PR DESCRIPTION
## 概要

v2.0.0 release ブランチの整合性レビューで見つかった doc 更新漏れ(4箇所)の修正。

## 変更

- **internals.md**: Wrapper Scripts が「`claude -p` を実行」→ 実際は `claude_bg_spawn` + `claude_bg_wait_terminal`(ADR-0016 Phase 3)
- **ADR-0011**: 冒頭に「Superseded in part by ADR-0016」バナー追加(spawn 機構のみ置換・スケジューリング設計は現行。本文は ADR 慣習により歴史記録として保持)
- **CLAUDE.md**: anti-pattern 例 `exec claude -p` → `claude --bg`(生成 runner の実態に一致させる)
- **claude-code-constraints.md**: #558 auto-detach の記述を「-p 時代の failure class(ADR-0016 の動機)」として過去形化

doc のみの変更のためテストなし(CLAUDE.md 規約)。

Refs #599(release 整合性レビュー)