### PR TITLE
docs: Stop hook を実 marketplace install 検証済みに更新 (#604)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,10 +33,11 @@ the `1.9.x` line (see **Migration** below). Requires a recent Claude Code
 - **Worker lifecycle Stop hook (ADR-0019)**: a plugin `Stop` hook keeps a Worker
   session alive until `notify-complete.sh` records `TERMINATED`, closing the
   "Worker dies before its completion notification" gap. Live-verified to fire
-  in local self-hosting and in the spawn-time `--plugin-dir` plugin path (the
-  route cekernel itself uses to spawn sessions). Verification via an actual
-  `/plugin install` distribution is still open — tracked in
-  [#604](https://github.com/clonable-eden/cekernel/issues/604).
+  in local self-hosting, via spawn-time `--plugin-dir` (the route cekernel
+  itself uses to spawn sessions), **and from a real marketplace
+  `/plugin install`** — hooks auto-discovered from `hooks/hooks.json`, on
+  macOS and a Linux devcontainer
+  ([#604](https://github.com/clonable-eden/cekernel/issues/604)).
 - **/workflows boundary (ADR-0015)**: state that survives the session belongs to
   cekernel; in-session fan-out belongs to `/workflows` — documented usage guide.
 - **Conditional `--bare` (ADR-0016 Amendment 1)**: bare mode is now selected by

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -538,6 +538,27 @@ sessions under **both** local self-hosting and plugin-installed usage — the
 enabling signal is the spawn-time flag, not the parent's plugin/local namespace.
 See ADR-0019 Consequences.
 
+**Verified (2026-07-08, #604 — real marketplace install)**: hooks also work
+through the actual `/plugin install` distribution path, without any spawn-time
+flag. A local marketplace install of the v2.0.0 release content (cache copy
+under `~/.claude/plugins/cache/`) auto-discovered `hooks/hooks.json` **without
+a `hooks` key in `plugin.json`** (registered in interactive `/hooks`, fired in
+non-interactive `claude -p`), on macOS (v2.1.202) and a Linux devcontainer
+(v2.1.204). The cache copy preserved the guard script's executable bit; `jq`
+is the guard's runtime dependency (fail-open if absent). An explicit
+`plugin.json` `hooks` declaration is therefore unnecessary — and is the
+riskier option, since hook merge rules for a declared-plus-discovered default
+path are undocumented (double-registration risk).
+
+**Indicator caveat (v2.1.202+)**: `num_turns` in `--output-format json` no
+longer reflects Stop-hook continuations (it stays `1` even when the hook
+fires and the conversation continues — the 2026-07-07 experiment's
+`num_turns=13` was v2.1.201 behavior). Verify firing by the **result text**
+instead: a control run returns the prompted reply verbatim, a hook run
+returns a reply addressing the injected `additionalContext`. The documented
+cap of 8 consecutive Stop-hook continuations per turn boundary was observed
+live ("same as the previous seven times").
+
 **Implications for cekernel**:
 - cekernel-origin lifecycle hooks must ship in the plugin's `hooks/hooks.json`
   — cekernel passes `--plugin-dir <cekernel-root>` on every spawn branch


### PR DESCRIPTION
## 概要

#604 完了(実 `/plugin install` で hooks auto-discovery + `-p` 発火を macOS / Linux devcontainer で確認)を受けて、v2.0.0 notes の Stop hook 文言を「未検証・#604 追跡中」→「検証済み」に更新。

2.0-dev(#607 constraints doc 記録)の release への取り込みを含む。

Refs #604