### PR TITLE
docs: v2.0.0 リリースノートの整合性修正(What's Changed 欠落・ADR 誤記・Stop hook 検証文言)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ normal behavior testing and is fine.)
 **Assert behavior, never text** (ADR-0017). Tests verify executed effects
 and recorded argv — not the text of generated scripts, and not the source
 text of scripts either. Grep-testing a generated runner for strings like
-`exec claude -p`, or grepping `spawn.sh` source for `resolve_repo_root`,
+`claude --bg`, or grepping `spawn.sh` source for `resolve_repo_root`,
 is the same anti-pattern as `.md`-grep — it breaks on mechanism or wording
 changes even when behavior is preserved.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,9 +32,11 @@ the `1.9.x` line (see **Migration** below). Requires a recent Claude Code
   non-executable files ("assert behavior, never text").
 - **Worker lifecycle Stop hook (ADR-0019)**: a plugin `Stop` hook keeps a Worker
   session alive until `notify-complete.sh` records `TERMINATED`, closing the
-  "Worker dies before its completion notification" gap. Live-verified to fire in
-  both local self-hosting and plugin-installed usage (via spawn-time
-  `--plugin-dir`).
+  "Worker dies before its completion notification" gap. Live-verified to fire
+  in local self-hosting and in the spawn-time `--plugin-dir` plugin path (the
+  route cekernel itself uses to spawn sessions). Verification via an actual
+  `/plugin install` distribution is still open — tracked in
+  [#604](https://github.com/clonable-eden/cekernel/issues/604).
 - **/workflows boundary (ADR-0015)**: state that survives the session belongs to
   cekernel; in-session fan-out belongs to `/workflows` — documented usage guide.
 - **Conditional `--bare` (ADR-0016 Amendment 1)**: bare mode is now selected by
@@ -109,12 +111,15 @@ permission portability, namespace-agnostic Reviewer grant — the #600 fix).
 * feat: Phase 5 — wezterm/tmux backend を claude attach UX に再構築 by @clonable-eden in #578
 * feat: Phase 2 — spawn-orchestrator.sh を claude --bg 化 by @clonable-eden in #580
 * feat: Phase 4 — orchctl ps を claude agents --json の view 層に by @clonable-eden in #582
-* feat: Worker lifecycle Stop hook guard via additionalContext (ADR-0018) by @clonable-eden in #583
+* feat: Worker lifecycle Stop hook guard via additionalContext (ADR-0019) by @clonable-eden in #583
 * fix: prefer status over state when reading claude agents --json liveness by @clonable-eden in #584
 * feat: Phase 3 — wrapper.sh を claude --bg 化 + registry 意味論変更 by @clonable-eden in #585
 * refactor: agents/skills markdown のスリム化 — 指示のみに縮退、env 儀式の撤去 by @clonable-eden in #590
 * fix: PR #572 レビューの非ブロッキング指摘 5 件のフォローアップ by @clonable-eden in #592
 * feat: ADR-0018 実装 — claude CLI 契約層の確立(#591/#589 を契約内で修正) by @clonable-eden in #596
 * feat: Worker spawn 前の粗い permission preflight(ADR-0012 Amendment 4 層1) by @clonable-eden in #597
+* fix: Reviewer subagent grant を plugin モード対応に(namespace-agnostic) by @clonable-eden in #601
+* docs: --bg での worktree cleanup 発火ギャップを記録 (#602) by @clonable-eden in #603
+* docs: 2.0 --bg 移行で残った claude -p 記述の更新漏れを修正 by @clonable-eden in #605
 
 **Full Changelog**: https://github.com/clonable-eden/cekernel/compare/cekernel-v1.9.0...cekernel-v2.0.0

--- a/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
+++ b/docs/adr/0011-scheduled-trigger-via-os-native-schedulers.md
@@ -4,6 +4,14 @@
 
 Accepted
 
+> **Superseded in part by ADR-0016 (2.0.0)**: the spawn mechanism described
+> throughout this ADR — wrapper scripts invoking `claude -p` — was replaced by
+> `claude --bg` background sessions (`claude_bg_spawn` /
+> `claude_bg_wait_terminal`, ADR-0016 Phase 3). The scheduling architecture
+> (OS-native schedulers, registry, wrapper generation, log layout) remains
+> current. The `claude -p` references below are preserved as the historical
+> record of this decision.
+
 ## Context
 
 cekernel currently operates in a pull model — a human runs `/dispatch` or `/orchestrate` to trigger issue processing. There is no automated scheduling capability.

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -52,9 +52,10 @@ Known characteristics:
 Additionally (observed 2026-07-07, claude v2.1.201): **the harness may
 auto-detach a long-running foreground Bash call into a background task**
 even when the agent intended a blocking call. In `claude -p` execution this
-is fatal in combination with turn-end process exit: the agent believes it
+was fatal in combination with turn-end process exit: the agent believes it
 will be re-invoked on completion, ends its turn, and the process dies with
-its watchers (#558). Setting `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in
+its watchers (#558) — the failure class that motivated ADR-0016's move to
+`claude --bg`. Setting `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` in
 the spawned process's environment keeps Bash calls truly in the foreground.
 
 **Implications for cekernel**:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -215,7 +215,9 @@ $CEKERNEL_VAR_DIR/              # default: ~/.local/var/cekernel (user-specified
 `scripts/scheduler/wrapper.sh` generates runner scripts at `runners/<id>.sh`. Each wrapper:
 
 1. Sets `PATH` (registration-time snapshot)
-2. Executes `claude -p` with `if/else` pattern (`set -e` safe)
+2. Spawns a `claude --bg` background session via `claude_bg_spawn`, then polls
+   it to a terminal state with `claude_bg_wait_terminal` (ADR-0016 Phase 3;
+   `if/else` pattern, `set -e` safe)
 3. Updates registry status (`success` / `error`)
 4. Sends OS-native notification on failure (best-effort)
 


### PR DESCRIPTION
## 概要

リリース前整合性レビュー(#599)の指摘修正。release ブランチ向け。

## 変更

- **F1**: What's Changed に欠落していた **#601**(#600 の Reviewer grant fix)・**#603**・**#605** を追加(ADR 節が Amendment 5 / #600 fix に言及しているのに対応 PR 行が無い自己矛盾を解消)
- **F4**: #583 行の ADR-0018 → **ADR-0019**(PR タイトル自体を先に訂正済みなので「タイトルそのまま」規約は維持)
- **F5b**: Stop hook の検証文言を実態に正確化 — 検証したのは spawn-time `--plugin-dir` 経路であり、実 `/plugin install` 配布は未検証(#604 で追跡)
- 2.0-dev(#605 doc 修正)の release への取り込みを含む

Refs #599, #604