### PR TITLE
refactor: ADR-0020 Phase 1 — 状態ファイルベースの slot 会計 + reaper/resolver/orchestrator 配線

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -217,7 +217,17 @@ source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <i
 
 ## Error Handling
 
-- **Worker unresponsive or timeout** (`watch.sh` returns `timeout`): `send-signal.sh <issue> TERM` → `sleep ${CEKERNEL_TERM_GRACE_PERIOD:-120}` → `health-check.sh <issue>` → if still alive, `cleanup-worktree.sh --force <issue>`
+- **Worker unresponsive or timeout** (`watch.sh` returns `timeout`): `send-signal.sh <issue> TERM` → `sleep ${CEKERNEL_TERM_GRACE_PERIOD:-120}` → `health-check.sh <issue>`:
+  - Worker still alive → `cleanup-worktree.sh --force <issue>` (kills the session)
+  - Worker dead (TERM succeeded but no FIFO notification) → `cleanup-worktree.sh <issue>` (plain cleanup; the reaper writes the exit record for non-TERMINATED state — ADR-0020 Phase 1)
+- **Worker blocked** (`watch.sh` returns `blocked`): the Worker session is stalled on a permission dialog that nobody can approve headless. `watch.sh` has already written the terminal record (`TERMINATED:blocked`). Stop the session and clean up:
+
+```bash
+# blocked handler: session stop + cleanup (ADR-0020 Phase 1)
+cleanup-worktree.sh <issue>
+source desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> blocked (permission dialog)" ""
+source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
+```
 - **Zombie / hang diagnosis**: `health-check.sh [issue]`; lifecycle logs live in `${CEKERNEL_IPC_DIR}/logs/` (`watch-logs.sh [issue]`) — a long-silent log suggests a hang
 - **CI failure**: the Worker retries up to `CEKERNEL_CI_MAX_RETRIES`, then reports `failed` — escalate to human
 - **Reviewer failure** (API outage, Agent tool error, `failed`, unrecognized line): treat as escalation (above)

--- a/envs/README.md
+++ b/envs/README.md
@@ -12,6 +12,8 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_MAX_ORCHESTRATORS` | `3` | Positive integer | `dispatch`, `orchestrate` | Maximum number of concurrently running orchestrators |
 | `CEKERNEL_MAX_ORCH_CHILDREN` | `5` | Positive integer | `spawn.sh` | Maximum concurrent children (workers + reviewers) per orchestrator |
 | `CEKERNEL_WORKER_TIMEOUT` | `3600` | Positive integer (seconds) | `watch.sh` | Worker timeout before auto-termination |
+| `CEKERNEL_STATE_POLL_INTERVAL` | `5` | Positive integer (seconds) | `watch.sh` | State file poll interval (local fs read — cheap). Completion latency is bounded by this value (ADR-0020 Phase 1: polling split) |
+| `CEKERNEL_POLL_INTERVAL` | `30` | Positive integer (seconds) | `watch.sh` | Backend verdict poll interval (`claude agents --json` — spawns a process, heavier). Controls how often `watch.sh` checks backend liveness (ADR-0020 Phase 1: polling split) |
 | `CEKERNEL_WATCH_QUERY_RETRY_MAX` | `3` | Positive integer | `watch.sh` | Consecutive unverifiable liveness polls (`query-failed` / `unknown-value` verdicts, ADR-0018) tolerated before watch escalates an `error` result. The escalation detail warns the Worker may still be running — do not clean up on this result alone |
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Any filename | `checkpoint-file.sh` | Checkpoint file name in worktree |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Any filename | `task-file.sh` | Task file name in worktree |

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -87,9 +87,12 @@ resolve_target() {
   fi
 
   # If --session given, use it directly
+  # ADR-0020 Phase 1: resolve by state file existence (not FIFO).
+  # A state file is written unconditionally at spawn; this makes
+  # pipe-less held slots addressable by recover/kill.
   if [[ -n "$session_filter" ]]; then
     local ipc_dir="${IPC_BASE}/${session_filter}"
-    if [[ -p "${ipc_dir}/worker-${issue}" ]]; then
+    if [[ -f "${ipc_dir}/worker-${issue}.state" ]]; then
       RESOLVED_SESSION="$session_filter"
       RESOLVED_ISSUE="$issue"
       return 0
@@ -118,7 +121,7 @@ resolve_target() {
         [[ "$sid_repo" == "$repo_prefix" ]] || continue
       fi
 
-      if [[ -p "${session_dir}worker-${issue}" ]]; then
+      if [[ -f "${session_dir}worker-${issue}.state" ]]; then
         matches+=("${sid}:${issue}")
       fi
     done
@@ -624,8 +627,17 @@ cmd_kill() {
     rm -f "$pane_file"
   done
 
-  # Mark as terminated
-  worker_state_write "$RESOLVED_ISSUE" TERMINATED "killed"
+  # ADR-0020 Phase 1: write-once guard — do not overwrite an existing
+  # TERMINATED record. An operator killing an already-completed Worker
+  # (TERMINATED:ci-passed, review pending) must not relabel the completion,
+  # which would strand the issue non-resumable and erase the PR detail.
+  # The session stop above stays unconditional (a no-op on a finished session).
+  local kill_state_json kill_current_state
+  kill_state_json=$(worker_state_read "$RESOLVED_ISSUE")
+  kill_current_state=$(echo "$kill_state_json" | jq -r '.state')
+  if [[ "$kill_current_state" != "TERMINATED" ]]; then
+    worker_state_write "$RESOLVED_ISSUE" TERMINATED "killed"
+  fi
   echo "Worker #${RESOLVED_ISSUE} killed." >&2
 }
 
@@ -819,10 +831,11 @@ cmd_gc() {
     return 0
   }
 
-  # ── 1. Collect active issues (FIFOs across all sessions) ──
+  # ── 1. Collect active issues (FIFOs + non-TERMINATED state across all sessions) ──
   # Build a set of active issue numbers per session for orphan detection.
-  # FIFOs are checked for staleness: if the process is dead or state is
-  # TERMINATED, the FIFO is removed and not added to active_issues.
+  # ADR-0020 Phase 1: non-TERMINATED state files mark the issue active
+  # (held slot), regardless of FIFO existence.
+  # FIFOs are still checked for staleness (Phase 3 will remove FIFO create).
   # Uses a temp file instead of declare -A for bash 3.2 compatibility.
   local active_issues_file
   active_issues_file=$(mktemp /tmp/cekernel-gc-active.XXXXXX)
@@ -830,6 +843,23 @@ cmd_gc() {
   if [[ -d "$IPC_BASE" ]]; then
     for session_dir in "$IPC_BASE"/*/; do
       [[ -d "$session_dir" ]] || continue
+
+      # ADR-0020: scan state files for non-TERMINATED (held slot protection)
+      for state_file in "$session_dir"worker-*.state; do
+        [[ -f "$state_file" ]] || continue
+        local sf_name sf_issue sf_state
+        sf_name=$(basename "$state_file")
+        sf_issue="${sf_name#worker-}"
+        sf_issue="${sf_issue%.state}"
+        sf_state="UNKNOWN"
+        local sf_line
+        sf_line=$(cat "$state_file")
+        sf_state="${sf_line%%:*}"
+        if [[ "$sf_state" != "TERMINATED" ]]; then
+          echo "${session_dir}:${sf_issue}" >> "$active_issues_file"
+        fi
+      done
+
       for fifo in "$session_dir"worker-*; do
         [[ -p "$fifo" ]] || continue
         local fname
@@ -848,7 +878,10 @@ cmd_gc() {
           fi
           cleaned=$((cleaned + 1))
         else
-          echo "${session_dir}:${issue}" >> "$active_issues_file"
+          # Add to active_issues if not already present (from state file scan)
+          if ! grep -qxF "${session_dir}:${issue}" "$active_issues_file" 2>/dev/null; then
+            echo "${session_dir}:${issue}" >> "$active_issues_file"
+          fi
         fi
       done
     done

--- a/scripts/orchestrator/cleanup-worktree.sh
+++ b/scripts/orchestrator/cleanup-worktree.sh
@@ -7,9 +7,12 @@
 # or kills process group for headless backend).
 #
 # CEKERNEL_KEEP_WORKTREE=true preserves the worktree and local branch while
-# still killing the Worker and cleaning IPC resources (FIFOs are removed so
-# concurrency slots do not leak). --force always removes the worktree,
-# ignoring CEKERNEL_KEEP_WORKTREE (zombie recovery must free the worktree).
+# still killing the Worker and cleaning IPC resources. Concurrency slots
+# are freed by deleting the state file (ADR-0020 Phase 1). --force always
+# removes the worktree, ignoring CEKERNEL_KEEP_WORKTREE (zombie recovery
+# must free the worktree).
+# ADR-0020: non-TERMINATED state is logged (REAP_EXIT) before deletion;
+# lifecycle logs are retained (gc handles orphan log cleanup).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/orchestrator/cleanup-worktree.sh
+++ b/scripts/orchestrator/cleanup-worktree.sh
@@ -74,6 +74,23 @@ else
   fi
 fi
 
+# ADR-0020 Phase 1: reaper semantics — if state is non-TERMINATED,
+# append the exit event to the lifecycle log before deleting the state
+# file (so the record survives to gc's orphan sweep).
+# TERMINATED entries need no exit record (the Worker already wrote it).
+_REAP_STATE="TERMINATED"
+_REAP_STATE_FILE="${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.state"
+if [[ -f "$_REAP_STATE_FILE" ]]; then
+  _REAP_LINE=$(cat "$_REAP_STATE_FILE")
+  _REAP_STATE="${_REAP_LINE%%:*}"
+fi
+if [[ "$_REAP_STATE" != "TERMINATED" ]]; then
+  _REAP_LOG="${CEKERNEL_IPC_DIR}/logs/worker-${ISSUE_NUMBER}.log"
+  if [[ -d "${CEKERNEL_IPC_DIR}/logs" ]]; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] REAP_EXIT issue=#${ISSUE_NUMBER} state=${_REAP_STATE}" >> "$_REAP_LOG"
+  fi
+fi
+
 # FIFO cleanup (session-scoped)
 rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}"
 # State file cleanup
@@ -94,9 +111,10 @@ rm -f "${CEKERNEL_IPC_DIR}/worker-${ISSUE_NUMBER}.priority"
 # Payload file cleanup (wezterm backend: avoids send-text 1024-byte limit)
 rm -f "${CEKERNEL_IPC_DIR}/payload-${ISSUE_NUMBER}.b64"
 
-# Log file cleanup
-rm -f "${CEKERNEL_IPC_DIR}/logs/worker-${ISSUE_NUMBER}.log"
-# Remove empty logs directory
+# ADR-0020 Phase 1: lifecycle log is RETAINED (no longer deleted).
+# The record survives to gc's orphan sweep and post-mortem analysis.
+# gc removes orphan logs whose Worker is no longer active.
+# Remove empty logs directory only (safe: won't remove if log files remain)
 rmdir "${CEKERNEL_IPC_DIR}/logs" 2>/dev/null || true
 
 # Remove empty session directory

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -71,7 +71,19 @@ AGENT_NAME="${!AGENT_VAR:-$AGENT_TYPE}"
 MAX_ORCH_CHILDREN="${CEKERNEL_MAX_ORCH_CHILDREN:-5}"
 
 active_worker_count() {
-  find "$CEKERNEL_IPC_DIR" -maxdepth 1 -name 'worker-*' -type p 2>/dev/null | wc -l | tr -d ' '
+  # ADR-0020 Phase 1: count non-TERMINATED state files (not pipes).
+  # A Worker holds a slot while its state is not TERMINATED.
+  local count=0
+  for sf in "$CEKERNEL_IPC_DIR"/worker-*.state; do
+    [[ -f "$sf" ]] || continue
+    local line
+    line=$(cat "$sf")
+    local state="${line%%:*}"
+    if [[ "$state" != "TERMINATED" ]]; then
+      count=$((count + 1))
+    fi
+  done
+  echo "$count"
 }
 
 mkdir -p "$CEKERNEL_IPC_DIR"

--- a/scripts/orchestrator/spawn.sh
+++ b/scripts/orchestrator/spawn.sh
@@ -4,7 +4,7 @@
 # Usage: spawn.sh --agent <type> [--resume] [--priority <priority>] [--repo <owner/repo>] [--fallback-model <model>] <issue-number> [base-branch]
 #   type:     Process type (e.g., worker)
 #   priority: critical|high|normal|low or numeric 0-19 (default: normal)
-# Output: FIFO path (stdout last line)
+# Output: FIFO path (stdout last line; ADR-0020 Phase 3 will remove this)
 # Options:
 #   --agent           Process type to spawn (required)
 #   --resume          Resume a suspended process (reuse existing worktree)

--- a/scripts/orchestrator/watch.sh
+++ b/scripts/orchestrator/watch.sh
@@ -5,14 +5,15 @@
 #
 # Environment:
 #   CEKERNEL_WORKER_TIMEOUT — Process timeout in seconds (default: 3600)
-#   CEKERNEL_POLL_INTERVAL  — State file poll interval in seconds (default: 30)
+#   CEKERNEL_STATE_POLL_INTERVAL — State file poll interval in seconds (default: 5)
+#   CEKERNEL_POLL_INTERVAL  — Backend verdict poll interval in seconds (default: 30)
 #   CEKERNEL_WATCH_QUERY_RETRY_MAX — Consecutive unverifiable polls
 #     (query-failed / unknown-value) tolerated before escalating an
 #     "error" result (default: 3; ADR-0018 degradation policy)
 #
 # Monitors each process via triple-path detection:
 #   1. FIFO (primary, sub-second latency)
-#   2. State file polling (fallback, up to POLL_INTERVAL latency)
+#   2. State file polling (fallback, up to STATE_POLL_INTERVAL latency)
 #   3. Process crash detection (backend verdict, ADR-0018);
 #      blocked sessions (permission-dialog stall) are surfaced as a
 #      distinct "blocked" result (ADR-0016)
@@ -32,6 +33,7 @@ FIFO_DIR="$CEKERNEL_IPC_DIR"
 RESULT_DIR=$(mktemp -d)
 PIDS=()
 TIMEOUT="${CEKERNEL_WORKER_TIMEOUT:-3600}"
+STATE_POLL_INTERVAL="${CEKERNEL_STATE_POLL_INTERVAL:-5}"
 POLL_INTERVAL="${CEKERNEL_POLL_INTERVAL:-30}"
 QUERY_RETRY_MAX="${CEKERNEL_WATCH_QUERY_RETRY_MAX:-3}"
 
@@ -63,22 +65,27 @@ watch_one() {
   local elapsed=0
   local query_failures=0
 
-  log_event "$issue" "FIFO_WATCH_START" "issue=#${issue} timeout=${TIMEOUT} poll_interval=${POLL_INTERVAL}"
+  log_event "$issue" "FIFO_WATCH_START" "issue=#${issue} timeout=${TIMEOUT} state_poll=${STATE_POLL_INTERVAL} backend_poll=${POLL_INTERVAL}"
 
   # If FIFO exists, open it. If not, fall through to state-only polling.
   if [[ -p "$fifo" ]]; then
     exec 3<>"$fifo"
-    echo "Watching issue #${issue} (timeout: ${TIMEOUT}s, poll: ${POLL_INTERVAL}s)..." >&2
+    echo "Watching issue #${issue} (timeout: ${TIMEOUT}s, state_poll: ${STATE_POLL_INTERVAL}s, backend_poll: ${POLL_INTERVAL}s)..." >&2
   else
     has_fifo=0
     echo "Warning: FIFO not found for issue #${issue}. Falling back to state file polling." >&2
     log_event "$issue" "FIFO_MISSING" "issue=#${issue} path=${fifo}"
   fi
 
+  # ADR-0020 Phase 1: polling split — state at STATE_POLL_INTERVAL (5s),
+  # backend verdict at POLL_INTERVAL (30s). Track when the next backend
+  # check is due.
+  local next_backend_check=$POLL_INTERVAL
+
   while [[ $elapsed -lt $TIMEOUT ]]; do
     # Clamp wait time to remaining budget
     local remaining=$((TIMEOUT - elapsed))
-    local wait_time=$POLL_INTERVAL
+    local wait_time=$STATE_POLL_INTERVAL
     [[ $remaining -lt $wait_time ]] && wait_time=$remaining
 
     # Primary: FIFO read (only if FIFO was available)
@@ -94,7 +101,9 @@ watch_one() {
       sleep "$wait_time"
     fi
 
-    # Fallback: check state file
+    elapsed=$((elapsed + wait_time))
+
+    # Fallback: check state file (every STATE_POLL_INTERVAL)
     local state_json
     state_json=$(worker_state_read "$issue")
     local state
@@ -107,6 +116,12 @@ watch_one() {
       rm -f "$fifo"
       break
     fi
+
+    # Backend verdict check: only at POLL_INTERVAL cadence
+    if [[ $elapsed -lt $next_backend_check ]]; then
+      continue
+    fi
+    next_backend_check=$((elapsed + POLL_INTERVAL))
 
     # Crash/blocked detection: only when a handle file is present (without
     # it, we can't verify the worker). The backend reports the ADR-0018
@@ -133,6 +148,20 @@ watch_one() {
             ;;
           blocked)
             query_failures=0
+            # ADR-0020 Phase 1: write-once — re-read state before writing.
+            # If already TERMINATED, the Worker completed just before the
+            # backend reported blocked; consume the existing record.
+            state_json=$(worker_state_read "$issue")
+            state=$(echo "$state_json" | jq -r '.state')
+            if [[ "$state" == "TERMINATED" ]]; then
+              result=$(build_result_from_state "$state_json")
+              log_event "$issue" "STATE_FALLBACK" "issue=#${issue} state=TERMINATED (write-once, before blocked write)"
+              [[ $has_fifo -eq 1 ]] && exec 3>&-
+              rm -f "$fifo"
+              break
+            fi
+            # ADR-0020: write TERMINATED for blocked (terminal by policy)
+            worker_state_write "$issue" TERMINATED "blocked:Worker session is waiting on a permission dialog"
             result="{\"issue\":${issue},\"result\":\"blocked\",\"detail\":\"Worker session is waiting on a permission dialog\"}"
             echo "Error: issue #${issue} Worker session is blocked (permission dialog)." >&2
             log_event "$issue" "WORKER_BLOCKED" "issue=#${issue} state=${state}"
@@ -142,6 +171,7 @@ watch_one() {
             ;;
           query-failed|unknown-value)
             # Unverifiable — retry, escalate when persistent.
+            # ADR-0020: no TERMINATED write (slot held on doubt)
             query_failures=$((query_failures + 1))
             if [[ "$query_failures" -ge "$QUERY_RETRY_MAX" ]]; then
               result="{\"issue\":${issue},\"result\":\"error\",\"detail\":\"agents query unverifiable (${wstatus}) for ${query_failures} consecutive polls — worker may still be running, do not clean up on this result alone\"}"
@@ -164,6 +194,21 @@ watch_one() {
         worker_dead=1
       fi
       if [[ "$worker_dead" -eq 1 ]]; then
+        # ADR-0020 Phase 1: write-once — re-read state before writing.
+        # If already TERMINATED, the Worker completed just before the
+        # backend reported dead; consume the existing record instead of
+        # overwriting with crashed.
+        state_json=$(worker_state_read "$issue")
+        state=$(echo "$state_json" | jq -r '.state')
+        if [[ "$state" == "TERMINATED" ]]; then
+          result=$(build_result_from_state "$state_json")
+          log_event "$issue" "STATE_FALLBACK" "issue=#${issue} state=TERMINATED (write-once, before crashed write)"
+          [[ $has_fifo -eq 1 ]] && exec 3>&-
+          rm -f "$fifo"
+          break
+        fi
+        # ADR-0020: write TERMINATED for crashed exit
+        worker_state_write "$issue" TERMINATED "crashed:${worker_detail}"
         result="{\"issue\":${issue},\"result\":\"crashed\",\"detail\":\"${worker_detail}\"}"
         echo "Error: issue #${issue} Worker process crashed (state: ${state})." >&2
         log_event "$issue" "WORKER_CRASH" "issue=#${issue} state=${state}"
@@ -172,11 +217,10 @@ watch_one() {
         break
       fi
     fi
-
-    elapsed=$((elapsed + wait_time))
   done
 
   # Timeout: neither FIFO nor state file indicated completion
+  # ADR-0020: no TERMINATED write for timeout (slot held — on doubt, refuse to free)
   if [[ -z "$result" ]]; then
     [[ $has_fifo -eq 1 ]] && exec 3>&-
     rm -f "$fifo"

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -370,7 +370,7 @@ worker_state() {
   assert_not_exists "priority removed" "${session_dir}/worker-296.priority"
 }
 
-@test "gc removes stale FIFO when NEW + no handle + past stale timeout" {
+@test "gc removes stale FIFO when NEW + no handle + past stale timeout (state held)" {
   local session_dir="${IPC_BASE}/session-gc-stale2"
   mkdir -p "$session_dir"
   mkfifo "${session_dir}/worker-297"
@@ -378,11 +378,14 @@ worker_state() {
   echo "worker" > "${session_dir}/worker-297.type"
   run env CEKERNEL_GC_STALE_TIMEOUT=0 bash "$ORCHCTL" gc
   assert_not_exists "stale NEW FIFO removed" "${session_dir}/worker-297"
-  assert_not_exists "state removed" "${session_dir}/worker-297.state"
-  assert_not_exists "type removed" "${session_dir}/worker-297.type"
+  # ADR-0020 Phase 1: non-TERMINATED state files hold the slot — gc does
+  # not remove them. The slot is freed by `orchctl recover` or Phase 2's gc
+  # TERMINATED write.
+  assert_file_exists "state held (non-TERMINATED)" "${session_dir}/worker-297.state"
+  assert_file_exists "type held" "${session_dir}/worker-297.type"
 }
 
-@test "gc removes stale FIFO with dead handle PID" {
+@test "gc removes stale FIFO with dead handle PID (state held)" {
   local session_dir="${IPC_BASE}/session-gc-stale3"
   mkdir -p "$session_dir"
   mkfifo "${session_dir}/worker-298"
@@ -391,8 +394,11 @@ worker_state() {
   echo "99999999" > "${session_dir}/handle-298.worker"
   run bash "$ORCHCTL" gc
   assert_not_exists "stale FIFO removed" "${session_dir}/worker-298"
-  assert_not_exists "state removed" "${session_dir}/worker-298.state"
-  assert_not_exists "dead handle removed" "${session_dir}/handle-298.worker"
+  # ADR-0020 Phase 1: non-TERMINATED state holds the slot and all
+  # companion files (handle included). The held slot is addressed by
+  # `orchctl recover` or Phase 2's gc TERMINATED write.
+  assert_file_exists "state held (non-TERMINATED)" "${session_dir}/worker-298.state"
+  assert_file_exists "handle held (companion of held slot)" "${session_dir}/handle-298.worker"
 }
 
 @test "gc preserves FIFO with live handle" {
@@ -413,7 +419,7 @@ worker_state() {
 # `claude agents --json` instead of assuming they are always alive.
 # A failed query stays conservative (assume alive — never gc on doubt).
 
-@test "gc removes stale FIFO when the token handle session is not listed" {
+@test "gc removes stale FIFO when the token handle session is not listed (state held)" {
   mock_claude
   local session_dir="${IPC_BASE}/session-gc-token1"
   mkdir -p "$session_dir"
@@ -424,8 +430,9 @@ worker_state() {
   # empty agents queue → [] → session not listed → dead
   run bash "$ORCHCTL" gc
   assert_not_exists "stale FIFO removed" "${session_dir}/worker-573"
-  assert_not_exists "state removed" "${session_dir}/worker-573.state"
-  assert_not_exists "dead token handle removed" "${session_dir}/handle-573.worker"
+  # ADR-0020 Phase 1: non-TERMINATED state holds the slot and all companion files
+  assert_file_exists "state held (non-TERMINATED)" "${session_dir}/worker-573.state"
+  assert_file_exists "handle held (companion of held slot)" "${session_dir}/handle-573.worker"
 }
 
 @test "gc preserves FIFO when the token handle session is busy" {

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -56,6 +56,20 @@ worker_state() {
   cat "${IPC}/worker-${1}.state"
 }
 
+# ── ADR-0020 Phase 1: resolve_target uses state file, not FIFO ──
+
+@test "resolve_target finds worker by state file (no FIFO needed)" {
+  mkdir -p "$IPC"
+  # Create state file but NO FIFO
+  echo "RUNNING:2026-02-28T10:00:00Z:phase1:implement" > "${IPC}/worker-10.state"
+  echo "10" > "${IPC}/worker-10.priority"
+
+  # term should find the worker via state file
+  run bash "$ORCHCTL" term 10 --session "$SESSION"
+  assert_eq "term exits 0 (worker found via state)" "0" "$status"
+  assert_file_exists "signal file created" "${IPC}/worker-10.signal"
+}
+
 # ── term ──
 
 @test "term creates TERM signal file" {
@@ -176,6 +190,16 @@ worker_state() {
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
   assert_match "tmux window killed" "kill-window -t my-session:1" \
     "$(cat "${BATS_TEST_TMPDIR}/tmux-argv.log")"
+}
+
+# ── ADR-0020 Phase 1: kill write-once guard ──
+
+@test "kill does NOT overwrite existing TERMINATED state (write-once)" {
+  make_worker 10 "TERMINATED:2026-02-28T10:00:00Z:ci-passed:55"
+  run bash "$ORCHCTL" kill 10 --session "$SESSION"
+  assert_eq "kill exits 0" "0" "$status"
+  # State must still be ci-passed:55, NOT killed
+  assert_match "state preserved as ci-passed" "ci-passed:55" "$(worker_state 10)"
 }
 
 @test "kill stops a wezterm-backend session AND kills the pane (Phase 5 contract)" {
@@ -606,6 +630,34 @@ worker_state() {
 # active_issues records "session_dir:issue" but the log orphan check was
 # passing "session_dir/logs/" as sdir, producing "session_dir/logs/:issue"
 # which never matches — making all logs appear orphan.
+
+# ── ADR-0020 Phase 1: gc orphan-sweep protection key ──
+# Non-TERMINATED state files protect the issue from gc orphan sweep,
+# regardless of FIFO existence. This ensures held slots survive gc.
+
+@test "gc preserves non-TERMINATED state files (held slot survives gc)" {
+  local session_dir="${IPC_BASE}/session-gc-held"
+  mkdir -p "$session_dir"
+  # No FIFO, but non-TERMINATED state → held slot, must survive
+  echo "RUNNING:2026-02-28T10:00:00Z:phase1:implement" > "${session_dir}/worker-710.state"
+  echo "10" > "${session_dir}/worker-710.priority"
+  echo "worker" > "${session_dir}/worker-710.type"
+  run bash "$ORCHCTL" gc
+  assert_file_exists "held slot state preserved" "${session_dir}/worker-710.state"
+  assert_file_exists "held slot priority preserved" "${session_dir}/worker-710.priority"
+  assert_file_exists "held slot type preserved" "${session_dir}/worker-710.type"
+}
+
+@test "gc removes TERMINATED state files without FIFO (orphan cleanup)" {
+  local session_dir="${IPC_BASE}/session-gc-orphterm"
+  mkdir -p "$session_dir"
+  # TERMINATED state, no FIFO → orphan, should be cleaned
+  echo "TERMINATED:2026-02-28T10:00:00Z:ci-passed:99" > "${session_dir}/worker-711.state"
+  echo "10" > "${session_dir}/worker-711.priority"
+  run bash "$ORCHCTL" gc
+  assert_not_exists "orphan TERMINATED state removed" "${session_dir}/worker-711.state"
+  assert_not_exists "orphan priority removed" "${session_dir}/worker-711.priority"
+}
 
 @test "gc preserves log files of active workers" {
   mock_claude

--- a/tests/orchestrator/cleanup-worktree.bats
+++ b/tests/orchestrator/cleanup-worktree.bats
@@ -111,3 +111,66 @@ setup_ipc() {
   assert_eq "keep=true + --force: cleanup exits 0" "0" "$status"
   assert_not_exists "keep=true + --force: worktree removed" "$worktree"
 }
+
+# ── ADR-0020 Phase 1: reaper log retention + exit event on non-TERMINATED reap ──
+
+@test "cleanup retains the lifecycle log (no longer deletes it)" {
+  local issue="303"
+  local worktree
+  worktree=$(setup_worktree "$issue")
+  setup_ipc "$issue"
+
+  # Create log file
+  mkdir -p "${CEKERNEL_IPC_DIR}/logs"
+  echo "[2026-07-09T00:00:00Z] SPAWN issue=#${issue}" > "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log"
+
+  run bash "$CLEANUP_SCRIPT" "$issue"
+  assert_eq "cleanup exits 0" "0" "$status"
+
+  # ADR-0020: log is RETAINED (no longer deleted)
+  assert_file_exists "log file retained" "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log"
+}
+
+@test "cleanup appends exit event to log when reaping non-TERMINATED state" {
+  local issue="304"
+  local worktree
+  worktree=$(setup_worktree "$issue")
+  setup_ipc "$issue"
+
+  # Set state to RUNNING (non-TERMINATED)
+  echo "RUNNING:2026-07-09T00:00:00Z:phase1:implement" > "${CEKERNEL_IPC_DIR}/worker-${issue}.state"
+
+  # Create log file
+  mkdir -p "${CEKERNEL_IPC_DIR}/logs"
+  echo "[2026-07-09T00:00:00Z] SPAWN issue=#${issue}" > "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log"
+
+  run bash "$CLEANUP_SCRIPT" "$issue"
+  assert_eq "cleanup exits 0" "0" "$status"
+
+  # ADR-0020: exit event appended for non-TERMINATED reap
+  assert_file_exists "log file retained" "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log"
+  assert_match "exit event logged" "REAP_EXIT" "$(cat "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log")"
+}
+
+@test "cleanup does NOT append exit event when reaping TERMINATED state" {
+  local issue="305"
+  local worktree
+  worktree=$(setup_worktree "$issue")
+  setup_ipc "$issue"
+
+  # Set state to TERMINATED (already completed)
+  echo "TERMINATED:2026-07-09T00:00:00Z:ci-passed:55" > "${CEKERNEL_IPC_DIR}/worker-${issue}.state"
+
+  # Create log file
+  mkdir -p "${CEKERNEL_IPC_DIR}/logs"
+  echo "[2026-07-09T00:00:00Z] SPAWN issue=#${issue}" > "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log"
+
+  run bash "$CLEANUP_SCRIPT" "$issue"
+  assert_eq "cleanup exits 0" "0" "$status"
+
+  # No REAP_EXIT event for TERMINATED
+  if grep -q "REAP_EXIT" "${CEKERNEL_IPC_DIR}/logs/worker-${issue}.log" 2>/dev/null; then
+    echo "FAIL: REAP_EXIT must not be logged for TERMINATED state" >&2
+    return 1
+  fi
+}

--- a/tests/orchestrator/spawn.bats
+++ b/tests/orchestrator/spawn.bats
@@ -239,3 +239,60 @@ commit_settings() {
     return 1
   fi
 }
+
+# ── ADR-0020 Phase 1: active_worker_count counts non-TERMINATED state files ──
+
+@test "active_worker_count counts non-TERMINATED state files, not pipes" {
+  run_spawn
+  assert_eq "spawn exits 0" "0" "$status"
+
+  # After a successful spawn, the state file should be READY (post-spawn)
+  # and should count as 1 active worker
+  local ipc_dir
+  ipc_dir=$(find "${CEKERNEL_VAR_DIR}/ipc" -maxdepth 1 -type d -name "test-spawn-*" | head -1)
+
+  # Verify: state file exists and counts toward the active count
+  assert_file_exists "state file exists" "${ipc_dir}/worker-42.state"
+  local state_line
+  state_line=$(cat "${ipc_dir}/worker-42.state")
+  # State should be READY (not TERMINATED)
+  assert_match "state is READY" "^READY:" "$state_line"
+}
+
+@test "spawn.sh exits 2 when MAX_ORCH_CHILDREN non-TERMINATED state files exist" {
+  # First spawn succeeds
+  run_spawn
+  assert_eq "first spawn exits 0" "0" "$status"
+
+  # Find the IPC dir
+  local ipc_dir
+  ipc_dir=$(find "${CEKERNEL_VAR_DIR}/ipc" -maxdepth 1 -type d -name "test-spawn-*" | head -1)
+
+  # Create additional non-TERMINATED state files to hit the limit
+  # Default MAX_ORCH_CHILDREN is 5, so create 4 more (total 5 with the spawned one)
+  for i in 100 101 102 103; do
+    echo "RUNNING:2026-07-09T00:00:00Z:phase1:implement" > "${ipc_dir}/worker-${i}.state"
+  done
+
+  # Next spawn should fail with exit 2
+  run bash -c "cd '${TMP}/repo' && CEKERNEL_MAX_ORCH_CHILDREN=5 bash '${SPAWN_SCRIPT}' --agent worker 43 main"
+  assert_eq "spawn exits 2 at capacity" "2" "$status"
+}
+
+@test "spawn.sh does not count TERMINATED state files toward capacity" {
+  run_spawn
+  assert_eq "first spawn exits 0" "0" "$status"
+
+  local ipc_dir
+  ipc_dir=$(find "${CEKERNEL_VAR_DIR}/ipc" -maxdepth 1 -type d -name "test-spawn-*" | head -1)
+
+  # Create state files: 3 TERMINATED + 1 RUNNING = only 2 active (inc. issue 42)
+  echo "TERMINATED:2026-07-09T00:00:00Z:ci-passed:99" > "${ipc_dir}/worker-100.state"
+  echo "TERMINATED:2026-07-09T00:00:00Z:merged:88" > "${ipc_dir}/worker-101.state"
+  echo "TERMINATED:2026-07-09T00:00:00Z:crashed:boom" > "${ipc_dir}/worker-102.state"
+  echo "RUNNING:2026-07-09T00:00:00Z:phase1:implement" > "${ipc_dir}/worker-103.state"
+
+  # With MAX=3 and 2 active, should succeed
+  run bash -c "cd '${TMP}/repo' && CEKERNEL_MAX_ORCH_CHILDREN=3 bash '${SPAWN_SCRIPT}' --agent worker 44 main"
+  assert_eq "spawn succeeds with terminated workers not counting" "0" "$status"
+}

--- a/tests/orchestrator/watch.bats
+++ b/tests/orchestrator/watch.bats
@@ -212,6 +212,147 @@ teardown() {
   assert_match "detail is #999" '"detail":"#999"' "$result_json"
 }
 
+# ── ADR-0020 Phase 1: watch.sh terminal-state writes ──
+
+@test "watch writes TERMINATED:crashed state when backend reports crashed" {
+  worker_state_write 700 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-700.worker"
+  # empty agents queue → [] → session missing → crashed
+  mkfifo "${CEKERNEL_IPC_DIR}/worker-700"
+
+  run bash "$WATCH_SCRIPT" 700
+  assert_eq "watch exits non-zero" "1" "$status"
+  assert_match "result is crashed" '"result":"crashed"' "$output"
+  # ADR-0020: watch.sh writes TERMINATED state for crashed exit
+  local state_line
+  state_line=$(cat "${CEKERNEL_IPC_DIR}/worker-700.state")
+  assert_match "state is TERMINATED" "^TERMINATED:" "$state_line"
+  assert_match "detail is crashed" "crashed:" "$state_line"
+}
+
+@test "watch writes TERMINATED:blocked state when backend reports blocked" {
+  worker_state_write 701 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-701.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$TOKEN" background /tmp/wt 1700000000000 blocked)]"
+  mkfifo "${CEKERNEL_IPC_DIR}/worker-701"
+
+  run bash "$WATCH_SCRIPT" 701
+  assert_eq "watch exits non-zero" "1" "$status"
+  assert_match "result is blocked" '"result":"blocked"' "$output"
+  # ADR-0020: watch.sh writes TERMINATED state for blocked exit
+  local state_line
+  state_line=$(cat "${CEKERNEL_IPC_DIR}/worker-701.state")
+  assert_match "state is TERMINATED" "^TERMINATED:" "$state_line"
+  assert_match "detail is blocked" "blocked:" "$state_line"
+}
+
+@test "watch does NOT write TERMINATED for timeout (slot held)" {
+  worker_state_write 702 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-702.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$TOKEN" background /tmp/wt 1700000000000 busy)]"
+  mkfifo "${CEKERNEL_IPC_DIR}/worker-702"
+  export CEKERNEL_WORKER_TIMEOUT=2
+
+  run bash "$WATCH_SCRIPT" 702
+  # timeout exits non-zero
+  assert_eq "watch exits non-zero" "1" "$status"
+  assert_match "result is timeout" '"result":"timeout"' "$output"
+  # ADR-0020: timeout does NOT write TERMINATED — slot held
+  local state_line
+  state_line=$(cat "${CEKERNEL_IPC_DIR}/worker-702.state")
+  assert_match "state is NOT TERMINATED" "^RUNNING:" "$state_line"
+}
+
+@test "watch does NOT write TERMINATED for query-escalated (slot held)" {
+  worker_state_write 703 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-703.worker"
+  mock_bin claude 'exit 1'
+  mkfifo "${CEKERNEL_IPC_DIR}/worker-703"
+  export CEKERNEL_WATCH_QUERY_RETRY_MAX=2
+
+  run bash "$WATCH_SCRIPT" 703
+  assert_eq "watch exits non-zero" "1" "$status"
+  assert_match "result is error" '"result":"error"' "$output"
+  # ADR-0020: query-escalated does NOT write TERMINATED — slot held
+  local state_line
+  state_line=$(cat "${CEKERNEL_IPC_DIR}/worker-703.state")
+  assert_match "state is NOT TERMINATED" "^RUNNING:" "$state_line"
+}
+
+# ── ADR-0020 Phase 1: write-once race (dead verdict + prior TERMINATED record) ──
+
+@test "watch consumes existing TERMINATED record instead of writing crashed" {
+  # Simulate: Worker writes TERMINATED just before backend reports dead
+  worker_state_write 704 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-704.worker"
+  mkfifo "${CEKERNEL_IPC_DIR}/worker-704"
+
+  # Start watch in background
+  local out="${BATS_TEST_TMPDIR}/watch-out-704.json"
+  bash "$WATCH_SCRIPT" 704 > "$out" 2>/dev/null &
+  local watch_pid=$!
+  sleep 1
+
+  # Worker writes TERMINATED (simulating notify-complete before backend finishes)
+  worker_state_write 704 TERMINATED "ci-passed:55"
+  wait "$watch_pid" || true
+
+  local result_json
+  result_json=$(cat "$out")
+  # write-once: watch should report ci-passed (from state), NOT crashed
+  assert_match "result is ci-passed (write-once)" '"result":"ci-passed"' "$result_json"
+  assert_match "detail is 55" '"detail":"55"' "$result_json"
+
+  # State file must still say TERMINATED with ci-passed (not overwritten with crashed)
+  local state_line
+  state_line=$(cat "${CEKERNEL_IPC_DIR}/worker-704.state")
+  assert_match "state preserved as ci-passed" "ci-passed:55" "$state_line"
+}
+
+# ── ADR-0020 Phase 1: polling split (state 5s, backend 30s) ──
+
+@test "watch polls state at STATE_POLL_INTERVAL, not POLL_INTERVAL" {
+  worker_state_write 705 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-705.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$TOKEN" background /tmp/wt 1700000000000 busy)]"
+  mkfifo "${CEKERNEL_IPC_DIR}/worker-705"
+
+  # Set state poll to 1s and backend poll to 30s
+  # If state poll works at 1s, completion via state should be detected quickly
+  export CEKERNEL_STATE_POLL_INTERVAL=1
+  export CEKERNEL_POLL_INTERVAL=30
+  export CEKERNEL_WORKER_TIMEOUT=10
+
+  local out="${BATS_TEST_TMPDIR}/watch-out-705.json"
+  bash "$WATCH_SCRIPT" 705 > "$out" 2>/dev/null &
+  local watch_pid=$!
+
+  # Write TERMINATED after 2s — should be detected within ~3s (1s poll + margin)
+  sleep 2
+  worker_state_write 705 TERMINATED "ci-passed:66"
+
+  # Wait for watch to finish (with a timeout)
+  local waited=0
+  while kill -0 "$watch_pid" 2>/dev/null && [[ $waited -lt 8 ]]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if kill -0 "$watch_pid" 2>/dev/null; then
+    kill "$watch_pid" 2>/dev/null || true
+    echo "FAIL: watch did not detect state within 8s (STATE_POLL_INTERVAL should be 1s)" >&2
+    return 1
+  fi
+
+  wait "$watch_pid" || true
+  local result_json
+  result_json=$(cat "$out")
+  assert_match "result is ci-passed" '"result":"ci-passed"' "$result_json"
+}
+
 @test "watch resolves the headless backend from the env profile (#182 regression)" {
   worker_state_write 183 RUNNING "phase1:implement"
   echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-183.worker"


### PR DESCRIPTION
closes #614

## Summary
- `spawn.sh` の `active_worker_count()` を FIFO pipe 数 → 非-`TERMINATED` state ファイル数に移行
- `watch.sh` に terminal-state 書き込み（crashed/blocked → `TERMINATED`、timeout/query-escalated → slot 保持）
- write-once 不変条件: 既に `TERMINATED` なら上書きせず完了結果として消費
- ポーリング分割: state を `CEKERNEL_STATE_POLL_INTERVAL`(5s)、backend verdict を `CEKERNEL_POLL_INTERVAL`(30s)
- `orchctl kill` write-once guard: 既存の `TERMINATED` を上書きしない
- `orchctl resolve_target`: FIFO → state ファイル存在で解決（pipe-less held slot を addressable に）
- `orchctl gc` orphan-sweep: 非-`TERMINATED` state が held slot を保護（over-hold, never over-spawn）
- `cleanup-worktree.sh` reaper: 非-`TERMINATED` reap 時にログ append + ライフサイクルログ retain
- `orchestrator.md`: timeout-dead branch（plain cleanup）+ blocked handler（session stop + cleanup）を配線
- `envs/README.md`: `CEKERNEL_STATE_POLL_INTERVAL` と `CEKERNEL_POLL_INTERVAL` をカタログ追記

## Test Plan
- [x] `active_worker_count` が非-TERMINATED state N 件で N を返す / TERMINATED はカウントしない
- [x] `MAX_ORCH_CHILDREN` 到達で `spawn.sh` が exit 2
- [x] watch.sh crashed → TERMINATED 書き込み
- [x] watch.sh blocked → TERMINATED 書き込み
- [x] watch.sh timeout → TERMINATED 書かない（slot 保持）
- [x] watch.sh query-escalated → TERMINATED 書かない（slot 保持）
- [x] write-once race: dead verdict 直前の TERMINATED record が生き延びる
- [x] ポーリング分割: STATE_POLL_INTERVAL で state 検出
- [x] orchctl kill write-once: 既存 TERMINATED を上書きしない
- [x] orchctl resolve_target: state ファイルで解決（FIFO 不要）
- [x] gc: 非-TERMINATED state が orphan sweep を生き延びる
- [x] reaper: 非-TERMINATED reap 時 REAP_EXIT ログ + ログ retain
- [x] reaper: TERMINATED reap 時は REAP_EXIT なし
- [x] 既存テスト全件パス（163 tests）