### PR TITLE
feat: unix-architect — review モードに事実主張のコード突き合わせ検証を追加

### DIFF
--- a/skills/unix-architect/SKILL.md
+++ b/skills/unix-architect/SKILL.md
@@ -37,6 +37,14 @@ Identify the mode and subject. Read the referenced artifact (`gh issue view` / `
 
 Investigate the relevant codebase with `Glob`/`Grep`/`Read` (use `Task(Explore)` for broad exploration): existing patterns, conventions, constraints, and prior decisions that influence this one.
 
+When reviewing an ADR or design document, do not stop at pattern
+discovery: extract every factual claim the document makes about *current*
+behavior ("X writes Y first", "Z retains the log") and verify each
+against the code, citing file:line as evidence. A claim that is coherent
+within the document can still be false in the repository — internal-logic
+review cannot catch this class of error. Present the verification as a
+claim / verdict / evidence table in the review.
+
 ### Phase 4: Evaluate Through UNIX Principles
 
 Identify the **most relevant** principles (typically 3-5 — do NOT force-fit all 17). Assess alignment or tension with each; consider CS fundamentals (complexity, concurrency, failure modes, scalability); make trade-offs explicit — where principles conflict, acknowledge the tension and justify the choice.
@@ -82,6 +90,11 @@ Present the output in the conversation first, then ask where else to publish (mu
 3. **Conversation only**
 
 If the user requests changes, iterate and update all previously published destinations.
+
+When iterating on review feedback: text added or reworded in response to
+a review is *unreviewed* text. Before publishing the revision, re-verify
+any new factual claims it introduces (Phase 3 discipline applies to the
+delta, not just the original document).
 
 ## Guidelines
 


### PR DESCRIPTION
## 概要

ADR-0020(PR #610)のレビューで、3パスを経ても現行動作についての事実誤認が残存した問題(#611)への対応。`skills/unix-architect/SKILL.md` に2点追記する。

## 変更内容

- **Phase 3 (Analyze Current State)**: ADR/設計文書のレビュー時は、現行動作についての事実主張をすべて抽出し、file:line を根拠にコードと突き合わせる。検証結果は claim / verdict / evidence テーブルで提示する
- **Phase 7 (Present and Publish)**: レビュー指摘対応で加筆・改稿されたテキストは未レビュー扱いとし、改訂公開前に新規の事実主張を再検証する(Phase 3 の規律を差分にも適用)

## テスト

なし(skill 定義は非実行ファイルのため、CLAUDE.md のテスト方針によりテストは追加しない)

closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjxwmDrt59im6mT4VzqU37