### PR TITLE
fix: claude_bg_stop がフル UUID を claude stop に渡し停止が常に失敗する問題を修正

### DIFF
--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -283,7 +283,11 @@ Verified 2026-07-07 (Phase 1 probe, #546, session `971e554a`):
   is **epoch milliseconds** (numeric), not an ISO string.
 - The reported `cwd` is **realpath'd** (`/tmp` → `/private/tmp` on macOS)
   — cwd-based matching must normalize with `pwd -P` first.
-- `claude stop <short-id>` accepts the short ID as the stop token.
+- `claude stop <short-id>` accepts **only** the short 8-char job ID as
+  the stop token — a full session UUID fails with "No job matching"
+  (#621, verified v2.1.202). The short ID is the first 8 hex chars of
+  the `sessionId`. `claude-bg.sh` truncates the handle token before
+  passing it to `claude stop`.
 
 Verified 2026-07-07 (#581 field split, #591 terminal conflation, #593
 roster observation; claude v2.1.202):

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -97,8 +97,11 @@
 #       calling — the daemon's inherited environment is unspecified.
 #
 #   claude_bg_stop <token>
-#     — Stop the session via `claude stop`. Never fails; empty token is a
-#       no-op (reap semantics: done sessions linger until stopped).
+#     — Stop the session via `claude stop`. The token (full UUID or short
+#       ID) is truncated to 8 chars — `claude stop` only accepts the
+#       short job ID (#621). Never fails (reap semantics: returns 0 even
+#       when `claude stop` errors); stop failure emits a stderr warning
+#       (Rule of Repair). Empty token is a no-op.
 #
 #   claude_bg_wait_terminal <token> <interval> <timeout>
 #     — Poll `agents --json --all` until the verdict is terminal for

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -246,7 +246,17 @@ claude_bg_spawn() {
 claude_bg_stop() {
   local token="${1:-}"
   [[ -n "$token" ]] || return 0
-  claude stop "$token" >/dev/null 2>&1 || true
+
+  # `claude stop` accepts only the short 8-char job ID (first 8 hex chars
+  # of the sessionId). Full UUIDs always fail with "No job matching" (#621).
+  local job_id="${token:0:8}"
+  local stop_err
+  if ! stop_err=$(claude stop "$job_id" 2>&1); then
+    # Rule of Repair: make stop failure visible — the previous || true
+    # silently swallowed every failure, hiding #621 for weeks.
+    echo "Warning: claude stop '${job_id}' failed: ${stop_err}" >&2
+  fi
+  return 0
 }
 
 # claude_bg_wait_terminal <token> <interval> <timeout>

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -169,7 +169,7 @@ worker_state() {
   run bash "$ORCHCTL" kill 10 --session "$SESSION"
   assert_eq "kill exits 0" "0" "$status"
   assert_file_exists "claude stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the session token" "$SESSION_TOKEN" \
+  assert_eq "stop called with truncated job ID (#621)" "${SESSION_TOKEN:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
 }
 
@@ -186,7 +186,7 @@ worker_state() {
   run bash "$ORCHCTL" kill 10 --session "$SESSION"
   assert_eq "kill exits 0" "0" "$status"
   assert_file_exists "claude stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the session token" "$SESSION_TOKEN" \
+  assert_eq "stop called with truncated job ID (#621)" "${SESSION_TOKEN:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
   assert_match "tmux window killed" "kill-window -t my-session:1" \
     "$(cat "${BATS_TEST_TMPDIR}/tmux-argv.log")"
@@ -212,7 +212,7 @@ worker_state() {
   run bash "$ORCHCTL" kill 10 --session "$SESSION"
   assert_eq "kill exits 0" "0" "$status"
   assert_file_exists "claude stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the session token" "$SESSION_TOKEN" \
+  assert_eq "stop called with truncated job ID (#621)" "${SESSION_TOKEN:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
   assert_match "wezterm pane killed" "cli kill-pane --pane-id 42" \
     "$(cat "${BATS_TEST_TMPDIR}/wezterm-argv.log")"
@@ -534,7 +534,7 @@ worker_state() {
   run bash "$ORCHCTL" gc
   assert_file_exists "lingering done session reaped via claude stop" \
     "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the token" "$SESSION_TOKEN" \
+  assert_eq "stop called with truncated job ID (#621)" "${SESSION_TOKEN:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
   assert_not_exists "orchestrator.claude-session-id removed" \
     "${session_dir}/orchestrator.claude-session-id"

--- a/tests/helpers/mock-claude.bash
+++ b/tests/helpers/mock-claude.bash
@@ -105,7 +105,9 @@
 # Shim behavior:
 #   claude ... --bg ...    → prints `backgrounded · <short-id>`, records argv
 #   claude agents --json   → replays the enqueued response sequence
-#   claude stop <id>       → appends <id> to stop.log
+#   claude stop <id>       → appends <id> to stop.log (the real CLI
+#                            accepts only the short 8-char job ID — #621;
+#                            claude-bg.sh truncates before calling)
 #   anything else          → diagnostic on stderr, exit 1 (Rule of Repair:
 #                            argv shapes the mock does not model must fail
 #                            noisily, never pass silently)

--- a/tests/orchestrator/test-cleanup-pane.sh
+++ b/tests/orchestrator/test-cleanup-pane.sh
@@ -90,7 +90,7 @@ echo "42" > "${CEKERNEL_IPC_DIR}/pane-${ISSUE}.worker"
 cd "$FAKE_REPO"
 CEKERNEL_BACKEND=wezterm bash "${CEKERNEL_DIR}/scripts/orchestrator/cleanup-worktree.sh" "$ISSUE" 2>/dev/null
 
-if grep -q "stop ${SESSION_TOKEN}" "$CLAUDE_LOG" 2>/dev/null; then
+if grep -q "stop ${SESSION_TOKEN:0:8}" "$CLAUDE_LOG" 2>/dev/null; then
   echo "  PASS: Session stopped via claude stop"
   TESTS_PASSED=$((TESTS_PASSED + 1))
 else

--- a/tests/scheduler/wrapper-preflight-registry.bats
+++ b/tests/scheduler/wrapper-preflight-registry.bats
@@ -193,7 +193,7 @@ enqueue_session() {
   run "$W_RUNNER"
 
   assert_file_exists "stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the captured token" "$W_UUID" \
+  assert_eq "stop called with truncated job ID (#621)" "${W_UUID:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
 }
 
@@ -209,7 +209,7 @@ enqueue_session() {
   assert_match "END line records the blocked state" \
     "END status=error state=blocked" "$(cat "$W_SYSLOG")"
   # blocked never unblocks unattended — the session must be reaped
-  assert_eq "blocked session stopped" "$W_UUID" \
+  assert_eq "blocked session stopped (#621 truncated)" "${W_UUID:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
 }
 

--- a/tests/shared/backend-headless.bats
+++ b/tests/shared/backend-headless.bats
@@ -320,7 +320,7 @@ FULL_UUID="aaaa1111-2222-4333-8444-555566667777"
   echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
   backend_kill_worker 500
   assert_file_exists "stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the token" "$FULL_UUID" \
+  assert_eq "stop called with truncated job ID (#621)" "${FULL_UUID:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
 }
 
@@ -328,7 +328,7 @@ FULL_UUID="aaaa1111-2222-4333-8444-555566667777"
   echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
   echo "bbbb0000-1111-4222-8333-444455556666" > "${CEKERNEL_IPC_DIR}/handle-500.reviewer"
   backend_kill_worker 500 worker
-  assert_eq "only the worker token stopped" "$FULL_UUID" \
+  assert_eq "only the worker token stopped (#621 truncated)" "${FULL_UUID:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
 }
 
@@ -338,8 +338,9 @@ FULL_UUID="aaaa1111-2222-4333-8444-555566667777"
   backend_kill_worker 500
   local stopped
   stopped=$(sort "${MOCK_CLAUDE_STATE_DIR}/stop.log")
-  assert_match "worker token stopped" "$FULL_UUID" "$stopped"
-  assert_match "reviewer token stopped" "bbbb0000-1111-4222-8333-444455556666" "$stopped"
+  # #621: tokens are truncated to 8 chars before claude stop
+  assert_match "worker token stopped" "${FULL_UUID:0:8}" "$stopped"
+  assert_match "reviewer token stopped" "bbbb0000" "$stopped"
 }
 
 @test "backend_kill_worker exits cleanly for a non-existent handle" {

--- a/tests/shared/backend-tmux.bats
+++ b/tests/shared/backend-tmux.bats
@@ -256,7 +256,7 @@ enqueue_spawn_capture() {
   backend_kill_worker 400
 
   assert_file_exists "claude stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the token" "$FULL_UUID" \
+  assert_eq "stop called with truncated job ID (#621)" "${FULL_UUID:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
   assert_match "window killed" "kill-window -t my-session:1" \
     "$(cat "${MOCK_TMUX_STATE_DIR}/argv.log")"

--- a/tests/shared/backend-wezterm.bats
+++ b/tests/shared/backend-wezterm.bats
@@ -276,7 +276,7 @@ enqueue_spawn_capture() {
   backend_kill_worker 500
 
   assert_file_exists "claude stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stop called with the token" "$FULL_UUID" \
+  assert_eq "stop called with truncated job ID (#621)" "${FULL_UUID:0:8}" \
     "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
   assert_match "window panes killed" "kill-pane" \
     "$(cat "${MOCK_WEZTERM_STATE_DIR}/argv.log")"

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -249,19 +249,34 @@ enqueue_pair() {
   assert_eq "exit status" "1" "$status"
 }
 
-# ── claude_bg_stop ──
+# ── claude_bg_stop (#621: token truncation + Rule of Repair) ──
 
-@test "stop: delegates to claude stop and never fails" {
+@test "stop: full UUID is truncated to short 8-char job ID" {
   run claude_bg_stop "$FULL_UUID"
   assert_eq "exit status" "0" "$status"
   assert_file_exists "stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
-  assert_eq "stopped token" "$FULL_UUID" "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
+  assert_eq "stopped token" "aaaa1111" "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
+}
+
+@test "stop: short ID is passed through unchanged" {
+  run claude_bg_stop "abcd5678"
+  assert_eq "exit status" "0" "$status"
+  assert_file_exists "stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
+  assert_eq "stopped token" "abcd5678" "$(cat "${MOCK_CLAUDE_STATE_DIR}/stop.log")"
 }
 
 @test "stop: empty token is a no-op success" {
   run claude_bg_stop ""
   assert_eq "exit status" "0" "$status"
   assert_not_exists "no stop recorded" "${MOCK_CLAUDE_STATE_DIR}/stop.log"
+}
+
+@test "stop: failure emits a stderr warning (Rule of Repair) but still exits 0" {
+  # Replace claude shim with one that fails on stop
+  mock_bin claude 'if [ "$1" = "stop" ]; then echo "No job matching" >&2; exit 1; fi'
+  run --separate-stderr claude_bg_stop "deadbeef"
+  assert_eq "exit status (reap semantics)" "0" "$status"
+  assert_match "stderr warns about stop failure" "stop.*failed\|Warning.*stop" "$stderr"
 }
 
 # ── claude_bg_capture_session_id ──

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -276,7 +276,7 @@ enqueue_pair() {
   mock_bin claude 'if [ "$1" = "stop" ]; then echo "No job matching" >&2; exit 1; fi'
   run --separate-stderr claude_bg_stop "deadbeef"
   assert_eq "exit status (reap semantics)" "0" "$status"
-  assert_match "stderr warns about stop failure" "stop.*failed\|Warning.*stop" "$stderr"
+  assert_match "stderr warns about stop failure" "stop.*failed|Warning.*stop" "$stderr"
 }
 
 # ── claude_bg_capture_session_id ──


### PR DESCRIPTION
closes #621

## Summary
- `claude_bg_stop` が `claude stop` にトークンを渡す前に先頭8文字に切り詰めるよう修正（`claude stop` は短縮8桁 job ID のみ受け付け、フル UUID は `No job matching` で失敗する）
- 停止失敗の `|| true` による無言の握り潰しを撤去し、失敗時は stderr に警告を出力（Rule of Repair）。reap セマンティクス（return 0）は維持
- `claude-code-constraints.md` § Background Agent Sessions に `claude stop` の短縮 ID 制約を追記
- `mock-claude.bash` のコメントを staleness coupling として同期更新

## Test Plan
- [x] `claude_bg_stop` にフル UUID → mock claude に短縮8桁で届くことを assert
- [x] `claude_bg_stop` に短縮 ID → そのまま届くことを assert
- [x] 停止失敗時に stderr 警告が出ることを assert
- [x] 全36テスト pass（`bats tests/shared/claude-bg.bats`）