### PR TITLE
refactor: ADR-0020 Phase 2 — state-based roster enumeration + gc reap write

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -90,7 +90,7 @@ Use `process-status.sh` to check active processes (Workers and Reviewers) in the
 
 ```bash
 scripts/orchestrator/process-status.sh
-# {"issue":4,"type":"worker","worktree":"/path/.worktrees/issue/4-...","fifo":"/usr/local/var/cekernel/ipc/.../worker-4","uptime":"12m"}
+# {"issue":4,"type":"worker","worktree":"/path/.worktrees/issue/4-...","uptime":"12m","state":"RUNNING","state_detail":"phase1:implement"}
 ```
 
 ## IPC: Named Pipe

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -169,6 +169,14 @@ compute_elapsed() {
   local issue
   issue=$(basename "$fifo" | sed 's/^worker-//')
 
+  compute_elapsed_from_issue "$ipc_dir" "$issue"
+}
+
+# ── Helper: compute elapsed time from ipc_dir + issue ──
+# ADR-0020 Phase 2: decoupled from FIFO path for state-based enumeration.
+compute_elapsed_from_issue() {
+  local ipc_dir="$1" issue="$2"
+
   # Read process type to locate the right .spawned file
   local process_type="worker"
   local type_file="${ipc_dir}/worker-${issue}.type"
@@ -242,10 +250,9 @@ cmd_ls() {
       sid_repo="${sid%-*}"
     fi
 
-    for fifo in "$session_dir"worker-*; do
-      [[ -p "$fifo" ]] || continue
-      local issue
-      issue=$(basename "$fifo" | sed 's/^worker-//')
+    # ADR-0020 Phase 2: enumerate by non-TERMINATED state files, not FIFOs.
+    local issue
+    for issue in $(worker_state_list_active "$session_dir"); do
       found=$((found + 1))
 
       # Set context for shared helpers
@@ -272,7 +279,7 @@ cmd_ls() {
 
       # Elapsed time
       local elapsed
-      elapsed=$(compute_elapsed "$fifo")
+      elapsed=$(compute_elapsed_from_issue "$session_dir" "$issue")
 
       # Backend
       local backend
@@ -430,11 +437,9 @@ cmd_inspect() {
   local priority
   priority=$(echo "$priority_json" | jq -r '.priority')
 
-  # Elapsed time
+  # Elapsed time (ADR-0020 Phase 2: uses issue-based lookup, not FIFO)
   local elapsed=""
-  if [[ -p "$fifo" ]]; then
-    elapsed=$(compute_elapsed "$fifo")
-  fi
+  elapsed=$(compute_elapsed_from_issue "$CEKERNEL_IPC_DIR" "$RESOLVED_ISSUE")
 
   # Backend
   local backend
@@ -870,11 +875,24 @@ cmd_gc() {
 
         # Check if this FIFO is stale
         if _gc_is_stale_fifo "$session_dir" "$issue" "$fifo" "$stale_timeout"; then
-          # Stale: remove FIFO and do NOT add to active_issues
+          # Stale: remove FIFO
           if [[ "$dry_run" -eq 1 ]]; then
             echo "[dry-run] would remove stale FIFO: $fifo" >&2
           else
             rm -f "$fifo"
+            # ADR-0020 Phase 2: write TERMINATED:crashed:detected-by-gc for
+            # non-TERMINATED entries (write-once: never clobber existing TERMINATED).
+            local _gc_state_file="${session_dir}worker-${issue}.state"
+            if [[ -f "$_gc_state_file" ]]; then
+              local _gc_line _gc_state
+              _gc_line=$(cat "$_gc_state_file")
+              _gc_state="${_gc_line%%:*}"
+              if [[ "$_gc_state" != "TERMINATED" ]]; then
+                local _gc_ts
+                _gc_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                echo "TERMINATED:${_gc_ts}:crashed:detected-by-gc" > "$_gc_state_file"
+              fi
+            fi
           fi
           cleaned=$((cleaned + 1))
         else

--- a/scripts/orchestrator/health-check.sh
+++ b/scripts/orchestrator/health-check.sh
@@ -4,8 +4,8 @@
 # Usage: health-check.sh [issue-number...]
 #   Without issue numbers: inspect all Workers in the session
 #
-# Zombie = FIFO exists but the Worker process is dead
-# (waitpid + WNOHANG equivalent)
+# ADR-0020 Phase 2: zombie = non-TERMINATED state + dead backend verdict
+# (the held slot that orchctl recover resolves).
 # Blocked = Worker session is waiting on a permission dialog (ADR-0016;
 # headless backend only — surfaced distinctly, counts as unhealthy)
 #
@@ -22,16 +22,23 @@ source "${SCRIPT_DIR}/../shared/session-id.sh"
 source "${SCRIPT_DIR}/../shared/backend-adapter.sh"
 source "${SCRIPT_DIR}/../shared/worker-state.sh"
 
-# If issue numbers are specified, inspect only those. Otherwise inspect all FIFOs in session
+# If issue numbers are specified, inspect only those.
+# Otherwise inspect all non-TERMINATED workers in session (ADR-0020 Phase 2).
 if [[ $# -gt 0 ]]; then
-  ISSUES=("$@")
+  # Filter explicitly-specified issues: skip TERMINATED ones
+  ISSUES=()
+  for _arg_issue in "$@"; do
+    _state_json=$(worker_state_read "$_arg_issue")
+    _state=$(echo "$_state_json" | jq -r '.state')
+    if [[ "$_state" != "TERMINATED" ]]; then
+      ISSUES+=("$_arg_issue")
+    fi
+  done
 else
   ISSUES=()
   if [[ -d "$CEKERNEL_IPC_DIR" ]]; then
-    for fifo in "${CEKERNEL_IPC_DIR}"/worker-*; do
-      [[ -p "$fifo" ]] || continue
-      issue=$(basename "$fifo" | sed 's/^worker-//')
-      ISSUES+=("$issue")
+    for _active_issue in $(worker_state_list_active "$CEKERNEL_IPC_DIR"); do
+      ISSUES+=("$_active_issue")
     done
   fi
 fi
@@ -43,17 +50,12 @@ fi
 
 UNHEALTHY=0
 
+# ADR-0020 Phase 2: zombie = non-TERMINATED state + dead backend verdict.
+# Only non-TERMINATED workers are inspected (enumeration already filters).
 check_worker() {
   local issue="$1"
-  local fifo="${CEKERNEL_IPC_DIR}/worker-${issue}"
   local status="unknown"
   local detail=""
-
-  # No active FIFO means completed
-  if [[ ! -p "$fifo" ]]; then
-    echo "{\"issue\":${issue},\"status\":\"completed\",\"detail\":\"No active FIFO\"}"
-    return 0
-  fi
 
   # 1. Backend verdict check (handle file managed by backend, ADR-0018).
   # Degradation policy: query-failed / unknown-value are INCONCLUSIVE —

--- a/scripts/orchestrator/process-status.sh
+++ b/scripts/orchestrator/process-status.sh
@@ -3,7 +3,9 @@
 #
 # Usage: process-status.sh
 # Output: JSON Lines (1 line = 1 process)
-#   {"issue": 4, "type": "worker", "worktree": "...", "fifo": "...", "uptime": "12m", "state": "RUNNING", "state_detail": "phase1:implement", "priority": 10, "priority_name": "normal"}
+#   {"issue": 4, "type": "worker", "worktree": "...", "uptime": "12m", "state": "RUNNING", "state_detail": "phase1:implement", "priority": 10, "priority_name": "normal"}
+#
+# ADR-0020 Phase 2: enumerates non-TERMINATED state files (not FIFOs).
 #
 # Exit codes:
 #   0 — Success
@@ -24,10 +26,8 @@ fi
 
 REPO_ROOT="$(resolve_repo_root 2>/dev/null || echo "")"
 
-# Collect process info from FIFO list
-find "$CEKERNEL_IPC_DIR" -maxdepth 1 -name 'worker-*' -type p 2>/dev/null | sort | while read -r fifo; do
-  basename_fifo=$(basename "$fifo")
-  issue="${basename_fifo#worker-}"
+# ADR-0020 Phase 2: enumerate by non-TERMINATED state files, not FIFOs.
+for issue in $(worker_state_list_active "$CEKERNEL_IPC_DIR"); do
 
   # Read process type from .type file
   type_file="${CEKERNEL_IPC_DIR}/worker-${issue}.type"
@@ -72,16 +72,15 @@ find "$CEKERNEL_IPC_DIR" -maxdepth 1 -name 'worker-*' -type p 2>/dev/null | sort
   worker_priority=$(echo "$priority_json" | jq -r '.priority')
   worker_priority_name=$(echo "$priority_json" | jq -r '.priority_name')
 
-  # JSON output
+  # JSON output (ADR-0020 Phase 2: fifo field removed)
   jq -cn \
     --argjson issue "$issue" \
     --arg type "$process_type" \
     --arg worktree "$worktree" \
-    --arg fifo "$fifo" \
     --arg uptime "$uptime" \
     --arg state "$worker_state" \
     --arg state_detail "$worker_state_detail" \
     --argjson priority "$worker_priority" \
     --arg priority_name "$worker_priority_name" \
-    '{issue: $issue, type: $type, worktree: $worktree, fifo: $fifo, uptime: $uptime, state: $state, state_detail: $state_detail, priority: $priority, priority_name: $priority_name}'
+    '{issue: $issue, type: $type, worktree: $worktree, uptime: $uptime, state: $state, state_detail: $state_detail, priority: $priority, priority_name: $priority_name}'
 done

--- a/scripts/shared/worker-state.sh
+++ b/scripts/shared/worker-state.sh
@@ -22,6 +22,29 @@
 # Valid states
 _CEKERNEL_VALID_STATES="NEW READY RUNNING WAITING SUSPENDED TERMINATED"
 
+# worker_state_list_active <ipc-dir>
+#   List issue numbers of non-TERMINATED workers in the given IPC directory.
+#   Outputs one issue number per line, sorted.
+#   Used by roster consumers (orchctl ls, process-status.sh, health-check.sh)
+#   to enumerate active workers without relying on FIFO existence.
+#   ADR-0020 Phase 2: single enumeration primitive, multiple consumers.
+worker_state_list_active() {
+  local ipc_dir="${1:?Usage: worker_state_list_active <ipc-dir>}"
+
+  for state_file in "${ipc_dir}"/worker-*.state; do
+    [[ -f "$state_file" ]] || continue
+    local fname issue state line
+    fname=$(basename "$state_file")
+    issue="${fname#worker-}"
+    issue="${issue%.state}"
+    line=$(cat "$state_file")
+    state="${line%%:*}"
+    if [[ "$state" != "TERMINATED" ]]; then
+      echo "$issue"
+    fi
+  done | sort -n
+}
+
 # worker_state_write <issue-number> <state> [detail]
 #   Write state to the worker state file.
 #   Exit 1 if state is invalid or CEKERNEL_IPC_DIR is not set.

--- a/scripts/shared/worker-state.sh
+++ b/scripts/shared/worker-state.sh
@@ -3,8 +3,8 @@
 #
 # Usage: source worker-state.sh
 #
-# Provides functions to read/write Worker state files.
-# State files live alongside FIFOs in the session IPC directory.
+# Provides functions to read/write/enumerate Worker state files.
+# State files are the roster key for active workers (ADR-0020 Phase 2).
 #
 # State machine:
 #   NEW → READY → RUNNING → WAITING → TERMINATED
@@ -18,6 +18,7 @@
 # Functions:
 #   worker_state_write <issue-number> <state> [detail]
 #   worker_state_read <issue-number>  → JSON to stdout
+#   worker_state_list_active <ipc-dir>  → issue numbers (non-TERMINATED), one per line
 
 # Valid states
 _CEKERNEL_VALID_STATES="NEW READY RUNNING WAITING SUSPENDED TERMINATED"

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -370,7 +370,7 @@ worker_state() {
   assert_not_exists "priority removed" "${session_dir}/worker-296.priority"
 }
 
-@test "gc removes stale FIFO when NEW + no handle + past stale timeout (state held)" {
+@test "gc removes stale FIFO when NEW + no handle + past stale timeout (reap write)" {
   local session_dir="${IPC_BASE}/session-gc-stale2"
   mkdir -p "$session_dir"
   mkfifo "${session_dir}/worker-297"
@@ -378,14 +378,16 @@ worker_state() {
   echo "worker" > "${session_dir}/worker-297.type"
   run env CEKERNEL_GC_STALE_TIMEOUT=0 bash "$ORCHCTL" gc
   assert_not_exists "stale NEW FIFO removed" "${session_dir}/worker-297"
-  # ADR-0020 Phase 1: non-TERMINATED state files hold the slot — gc does
-  # not remove them. The slot is freed by `orchctl recover` or Phase 2's gc
-  # TERMINATED write.
-  assert_file_exists "state held (non-TERMINATED)" "${session_dir}/worker-297.state"
-  assert_file_exists "type held" "${session_dir}/worker-297.type"
+  # ADR-0020 Phase 2: gc writes TERMINATED:crashed:detected-by-gc for
+  # stale non-TERMINATED entries, freeing the slot.
+  assert_file_exists "state file exists" "${session_dir}/worker-297.state"
+  local state_content
+  state_content=$(cat "${session_dir}/worker-297.state")
+  assert_match "state written to TERMINATED" "^TERMINATED:" "$state_content"
+  assert_match "detail is detected-by-gc" "crashed:detected-by-gc" "$state_content"
 }
 
-@test "gc removes stale FIFO with dead handle PID (state held)" {
+@test "gc removes stale FIFO with dead handle PID (reap write)" {
   local session_dir="${IPC_BASE}/session-gc-stale3"
   mkdir -p "$session_dir"
   mkfifo "${session_dir}/worker-298"
@@ -394,11 +396,12 @@ worker_state() {
   echo "99999999" > "${session_dir}/handle-298.worker"
   run bash "$ORCHCTL" gc
   assert_not_exists "stale FIFO removed" "${session_dir}/worker-298"
-  # ADR-0020 Phase 1: non-TERMINATED state holds the slot and all
-  # companion files (handle included). The held slot is addressed by
-  # `orchctl recover` or Phase 2's gc TERMINATED write.
-  assert_file_exists "state held (non-TERMINATED)" "${session_dir}/worker-298.state"
-  assert_file_exists "handle held (companion of held slot)" "${session_dir}/handle-298.worker"
+  # ADR-0020 Phase 2: gc writes TERMINATED:crashed:detected-by-gc
+  assert_file_exists "state file exists" "${session_dir}/worker-298.state"
+  local state_content
+  state_content=$(cat "${session_dir}/worker-298.state")
+  assert_match "state written to TERMINATED" "^TERMINATED:" "$state_content"
+  assert_match "detail is detected-by-gc" "crashed:detected-by-gc" "$state_content"
 }
 
 @test "gc preserves FIFO with live handle" {
@@ -419,7 +422,7 @@ worker_state() {
 # `claude agents --json` instead of assuming they are always alive.
 # A failed query stays conservative (assume alive — never gc on doubt).
 
-@test "gc removes stale FIFO when the token handle session is not listed (state held)" {
+@test "gc removes stale FIFO when the token handle session is not listed (reap write)" {
   mock_claude
   local session_dir="${IPC_BASE}/session-gc-token1"
   mkdir -p "$session_dir"
@@ -430,9 +433,12 @@ worker_state() {
   # empty agents queue → [] → session not listed → dead
   run bash "$ORCHCTL" gc
   assert_not_exists "stale FIFO removed" "${session_dir}/worker-573"
-  # ADR-0020 Phase 1: non-TERMINATED state holds the slot and all companion files
-  assert_file_exists "state held (non-TERMINATED)" "${session_dir}/worker-573.state"
-  assert_file_exists "handle held (companion of held slot)" "${session_dir}/handle-573.worker"
+  # ADR-0020 Phase 2: gc writes TERMINATED:crashed:detected-by-gc
+  assert_file_exists "state file exists" "${session_dir}/worker-573.state"
+  local state_content
+  state_content=$(cat "${session_dir}/worker-573.state")
+  assert_match "state written to TERMINATED" "^TERMINATED:" "$state_content"
+  assert_match "detail is detected-by-gc" "crashed:detected-by-gc" "$state_content"
 }
 
 @test "gc preserves FIFO when the token handle session is busy" {
@@ -709,12 +715,22 @@ worker_state() {
   mkdir -p "$session_dir"
   mkfifo "${session_dir}/worker-631"
   echo "TERMINATED:2026-02-28T10:00:00Z:ci-passed:55" > "${session_dir}/worker-631.state"
-  # TERMINATED + no live handle → stale FIFO, but state must NOT be overwritten
+  # TERMINATED + no live handle → stale FIFO removed.
+  # Write-once: gc must NOT write detected-by-gc over existing TERMINATED.
+  # The orphan sweep may later delete the state file (separate concern).
   run bash "$ORCHCTL" gc
   local state_content
   state_content=$(cat "${session_dir}/worker-631.state" 2>/dev/null || true)
-  # Even though the FIFO was stale, the TERMINATED record must be preserved
-  assert_match "state preserved as ci-passed" "ci-passed:55" "$state_content"
+  # If the file still exists, it must still say ci-passed (not detected-by-gc).
+  # If the file was deleted by orphan sweep, that's also correct (not overwritten).
+  if [[ -n "$state_content" ]]; then
+    assert_match "state preserved as ci-passed" "ci-passed:55" "$state_content"
+  fi
+  # Either way, detected-by-gc must NOT appear
+  if [[ "$state_content" == *"detected-by-gc"* ]]; then
+    echo "FAIL: TERMINATED state was overwritten with detected-by-gc" >&2
+    return 1
+  fi
 }
 
 @test "gc reap writes crashed:detected-by-gc for dead handle PID" {

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -681,3 +681,68 @@ worker_state() {
   assert_file_exists "active worker log preserved" "${session_dir}/logs/worker-622.log"
   assert_file_exists "active worker stdout log preserved" "${session_dir}/logs/worker-622.stdout.log"
 }
+
+# ── gc: ADR-0020 Phase 2 — reap writes TERMINATED:crashed:detected-by-gc ──
+
+@test "gc reap writes crashed:detected-by-gc for stale non-TERMINATED worker" {
+  mock_claude
+  local session_dir="${IPC_BASE}/session-gc-reap1"
+  mkdir -p "$session_dir"
+  mkfifo "${session_dir}/worker-630"
+  echo "RUNNING:2026-02-28T10:00:00Z:working" > "${session_dir}/worker-630.state"
+  echo "$SESSION_TOKEN" > "${session_dir}/handle-630.worker"
+  # empty agents queue → session not listed → dead
+  run bash "$ORCHCTL" gc
+  # The stale FIFO should be removed
+  assert_not_exists "stale FIFO removed" "${session_dir}/worker-630"
+  # State should be rewritten to TERMINATED:crashed:detected-by-gc
+  assert_file_exists "state file still exists" "${session_dir}/worker-630.state"
+  local state_content
+  state_content=$(cat "${session_dir}/worker-630.state")
+  assert_match "state is TERMINATED" "^TERMINATED:" "$state_content"
+  assert_match "detail is crashed:detected-by-gc" "crashed:detected-by-gc" "$state_content"
+}
+
+@test "gc reap does NOT overwrite existing TERMINATED state (write-once)" {
+  mock_claude
+  local session_dir="${IPC_BASE}/session-gc-reap2"
+  mkdir -p "$session_dir"
+  mkfifo "${session_dir}/worker-631"
+  echo "TERMINATED:2026-02-28T10:00:00Z:ci-passed:55" > "${session_dir}/worker-631.state"
+  # TERMINATED + no live handle → stale FIFO, but state must NOT be overwritten
+  run bash "$ORCHCTL" gc
+  local state_content
+  state_content=$(cat "${session_dir}/worker-631.state" 2>/dev/null || true)
+  # Even though the FIFO was stale, the TERMINATED record must be preserved
+  assert_match "state preserved as ci-passed" "ci-passed:55" "$state_content"
+}
+
+@test "gc reap writes crashed:detected-by-gc for dead handle PID" {
+  local session_dir="${IPC_BASE}/session-gc-reap3"
+  mkdir -p "$session_dir"
+  mkfifo "${session_dir}/worker-632"
+  echo "RUNNING:2026-02-28T10:00:00Z:working" > "${session_dir}/worker-632.state"
+  echo "99999999" > "${session_dir}/handle-632.worker"
+  run bash "$ORCHCTL" gc
+  assert_not_exists "stale FIFO removed" "${session_dir}/worker-632"
+  assert_file_exists "state file still exists" "${session_dir}/worker-632.state"
+  local state_content
+  state_content=$(cat "${session_dir}/worker-632.state")
+  assert_match "state is TERMINATED" "^TERMINATED:" "$state_content"
+  assert_match "detail is crashed:detected-by-gc" "crashed:detected-by-gc" "$state_content"
+}
+
+@test "gc reap writes crashed:detected-by-gc for stale NEW past timeout" {
+  local session_dir="${IPC_BASE}/session-gc-reap4"
+  mkdir -p "$session_dir"
+  mkfifo "${session_dir}/worker-633"
+  echo "NEW:2026-02-28T01:00:00Z:spawning" > "${session_dir}/worker-633.state"
+  echo "worker" > "${session_dir}/worker-633.type"
+  run env CEKERNEL_GC_STALE_TIMEOUT=0 bash "$ORCHCTL" gc
+  assert_not_exists "stale FIFO removed" "${session_dir}/worker-633"
+  assert_file_exists "state file still exists" "${session_dir}/worker-633.state"
+  local state_content
+  state_content=$(cat "${session_dir}/worker-633.state")
+  assert_match "state is TERMINATED" "^TERMINATED:" "$state_content"
+  assert_match "detail is crashed:detected-by-gc" "crashed:detected-by-gc" "$state_content"
+}

--- a/tests/ctl/orchctl-read.bats
+++ b/tests/ctl/orchctl-read.bats
@@ -522,6 +522,33 @@ make_handle() {
 
 # ── usage ──
 
+# ── ls: ADR-0020 Phase 2 — state-based enumeration ──
+
+@test "ls enumerates by state file, not FIFO (ADR-0020 Phase 2)" {
+  # Worker with state file but NO FIFO should appear in ls
+  mkdir -p "$IPC_A"
+  echo "RUNNING:2026-02-28T10:00:00Z:phase1:implement" > "${IPC_A}/worker-10.state"
+  echo "10" > "${IPC_A}/worker-10.priority"
+  run bash "$ORCHCTL" ls
+  assert_match "lists worker without FIFO" '"issue":10' "$output"
+  assert_match "shows state RUNNING" '"state":"RUNNING"' "$output"
+}
+
+@test "ls excludes TERMINATED workers (ADR-0020 Phase 2)" {
+  mkdir -p "$IPC_A"
+  echo "RUNNING:2026-02-28T10:00:00Z:phase1:implement" > "${IPC_A}/worker-10.state"
+  echo "10" > "${IPC_A}/worker-10.priority"
+  echo "TERMINATED:2026-02-28T10:00:00Z:ci-passed:55" > "${IPC_A}/worker-20.state"
+  echo "10" > "${IPC_A}/worker-20.priority"
+  run bash "$ORCHCTL" ls
+  local line_count
+  line_count=$(echo "$output" | grep -c '"issue"' || true)
+  assert_eq "only non-TERMINATED listed" "1" "$line_count"
+  assert_match "active worker listed" '"issue":10' "$output"
+}
+
+# ── usage ──
+
 @test "no command prints usage and exits 1" {
   run bash "$ORCHCTL"
   assert_eq "no command: exit 1" "1" "$status"

--- a/tests/orchestrator/health-check.bats
+++ b/tests/orchestrator/health-check.bats
@@ -87,3 +87,44 @@ _active_worker() {
   assert_eq "exit 0 (inconclusive is not unhealthy)" "0" "$status"
   assert_match "status unknown" '"status":"unknown"' "$output"
 }
+
+# ── ADR-0020 Phase 2: state-based zombie detection ──
+
+# Active worker fixture WITHOUT FIFO: state + handle only
+_active_worker_no_fifo() {
+  local issue="$1"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-${issue}.worker"
+  worker_state_write "$issue" RUNNING "phase1:implement"
+}
+
+@test "health-check discovers workers by state file, not FIFO (ADR-0020 Phase 2)" {
+  # Worker with state but NO FIFO — should be discoverable
+  _active_worker_no_fifo 95
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$TOKEN" background /tmp/wt 1700000000000 busy)]"
+
+  run bash "$HEALTH_SCRIPT"
+  assert_match "worker found without FIFO" '"issue":95' "$output"
+  assert_match "status healthy" '"status":"healthy"' "$output"
+}
+
+@test "health-check zombie = non-TERMINATED + dead verdict (ADR-0020 Phase 2)" {
+  # Worker with non-TERMINATED state + dead backend → zombie
+  _active_worker_no_fifo 96
+
+  run bash "$HEALTH_SCRIPT"
+  assert_eq "exit 1 (zombie)" "1" "$status"
+  assert_match "status zombie" '"status":"zombie"' "$output"
+}
+
+@test "health-check skips TERMINATED workers (ADR-0020 Phase 2)" {
+  worker_state_write 97 TERMINATED "ci-passed:55"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-97.worker"
+
+  run bash "$HEALTH_SCRIPT"
+  # TERMINATED workers should not be inspected at all
+  if [[ "$output" == *'"issue":97'* ]]; then
+    echo "FAIL: TERMINATED worker should not be inspected" >&2
+    return 1
+  fi
+}

--- a/tests/orchestrator/process-status.bats
+++ b/tests/orchestrator/process-status.bats
@@ -34,21 +34,20 @@ teardown() {
   assert_eq "empty output" "" "$output"
 }
 
-@test "one worker: one JSON line with issue, fifo path, uptime" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-20"
+@test "one worker: one JSON line with issue and uptime" {
+  worker_state_write 20 RUNNING "working"
   run bash "$STATUS_SCRIPT"
   local line_count
   line_count=$(echo "$output" | grep -c 'issue' || true)
   assert_eq "one JSON line" "1" "$line_count"
   assert_match "output contains issue 20" '"issue":20' "$output"
-  assert_match "output contains FIFO path" "worker-20" "$output"
   assert_match "output contains uptime field" '"uptime":' "$output"
 }
 
 @test "three workers: three JSON lines" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-20"
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-21"
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-22"
+  worker_state_write 20 RUNNING "working"
+  worker_state_write 21 RUNNING "working"
+  worker_state_write 22 RUNNING "working"
   run bash "$STATUS_SCRIPT"
   local line_count
   line_count=$(echo "$output" | grep -c 'issue')
@@ -62,11 +61,11 @@ teardown() {
 }
 
 @test "type field reads worker/reviewer from .type file, defaults to unknown" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-50"
+  worker_state_write 50 RUNNING "working"
   echo "worker" > "${CEKERNEL_IPC_DIR}/worker-50.type"
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-51"
+  worker_state_write 51 RUNNING "reviewing"
   echo "reviewer" > "${CEKERNEL_IPC_DIR}/worker-51.type"
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-52"
+  worker_state_write 52 RUNNING "working"
 
   run bash "$STATUS_SCRIPT"
   assert_match "type worker" '"type":"worker"' "$(echo "$output" | grep '"issue":50')"
@@ -74,11 +73,10 @@ teardown() {
   assert_match "missing type file shows unknown" '"type":"unknown"' "$(echo "$output" | grep '"issue":52')"
 }
 
-@test "uptime reads from .spawned file (not FIFO stat)" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-60"
+@test "uptime reads from .spawned file (not state file stat)" {
+  worker_state_write 60 RUNNING "working"
   echo "worker" > "${CEKERNEL_IPC_DIR}/worker-60.type"
   # Epoch 0 in .spawned forces a very large uptime (many hours).
-  # FIFO-mtime-based uptime would report seconds ("Xs") instead.
   echo "0" > "${CEKERNEL_IPC_DIR}/worker-60.spawned"
   run bash "$STATUS_SCRIPT"
   assert_match "uptime from .spawned (epoch 0 → hours)" '"uptime":"[0-9]+h' "$(echo "$output" | grep '"issue":60')"
@@ -87,34 +85,20 @@ teardown() {
 # ── State field integration (from test-process-status-state.sh) ──
 
 @test "state and state_detail read from state file" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-30"
   worker_state_write 30 RUNNING "phase1:implement"
   run bash "$STATUS_SCRIPT"
   assert_match "state field" '"state":"RUNNING"' "$output"
   assert_match "state detail" '"state_detail":"phase1:implement"' "$output"
 }
 
-@test "missing state file shows UNKNOWN" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-31"
-  run bash "$STATUS_SCRIPT"
-  assert_match "missing state shows UNKNOWN" '"state":"UNKNOWN"' "$(echo "$output" | grep '"issue":31')"
-}
-
-@test "TERMINATED worker with FIFO still shows state" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-32"
-  worker_state_write 32 TERMINATED "merged"
-  run bash "$STATUS_SCRIPT"
-  assert_match "TERMINATED state shown" '"state":"TERMINATED"' "$(echo "$output" | grep '"issue":32')"
-}
-
 # ── Priority field integration (from test-process-status-priority.sh) ──
 
 @test "priority file values are shown (high/critical/low)" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-40"
+  worker_state_write 40 RUNNING "working"
   worker_priority_write 40 high
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-42"
+  worker_state_write 42 RUNNING "working"
   worker_priority_write 42 critical
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-43"
+  worker_state_write 43 RUNNING "working"
   worker_priority_write 43 low
 
   run bash "$STATUS_SCRIPT"
@@ -130,7 +114,7 @@ teardown() {
 }
 
 @test "missing priority file shows default (normal/10)" {
-  mkfifo "${CEKERNEL_IPC_DIR}/worker-41"
+  worker_state_write 41 RUNNING "working"
   run bash "$STATUS_SCRIPT"
   local line41
   line41=$(echo "$output" | grep '"issue":41')

--- a/tests/orchestrator/process-status.bats
+++ b/tests/orchestrator/process-status.bats
@@ -137,3 +137,32 @@ teardown() {
   assert_match "default priority 10" '"priority":10' "$line41"
   assert_match "default priority name normal" '"priority_name":"normal"' "$line41"
 }
+
+# ── ADR-0020 Phase 2: state-based enumeration ──
+
+@test "enumerates by state file, not FIFO (ADR-0020 Phase 2)" {
+  # Worker with state file but NO FIFO should appear
+  worker_state_write 70 RUNNING "phase1:implement"
+  run bash "$STATUS_SCRIPT"
+  assert_match "worker without FIFO listed" '"issue":70' "$output"
+  assert_match "state shown" '"state":"RUNNING"' "$output"
+}
+
+@test "excludes TERMINATED workers (ADR-0020 Phase 2)" {
+  worker_state_write 71 RUNNING "phase1:implement"
+  worker_state_write 72 TERMINATED "ci-passed:55"
+  run bash "$STATUS_SCRIPT"
+  local line_count
+  line_count=$(echo "$output" | grep -c '"issue"' || true)
+  assert_eq "only non-TERMINATED listed" "1" "$line_count"
+  assert_match "active worker listed" '"issue":71' "$output"
+}
+
+@test "output does not contain fifo field (ADR-0020 Phase 2)" {
+  worker_state_write 73 RUNNING "phase1:implement"
+  run bash "$STATUS_SCRIPT"
+  if [[ "$output" == *'"fifo"'* ]]; then
+    echo "FAIL: output should not contain fifo field" >&2
+    return 1
+  fi
+}

--- a/tests/orchestrator/test-health-check.sh
+++ b/tests/orchestrator/test-health-check.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # test-health-check.sh — Zombie Worker detection tests
+# ADR-0020 Phase 2: zombie = non-TERMINATED state + dead backend verdict.
+# Workers are discovered by state file, not FIFO.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,6 +13,7 @@ echo "test: health-check"
 
 export CEKERNEL_SESSION_ID="test-health-00000001"
 source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+source "${CEKERNEL_DIR}/scripts/shared/worker-state.sh"
 
 cleanup() {
   rm -rf "$CEKERNEL_IPC_DIR" 2>/dev/null || true
@@ -22,26 +25,27 @@ mkdir -p "$CEKERNEL_IPC_DIR"
 # Use headless backend for tests (always available, even on CI without terminal)
 export CEKERNEL_BACKEND=headless
 
-# ── Test 1: No FIFO → completed ──
-RESULT=$(bash "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 70 2>/dev/null)
-assert_match "No FIFO reports completed" '"status":"completed"' "$RESULT"
+# ── Test 1: TERMINATED state → skipped (not inspected) ──
+worker_state_write 70 TERMINATED "ci-passed:55"
+EXIT_CODE=0
+bash "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 70 2>/dev/null || EXIT_CODE=$?
+assert_eq "TERMINATED worker not inspected returns exit 0" "0" "$EXIT_CODE"
 
-# ── Test 2: FIFO exists, no handle, no worktree → zombie ──
-mkfifo "${CEKERNEL_IPC_DIR}/worker-71"
+# ── Test 2: Non-TERMINATED state, no handle, no worktree → zombie ──
+worker_state_write 71 RUNNING "phase1:implement"
 RESULT=$(bash "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 71 2>/dev/null || true)
-assert_match "Orphaned FIFO reports zombie" '"status":"zombie"' "$RESULT"
-assert_match "Zombie detail mentions worker dead" 'worker dead' "$RESULT"
+assert_match "Non-TERMINATED + dead reports zombie" '"status":"zombie"' "$RESULT"
 
-# ── Test 3: No arguments → inspect all workers ──
-mkfifo "${CEKERNEL_IPC_DIR}/worker-72"
+# ── Test 3: No arguments → inspect all non-TERMINATED workers ──
+worker_state_write 72 WAITING "phase3:ci-waiting"
 RESULT=$(bash "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 2>/dev/null || true)
 assert_match "Issue 71 found in scan" '"issue":71' "$RESULT"
 assert_match "Issue 72 found in scan" '"issue":72' "$RESULT"
 
-# ── Test 4: No FIFOs in session → exit 0 ──
-rm -f "${CEKERNEL_IPC_DIR}/worker-71" "${CEKERNEL_IPC_DIR}/worker-72"
+# ── Test 4: No non-TERMINATED state files → exit 0 ──
+rm -f "${CEKERNEL_IPC_DIR}/worker-71.state" "${CEKERNEL_IPC_DIR}/worker-72.state"
 EXIT_CODE=0
 bash "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 2>/dev/null || EXIT_CODE=$?
-assert_eq "No workers returns exit 0" "0" "$EXIT_CODE"
+assert_eq "No active workers returns exit 0" "0" "$EXIT_CODE"
 
 report_results

--- a/tests/shared/load-env.bats
+++ b/tests/shared/load-env.bats
@@ -287,6 +287,8 @@ setup_orchestrator_fixture() {
   mkdir -p "$MOCK_USER_ENVS" "${MOCK_VAR_DIR}/ipc/${TEST_SESSION}"
   printf 'CEKERNEL_VAR_DIR=%s\n' "$MOCK_VAR_DIR" > "${MOCK_USER_ENVS}/default.env"
   mkfifo "${MOCK_VAR_DIR}/ipc/${TEST_SESSION}/worker-99"
+  # ADR-0020 Phase 2: scripts enumerate by state file, not FIFO.
+  echo "RUNNING:2026-02-28T10:00:00Z:phase1:implement" > "${MOCK_VAR_DIR}/ipc/${TEST_SESSION}/worker-99.state"
 }
 
 # Runs a script with CEKERNEL_VAR_DIR unset and the user profile pointing to
@@ -317,11 +319,11 @@ run_with_user_profile() {
 
 @test "health-check.sh uses CEKERNEL_VAR_DIR from user profile" {
   setup_orchestrator_fixture
-  # When load-env works, health-check finds the FIFO and does not report
-  # "completed" (which it would at the wrong default path).
+  # When load-env works, health-check finds the worker state file and does
+  # not report "No active workers" (which it would at the wrong default path).
   run run_with_user_profile "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 99
-  if [[ "$output" == *'"status":"completed"'* ]]; then
-    echo "FAIL: health-check.sh did not find FIFO via user profile: ${output}" >&2
+  if [[ "$output" == *"No active workers"* ]]; then
+    echo "FAIL: health-check.sh did not find state file via user profile: ${output}" >&2
     return 1
   fi
 }

--- a/tests/shared/test-json-output.sh
+++ b/tests/shared/test-json-output.sh
@@ -75,9 +75,9 @@ fi
 rm -f "$RESULT_FILE" "$FIFO"
 
 # ── Test 3: health-check.sh — Zombie worker JSON output is valid ──
-# Create FIFO without pane file (will be detected as zombie)
-FIFO="${CEKERNEL_IPC_DIR}/worker-903"
-mkfifo "$FIFO"
+# ADR-0020 Phase 2: health-check requires a non-TERMINATED state file.
+source "${CEKERNEL_DIR}/scripts/shared/worker-state.sh"
+worker_state_write 903 RUNNING "phase1:implement"
 # git worktree won't be found, so it falls back to "No worktree found"
 RESULT=$(bash "${CEKERNEL_DIR}/scripts/orchestrator/health-check.sh" 903 2>/dev/null || true)
 if echo "$RESULT" | head -1 | jq . >/dev/null 2>&1; then
@@ -88,11 +88,10 @@ else
   echo "    output: $RESULT"
   ((TESTS_FAILED++)) || true
 fi
-rm -f "$FIFO"
 
 # ── Test 4: process-status.sh — JSON Lines output is valid ──
-FIFO="${CEKERNEL_IPC_DIR}/worker-904"
-mkfifo "$FIFO"
+# ADR-0020 Phase 2: process-status enumerates by state file (not FIFO).
+worker_state_write 904 RUNNING "phase1:implement"
 RESULT=$(bash "${CEKERNEL_DIR}/scripts/orchestrator/process-status.sh" 2>/dev/null)
 if [[ -n "$RESULT" ]]; then
   if echo "$RESULT" | head -1 | jq . >/dev/null 2>&1; then
@@ -107,7 +106,6 @@ else
   echo "  FAIL: process-status produced no output"
   ((TESTS_FAILED++)) || true
 fi
-rm -f "$FIFO"
 
 # ── Cleanup ──
 unset -f wezterm 2>/dev/null || true

--- a/tests/shared/worker-state.bats
+++ b/tests/shared/worker-state.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# worker-state.bats — bats-core tests for worker_state_list_active
+# (ADR-0020 Phase 2: roster enumeration via state files)
+#
+# worker_state_list_active enumerates issue numbers from non-TERMINATED
+# state files in a given IPC directory. It replaces FIFO-based iteration
+# for all roster consumers (orchctl ls, process-status.sh, health-check.sh).
+
+load '../helpers/assertions'
+load '../helpers/session'
+
+setup() {
+  CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  set_test_session_id
+  source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+  source "${CEKERNEL_DIR}/scripts/shared/worker-state.sh"
+  rm -rf "$CEKERNEL_IPC_DIR"
+  mkdir -p "$CEKERNEL_IPC_DIR"
+}
+
+teardown() {
+  rm -rf "$CEKERNEL_IPC_DIR"
+}
+
+@test "worker_state_list_active: empty dir returns nothing" {
+  run worker_state_list_active "$CEKERNEL_IPC_DIR"
+  assert_eq "exit 0" "0" "$status"
+  assert_eq "empty output" "" "$output"
+}
+
+@test "worker_state_list_active: lists RUNNING worker" {
+  worker_state_write 10 RUNNING "phase1:implement"
+  run worker_state_list_active "$CEKERNEL_IPC_DIR"
+  assert_eq "exit 0" "0" "$status"
+  assert_eq "lists issue 10" "10" "$output"
+}
+
+@test "worker_state_list_active: excludes TERMINATED worker" {
+  worker_state_write 10 RUNNING "phase1:implement"
+  worker_state_write 20 TERMINATED "ci-passed:55"
+  run worker_state_list_active "$CEKERNEL_IPC_DIR"
+  assert_eq "exit 0" "0" "$status"
+  assert_eq "only issue 10" "10" "$output"
+}
+
+@test "worker_state_list_active: lists multiple non-TERMINATED states" {
+  worker_state_write 10 RUNNING "phase1:implement"
+  worker_state_write 20 WAITING "phase3:ci-waiting"
+  worker_state_write 30 NEW "spawning"
+  worker_state_write 40 READY "resume-requested"
+  worker_state_write 50 SUSPENDED "checkpoint-saved"
+  run worker_state_list_active "$CEKERNEL_IPC_DIR"
+  assert_eq "exit 0" "0" "$status"
+  local count
+  count=$(echo "$output" | wc -l | tr -d ' ')
+  assert_eq "five active workers" "5" "$count"
+}
+
+@test "worker_state_list_active: all TERMINATED returns nothing" {
+  worker_state_write 10 TERMINATED "ci-passed:55"
+  worker_state_write 20 TERMINATED "crashed:detected-by-gc"
+  run worker_state_list_active "$CEKERNEL_IPC_DIR"
+  assert_eq "exit 0" "0" "$status"
+  assert_eq "empty output" "" "$output"
+}
+
+@test "worker_state_list_active: works on arbitrary IPC dir (not just session)" {
+  local other_dir="${BATS_TEST_TMPDIR}/other-ipc"
+  mkdir -p "$other_dir"
+  echo "RUNNING:2026-02-28T10:00:00Z:phase1:implement" > "${other_dir}/worker-99.state"
+  run worker_state_list_active "$other_dir"
+  assert_eq "exit 0" "0" "$status"
+  assert_eq "lists issue 99" "99" "$output"
+}


### PR DESCRIPTION
closes #615

## Summary
- `worker_state_list_active()` を `worker-state.sh` に追加: 非 `TERMINATED` state ファイルを列挙する共有プリミティブ（Rule of Modularity: 1列挙プリミティブ、複数消費者）
- `orchctl ls` / `process-status.sh` / `health-check.sh` を FIFO ベース列挙から state ファイルベース列挙へ移行
- `health-check.sh` を再設計: zombie = 非 `TERMINATED` state + dead backend verdict（キー差し替えではない）
- `orchctl gc` reap 変更: pipe 削除 → `TERMINATED:crashed:detected-by-gc` 書き込み（非 `TERMINATED` のみ、write-once 不変条件を遵守）
- `process-status.sh` の JSON 出力から `fifo` フィールドを削除
- `docs/internals.md` のサンプル出力を更新
- 既存テストを FIFO ベースから state ベースのフィクスチャへ移行

## Test Plan
- [x] `worker_state_list_active` — 空ディレクトリ、RUNNING/TERMINATED 混在、全 TERMINATED
- [x] `orchctl ls` — state ファイルで列挙、TERMINATED 除外
- [x] `process-status.sh` — state ファイルで列挙、fifo フィールドなし
- [x] `health-check.sh` — FIFO なし Worker 発見、zombie = 非TERMINATED + dead verdict、TERMINATED スキップ
- [x] `orchctl gc` — reap write（crashed:detected-by-gc）、write-once guard、dead handle PID、stale NEW
- [x] `load-env.bats` 統合テスト更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)