### PR TITLE
fix: unset CEKERNEL_SESSION_ID in Step D to force new session scope

### DIFF
--- a/skills/references/orchestrator-launch.md
+++ b/skills/references/orchestrator-launch.md
@@ -50,6 +50,7 @@ Run the following in a **single** Bash tool call — it generates `CEKERNEL_SESS
 
 ```bash
 source "${CEKERNEL_SCRIPTS}/shared/load-env.sh"
+unset CEKERNEL_SESSION_ID          # Orchestrator launch = new session boundary (#622)
 source "${CEKERNEL_SCRIPTS}/shared/session-id.sh"
 mkdir -p "$CEKERNEL_IPC_DIR"
 

--- a/tests/shared/session-id.bats
+++ b/tests/shared/session-id.bats
@@ -27,3 +27,35 @@ setup() {
   run bash -c "export CEKERNEL_SESSION_ID='test-session-aabbccdd'; unset CEKERNEL_IPC_DIR; source '${SESSION_SCRIPT}'; echo \"\${CEKERNEL_IPC_DIR}\""
   assert_eq "IPC dir derived" "${expected_var_dir}/ipc/test-session-aabbccdd" "$output"
 }
+
+# Step D (orchestrator-launch.md): unset before source forces new session scope
+# See: #622 — Orchestrator launch must be a new-session boundary
+
+@test "Step D pattern: unset + source generates new ID even when CEKERNEL_SESSION_ID is already set" {
+  local old_id="cekernel-deadbeef"
+  run bash -c "
+    export CEKERNEL_SESSION_ID='${old_id}'
+    unset CEKERNEL_SESSION_ID
+    unset CEKERNEL_IPC_DIR
+    source '${SESSION_SCRIPT}'
+    echo \"\${CEKERNEL_SESSION_ID}\"
+  "
+  assert_eq "exits 0" "0" "$status"
+  assert_match "new ID has {name}-{hex8} format" "^[a-z0-9._-]+-[0-9a-f]{8}$" "$output"
+  # Must differ from the old ID
+  if [[ "$output" == "$old_id" ]]; then
+    echo "FAIL: Step D reused old session ID: ${output}" >&2
+    return 1
+  fi
+}
+
+@test "Step D pattern: unset + source generates new ID from clean environment" {
+  run bash -c "
+    unset CEKERNEL_SESSION_ID
+    unset CEKERNEL_IPC_DIR
+    source '${SESSION_SCRIPT}'
+    echo \"\${CEKERNEL_SESSION_ID}\"
+  "
+  assert_eq "exits 0" "0" "$status"
+  assert_match "new ID has {name}-{hex8} format" "^[a-z0-9._-]+-[0-9a-f]{8}$" "$output"
+}


### PR DESCRIPTION
closes #622

## Summary
- `orchestrator-launch.md` Step D で `session-id.sh` を source する直前に `unset CEKERNEL_SESSION_ID` を追加し、Orchestrator 起動ごとに新規セッションスコープを発番するように修正
- `session-id.sh` の再利用ガード自体は変更なし（子プロセス継承に必要）
- Step D パターン（`unset` + `source`）の behavior test を追加

## Test Plan
- [x] `CEKERNEL_SESSION_ID` が既に set された環境で Step D スニペットを実行 → 新規 ID が発番される
- [x] 空環境から Step D スニペットを実行 → 従来どおり新規 ID が発番される（回帰なし）
- [x] 既存の session-id.sh テスト（保持ガード含む）がすべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)