### PR TITLE
docs: #595 — 層2は auto モード classifier(機序確定)

### DIFF
--- a/docs/adr/0012-worker-review-separation.md
+++ b/docs/adr/0012-worker-review-separation.md
@@ -537,6 +537,12 @@ permissions (it cannot: there is no platform query API, only bypass flags):
    claim is asserted. A minimal experiment (auto-mode vs non-auto
    supervisor → does the Worker's classifier behavior change?) is a
    verification item, foldable into #587.
+   *(Resolved by #595, 2026-07-08, v2.1.202: layer 2 is the `auto`-mode
+   classifier and runs only in `auto`. The Worker inherits `auto` from the
+   operator's `~/.claude/settings.json` `defaultMode` — not from headless
+   intrinsics. The classifier is intent-sensitive: it blocks the Worker's
+   *unrequested* escalations, not commands per se. See
+   `docs/claude-code-constraints.md` § Permission Model.)*
 3. **Worker keeps avoidance-first on denial.** On a classifier denial the
    Worker first attempts a workaround (as in `#543`, which fell back from
    `bats` to a `ruby` check and still reached ci-passed); only when no

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -604,13 +604,26 @@ outcomes must either try the action and observe, or coarsely inspect
 1. **settings.json allowlist** — `permissions.allow` in the target repo's
    `.claude/settings.json`. Depends on the *target repo* having one
    (`#543` passed normal Bash/Edit/Write/Read via `allow:[...]`).
-2. **Safety classifier** — a classifier still rejects dangerous patterns
-   even when layer 1 allows the tool broadly. Observed: `#543` had `bats`
-   (external-repo code) rejected as "[Code from External]"; `#593` had
-   `rm -rf /tmp/...` "denied". **The mechanism is unconfirmed** — whether
-   it is inherited from the spawning supervisor's auto mode, or is a
-   classifier intrinsic to headless sessions, is not yet distinguished
-   (an earlier spawn mix-up, #545, warns against asserting inheritance).
+2. **Safety classifier (`auto` mode only)** — in `auto` permission mode a
+   classifier reviews each action and blocks ones that escalate *beyond the
+   user's explicit request*: spawning unsandboxed agents
+   (`[Create Unsafe Agents]`), executing externally-sourced code
+   (`[Code from External]`), or routing around a prior block
+   (`[Auto-Mode Bypass]`). It is **intent-sensitive, not command-based** —
+   the identical command runs untouched when the prompt explicitly asks for
+   it. It does **not** run in `default` / `acceptEdits` / `dontAsk`.
+   Workers meet it because the operator's `~/.claude/settings.json`
+   `defaultMode: auto` reaches the `claude --bg` Worker (cekernel passes no
+   `--permission-mode`), so a Worker that spawns an agent or runs cloned
+   test code *on its own initiative* while resolving an issue is blocked.
+   Verified v2.1.202, 2026-07-08 (#595): 7 Worker transcripts (all `auto`,
+   explicit "auto mode classifier" denials) plus a mode×command matrix in
+   which the classifier fired in 0/12 cells — every probe command was
+   explicitly requested. Scope of what is confirmed: only `defaultMode:
+   auto` is observed to propagate to the `--bg` Worker here. Whether a
+   *runtime* mode toggle propagates is untested; and `defaultMode:
+   bypassPermissions` is reported *not* to reach background sessions
+   (anthropics/claude-code#59112, v2.1.141 — unre-verified on 2.1.202).
 3. **blocked / denied** — when layers 1–2 are not satisfied, the session
    either stalls silently on a permission dialog (`blocked`) or the tool
    returns a denial the agent must handle.
@@ -624,8 +637,13 @@ outcomes must either try the action and observe, or coarsely inspect
 - cekernel delegates permission configuration to the target repository
   (separation of authority) — and cannot reimplement the resolution engine
   (no query API). See ADR-0012 Amendment 4.
-- Layer 2 is outside cekernel's control; its mechanism is Evolving and
-  should be re-verified (supervisor-auto-mode vs headless-intrinsic).
+- Layer 2 is the `auto`-mode classifier and exists only in `auto`. It comes
+  from the operator's setting (`defaultMode`), inherited by the Worker — not
+  intrinsic to headless sessions (#595 disproved the headless-intrinsic
+  hypothesis). cekernel does not override the mode (separation of authority,
+  ADR-0012 Amendment 4); mode selection is the operator's. Still Evolving:
+  platform behavior is version-specific (cf. #59112) and should be
+  re-verified as the CLI changes.
 
 ## Concurrency and Multi-Session
 


### PR DESCRIPTION
## 概要
research issue #595(完了検知とは別件の permission 調査)の結論を記録する。ADR-0012 Amendment 4 と constraints doc が「未確定」としていた層2 classifier の機序を確定した。

closes #595

## 結論(事実)
- 層2の拒否(`bats` の `[Code from External]`、`claude --bg` の `[Create Unsafe Agents]`)は **auto モードの classifier**。**auto モードでのみ存在**する
- Worker が auto なのは、operator の `~/.claude/settings.json` の `defaultMode: auto` が `claude --bg` Worker に伝播するため(cekernel は `--permission-mode` を渡さない)。**headless 固有ではない**
- classifier は **意図単位**(コマンド単位でない)。Worker の**独断の逸脱**を止める。明示的に頼まれた行為は auto でも通る

## 根拠(v2.1.202, 2026-07-08)
- **記録調査**: 実 Worker transcript 7件 — 全て auto モード、明示的な "auto mode classifier" 拒否
- **マトリクス**: mode(default/acceptEdits/dontAsk/auto)× command(ctrl/destroy/spawn)で、classifier は **12セル中0発火**(全 probe が明示要求だったため)。両方を合わせて初めて「auto 限定 かつ 意図単位」が言える

## 正直な限界(断定しない)
- 確認できたのは `defaultMode: auto` の伝播のみ
- **runtime のモード切替(shift+tab)の伝播は未検証**
- `defaultMode: bypassPermissions` は bg に伝播しないとの報告あり(anthropics/claude-code#59112, v2.1.141)。2.1.202 では未再検証。バージョン注記つきで記載
- #545 の戒め(継承の断定回避)に従い、二次情報は検証済みのものだけ引用

## 変更
- `docs/claude-code-constraints.md` § Permission Model 層2 + Implications
- `docs/adr/0012-worker-review-separation.md` Amendment 4 Decision 2 に解決注記

## やらないこと
- Worker への `--permission-mode` 強制(operator の権限選択を奪う。Amendment 4 の中立原則に反する)
- runtime モード追従(実現可能性未確認・不要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjxwmDrt59im6mT4VzqU37