### PR TITLE
fix: session-id.sh reads provisioned ID from .cekernel-env in worktree

### DIFF
--- a/scripts/shared/session-id.sh
+++ b/scripts/shared/session-id.sh
@@ -8,12 +8,29 @@
 #   CEKERNEL_IPC_DIR    — Exports $HOME/.local/var/cekernel/ipc/${CEKERNEL_SESSION_ID}
 
 if [[ -z "${CEKERNEL_SESSION_ID:-}" ]]; then
-  # Get repository name (fallback to "cekernel" outside git)
-  _repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "cekernel")
-  # Random 8-digit hex
-  _hex=$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')
-  export CEKERNEL_SESSION_ID="${_repo_name}-${_hex}"
-  unset _repo_name _hex
+  # Check for .cekernel-env provisioned by spawn.sh (Worker worktree context).
+  # When a Worker's process scripts source session-id.sh without
+  # CEKERNEL_SESSION_ID in the environment (shell state doesn't persist
+  # between Bash tool calls), reading the provisioned ID prevents incorrect
+  # re-derivation from the worktree directory name (#629).
+  _cekernel_toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || true
+  _cekernel_env_file="${_cekernel_toplevel:+${_cekernel_toplevel}/.cekernel-env}"
+  if [[ -n "${_cekernel_env_file:-}" && -f "$_cekernel_env_file" ]]; then
+    _provisioned_id=$(grep '^export CEKERNEL_SESSION_ID=' "$_cekernel_env_file" 2>/dev/null | head -1 | sed 's/^export CEKERNEL_SESSION_ID=//')
+    if [[ -n "${_provisioned_id:-}" ]]; then
+      export CEKERNEL_SESSION_ID="$_provisioned_id"
+    fi
+    unset _provisioned_id
+  fi
+  unset _cekernel_toplevel _cekernel_env_file
+
+  # Fallback: generate a new session ID (Orchestrator or non-worktree context)
+  if [[ -z "${CEKERNEL_SESSION_ID:-}" ]]; then
+    _repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "cekernel")
+    _hex=$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')
+    export CEKERNEL_SESSION_ID="${_repo_name}-${_hex}"
+    unset _repo_name _hex
+  fi
 fi
 
 CEKERNEL_VAR_DIR="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"

--- a/scripts/shared/session-id.sh
+++ b/scripts/shared/session-id.sh
@@ -3,17 +3,22 @@
 #
 # Usage: source session-id.sh
 #
-# Environment variables:
-#   CEKERNEL_SESSION_ID — Auto-generated as {repo-name}-{random-hex-8} if not set
-#   CEKERNEL_IPC_DIR    — Exports $HOME/.local/var/cekernel/ipc/${CEKERNEL_SESSION_ID}
+# Resolution order for CEKERNEL_SESSION_ID:
+#   1. Already set in environment → use as-is
+#   2. .cekernel-env exists at git toplevel → read provisioned ID (#629)
+#   3. Generate new ID as {repo-name}-{random-hex-8}
+#
+# Environment variables (exported):
+#   CEKERNEL_SESSION_ID — Session identifier
+#   CEKERNEL_IPC_DIR    — $HOME/.local/var/cekernel/ipc/${CEKERNEL_SESSION_ID}
 
 if [[ -z "${CEKERNEL_SESSION_ID:-}" ]]; then
-  # Check for .cekernel-env provisioned by spawn.sh (Worker worktree context).
-  # When a Worker's process scripts source session-id.sh without
-  # CEKERNEL_SESSION_ID in the environment (shell state doesn't persist
-  # between Bash tool calls), reading the provisioned ID prevents incorrect
-  # re-derivation from the worktree directory name (#629).
   _cekernel_toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || true
+
+  # Check for .cekernel-env provisioned by spawn.sh (Worker worktree context).
+  # Shell state doesn't persist between Claude Code Bash tool calls, so
+  # reading the provisioned ID prevents incorrect re-derivation from the
+  # worktree directory name (#629).
   _cekernel_env_file="${_cekernel_toplevel:+${_cekernel_toplevel}/.cekernel-env}"
   if [[ -n "${_cekernel_env_file:-}" && -f "$_cekernel_env_file" ]]; then
     _provisioned_id=$(grep '^export CEKERNEL_SESSION_ID=' "$_cekernel_env_file" 2>/dev/null | head -1 | sed 's/^export CEKERNEL_SESSION_ID=//')
@@ -22,15 +27,16 @@ if [[ -z "${CEKERNEL_SESSION_ID:-}" ]]; then
     fi
     unset _provisioned_id
   fi
-  unset _cekernel_toplevel _cekernel_env_file
+  unset _cekernel_env_file
 
   # Fallback: generate a new session ID (Orchestrator or non-worktree context)
   if [[ -z "${CEKERNEL_SESSION_ID:-}" ]]; then
-    _repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "cekernel")
+    _repo_name=$(basename "${_cekernel_toplevel:-cekernel}" 2>/dev/null || echo "cekernel")
     _hex=$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')
     export CEKERNEL_SESSION_ID="${_repo_name}-${_hex}"
     unset _repo_name _hex
   fi
+  unset _cekernel_toplevel
 fi
 
 CEKERNEL_VAR_DIR="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"

--- a/tests/shared/session-id.bats
+++ b/tests/shared/session-id.bats
@@ -59,3 +59,84 @@ setup() {
   assert_eq "exits 0" "0" "$status"
   assert_match "new ID has {name}-{hex8} format" "^[a-z0-9._-]+-[0-9a-f]{8}$" "$output"
 }
+
+# ── .cekernel-env auto-discovery (issue #629) ──
+
+@test "session-id.sh reads provisioned ID from .cekernel-env when CEKERNEL_SESSION_ID is unset" {
+  # Create a temp git repo with .cekernel-env (simulates a Worker worktree)
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init --quiet
+  echo "export CEKERNEL_SESSION_ID=cekernel-provisioned1" > "${tmpdir}/.cekernel-env"
+
+  run bash -c "
+    cd '$tmpdir'
+    unset CEKERNEL_SESSION_ID
+    unset CEKERNEL_IPC_DIR
+    source '${SESSION_SCRIPT}'
+    echo \"\${CEKERNEL_SESSION_ID}\"
+  "
+  rm -rf "$tmpdir"
+
+  assert_eq "exits 0" "0" "$status"
+  assert_eq "uses provisioned session ID" "cekernel-provisioned1" "$output"
+}
+
+@test "session-id.sh ignores .cekernel-env when CEKERNEL_SESSION_ID is already set" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init --quiet
+  echo "export CEKERNEL_SESSION_ID=cekernel-provisioned2" > "${tmpdir}/.cekernel-env"
+
+  run bash -c "
+    cd '$tmpdir'
+    export CEKERNEL_SESSION_ID='cekernel-explicit99'
+    unset CEKERNEL_IPC_DIR
+    source '${SESSION_SCRIPT}'
+    echo \"\${CEKERNEL_SESSION_ID}\"
+  "
+  rm -rf "$tmpdir"
+
+  assert_eq "exits 0" "0" "$status"
+  assert_eq "keeps explicit ID" "cekernel-explicit99" "$output"
+}
+
+@test "session-id.sh derives correct IPC dir from .cekernel-env provisioned ID" {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init --quiet
+  echo "export CEKERNEL_SESSION_ID=cekernel-ipctest01" > "${tmpdir}/.cekernel-env"
+
+  local expected_var_dir="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"
+  run bash -c "
+    cd '$tmpdir'
+    unset CEKERNEL_SESSION_ID
+    unset CEKERNEL_IPC_DIR
+    source '${SESSION_SCRIPT}'
+    echo \"\${CEKERNEL_IPC_DIR}\"
+  "
+  rm -rf "$tmpdir"
+
+  assert_eq "exits 0" "0" "$status"
+  assert_eq "IPC dir uses provisioned ID" "${expected_var_dir}/ipc/cekernel-ipctest01" "$output"
+}
+
+@test "session-id.sh falls back to generation when no .cekernel-env exists" {
+  # Use a temp git repo WITHOUT .cekernel-env
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  git -C "$tmpdir" init --quiet
+
+  run bash -c "
+    cd '$tmpdir'
+    unset CEKERNEL_SESSION_ID
+    unset CEKERNEL_IPC_DIR
+    source '${SESSION_SCRIPT}'
+    echo \"\${CEKERNEL_SESSION_ID}\"
+  "
+  rm -rf "$tmpdir"
+
+  assert_eq "exits 0" "0" "$status"
+  # Temp dir basename may contain uppercase (mktemp), so allow [A-Za-z]
+  assert_match "generates new ID" "^[a-zA-Z0-9._-]+-[0-9a-f]{8}$" "$output"
+}


### PR DESCRIPTION
closes #629

## Summary
- Worker の process scripts が `session-id.sh` を source する際、`CEKERNEL_SESSION_ID` が未 set だと worktree ディレクトリ名から誤ったセッション ID を再導出してしまうバグを修正
- `session-id.sh` に `.cekernel-env` 自動発見機構を追加: git toplevel に `.cekernel-env`（`spawn.sh` が provision 時に書き込み済み）が存在すれば、そこから provisioned session ID を読み取る
- 解決順序: (1) 環境変数 → (2) `.cekernel-env` → (3) 新規生成（従来挙動）

## Test plan
- [x] `.cekernel-env` が存在する worktree 内で provisioned ID が使われる
- [x] `CEKERNEL_SESSION_ID` が既に set されていれば `.cekernel-env` を無視する
- [x] `.cekernel-env` から読んだ ID で正しい IPC dir が導出される
- [x] `.cekernel-env` が存在しない場合は従来どおり新 ID を生成する
- [x] 既存テスト（Step D パターン含む）が全て通過
- [x] `notify-complete.bats` も通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)