### PR TITLE
fix: gc lock/log reap respects v2 opaque session tokens (#619)

### DIFF
--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../shared/load-env.sh"
+source "${SCRIPT_DIR}/../shared/issue-lock.sh"
 source "${SCRIPT_DIR}/../shared/worker-state.sh"
 source "${SCRIPT_DIR}/../shared/worker-priority.sh"
 source "${SCRIPT_DIR}/../shared/checkpoint-file.sh"
@@ -865,7 +866,10 @@ cmd_gc() {
         if [[ -f "$pid_file" ]]; then
           local holder_pid
           holder_pid=$(cat "$pid_file")
-          if ! kill -0 "$holder_pid" 2>/dev/null; then
+          # Delegate to _issue_lock_holder_alive (issue-lock.sh):
+          # numeric holders use kill -0, opaque session tokens (v2,
+          # ADR-0016) use claude_bg_token_verdict (ADR-0018).
+          if ! _issue_lock_holder_alive "$holder_pid"; then
             is_stale=1
           fi
         else
@@ -990,9 +994,11 @@ cmd_gc() {
       _gc_clean_orphan_files "$session_dir" "pane-*.*"     "pane-"    "pane"
       _gc_clean_orphan_files "$session_dir" "payload-*.b64" "payload-" "payload"
 
-      # Log files live in a subdirectory
+      # Log files live in a subdirectory.
+      # sdir must be session_dir (not session_dir/logs/) so the grep key
+      # matches active_issues entries ("session_dir:issue").  (#619 Bug 2)
       if [[ -d "${session_dir}logs" ]]; then
-        _gc_clean_orphan_files "${session_dir}logs/" "worker-*" "worker-" "log"
+        _gc_clean_orphan_files "${session_dir}" "logs/worker-*" "worker-" "log"
 
         if [[ "$dry_run" -eq 0 ]]; then
           rmdir "${session_dir}logs" 2>/dev/null || true

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -566,3 +566,59 @@ worker_state() {
   run bash "$ORCHCTL" gc
   assert_not_exists "legacy pid file swept" "${session_dir}/orchestrator.pid"
 }
+
+# ── gc: v2 lock liveness — opaque session token holders (#619 Bug 1) ──
+# v2 (ADR-0016) writes a session UUID as the lock holder. gc must delegate
+# to _issue_lock_holder_alive (which uses claude_bg_token_verdict) instead
+# of calling kill -0 directly — kill -0 always fails on non-numeric strings.
+
+@test "gc preserves lock with opaque session token holder when session is alive" {
+  mock_claude
+  local lock_dir="${CEKERNEL_VAR_DIR}/locks/testhash619/619.lock"
+  mkdir -p "$lock_dir"
+  echo "$SESSION_TOKEN" > "${lock_dir}/pid"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$SESSION_TOKEN" background /tmp/wt 1700000000000 busy)]"
+  run bash "$ORCHCTL" gc
+  assert_dir_exists "live token-holder lock preserved" "$lock_dir"
+}
+
+@test "gc removes lock with opaque session token holder when session is dead" {
+  mock_claude
+  local lock_dir="${CEKERNEL_VAR_DIR}/locks/testhash619/620.lock"
+  mkdir -p "$lock_dir"
+  echo "$SESSION_TOKEN" > "${lock_dir}/pid"
+  # empty agents queue → [] → session not listed → dead
+  run bash "$ORCHCTL" gc
+  assert_not_exists "dead token-holder lock removed" "$lock_dir"
+}
+
+@test "gc preserves lock with opaque session token when agents query fails (refuse-on-doubt)" {
+  local lock_dir="${CEKERNEL_VAR_DIR}/locks/testhash619/621.lock"
+  mkdir -p "$lock_dir"
+  echo "$SESSION_TOKEN" > "${lock_dir}/pid"
+  mock_bin claude 'exit 1'
+  run bash "$ORCHCTL" gc
+  assert_dir_exists "lock preserved on query failure" "$lock_dir"
+}
+
+# ── gc: orphan-log key mismatch (#619 Bug 2) ──
+# active_issues records "session_dir:issue" but the log orphan check was
+# passing "session_dir/logs/" as sdir, producing "session_dir/logs/:issue"
+# which never matches — making all logs appear orphan.
+
+@test "gc preserves log files of active workers" {
+  mock_claude
+  local session_dir="${IPC_BASE}/session-gc-log619"
+  mkdir -p "${session_dir}/logs"
+  # Create an active worker (FIFO + live handle)
+  mkfifo "${session_dir}/worker-622"
+  echo "RUNNING:2026-02-28T10:00:00Z:working" > "${session_dir}/worker-622.state"
+  echo "$$" > "${session_dir}/handle-622.worker"
+  # Create log files for the active worker
+  echo "log data" > "${session_dir}/logs/worker-622.log"
+  echo "stdout data" > "${session_dir}/logs/worker-622.stdout.log"
+  run bash "$ORCHCTL" gc
+  assert_file_exists "active worker log preserved" "${session_dir}/logs/worker-622.log"
+  assert_file_exists "active worker stdout log preserved" "${session_dir}/logs/worker-622.stdout.log"
+}


### PR DESCRIPTION
## Summary
- **Bug 1**: `orchctl gc` の lock sweep が `kill -0` を直接呼んでいたため、v2 (ADR-0016) のセッション UUID holder を常に stale 判定していた。`_issue_lock_holder_alive` (issue-lock.sh) に委譲して ADR-0018 準拠に修正
- **Bug 2**: orphan-log 突合のキーが `${session_dir}logs/:${issue}` となり active_issues (`${session_dir}:${issue}`) と不一致だった。sdir を `${session_dir}` に修正

closes #619

## Test plan
- [x] Bug 1: alive session token → lock preserved
- [x] Bug 1: dead session token → lock removed
- [x] Bug 1: agents query failure → lock preserved (refuse-on-doubt)
- [x] Bug 2: active worker log → preserved
- [x] 既存 gc テスト 27件 全パス (regression なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)