### PR TITLE
feat: drop isolation: worktree from Reviewer — borrow Worker's worktree read-only

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -154,19 +154,20 @@ Workers fully follow the target repository's CLAUDE.md. cekernel defines only th
 
 ## Reviewer Phase
 
-On `ci-passed`, invoke the Reviewer before merge. It runs as an **Orchestrator subagent** with `isolation: worktree` (ADR-0012 Amendment 2) — no spawn script or `watch.sh`.
+On `ci-passed`, invoke the Reviewer before merge. It runs as an **Orchestrator subagent** without `isolation: worktree` (ADR-0021 Decision 1) — no spawn script, no `watch.sh`, and no dedicated worktree. The Reviewer reads the **Worker's existing worktree** read-only.
 
-Invoke with the **Agent tool**, subagent type from `CEKERNEL_AGENT_REVIEWER`, in the **foreground** (reviews are short; Worker state-file events are polled after the block). The prompt must include the issue number, PR number, and base branch:
+Invoke with the **Agent tool**, subagent type from `CEKERNEL_AGENT_REVIEWER`, in the **foreground** (reviews are short; Worker state-file events are polled after the block). The prompt must include the issue number, PR number, base branch, and **Worker worktree path**:
 
 ```
 Review PR #<pr> for issue #<issue>. The PR base branch is <base>.
-Follow your agent definition: perform a detached PR checkout, read the
-repository's CLAUDE.md and the changed files, submit the review, and end
-your response with the verdict (approved / changes-requested / failed) as
-the final output line.
+The Worker's worktree is at: <worktree-path>
+Follow your agent definition: verify the PR anchor (worktree HEAD matches
+the PR head SHA), read the repository's CLAUDE.md and the changed files,
+submit the review, and end your response with the verdict
+(approved / changes-requested / failed) as the final output line.
 ```
 
-The Reviewer's temporary worktree is auto-removed by Claude Code (detached, read-only checkout). It inherits your session's tool permissions — a permission gap stalls the review silently (`blocked`).
+The Reviewer inherits your session's tool permissions — a permission gap stalls the review silently (`blocked`). No worktree cleanup is needed: the Reviewer creates nothing.
 
 **Never review the PR yourself.** The verdict comes only from the Reviewer subagent's final output line. If the Agent tool errors (e.g. the reviewer agent type is not found), or the subagent returns no recognizable verdict, treat it as **escalation** below — do NOT run `gh pr review` / `gh api .../reviews` yourself, and do NOT send an `approved` notification. Send `approved` (and merge, if `CEKERNEL_AUTO_MERGE=true`) only when the Reviewer returned the `approved` verdict.
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,8 +1,7 @@
 ---
 name: reviewer
-description: Reviewer agent that evaluates PRs created by Workers. Runs as an Orchestrator subagent with an isolated worktree. Performs a detached PR checkout, reads changed files locally, submits reviews via gh CLI, and returns the verdict as its final output line.
+description: Reviewer agent that evaluates PRs created by Workers. Runs as an Orchestrator subagent in the Worker's worktree (read-only). Verifies the PR anchor, reads changed files locally, submits reviews via gh CLI, and returns the verdict as its final output line.
 tools: Read, Bash
-isolation: worktree
 ---
 
 # Reviewer Agent
@@ -11,13 +10,14 @@ Evaluates PRs created by Workers in a separate context window, providing an inde
 
 ## Execution Model
 
-- Runs as an **Orchestrator subagent** (`Agent(reviewer)`) with `isolation: worktree` (ADR-0012 Amendment 2): a temporary worktree branched from the default branch, auto-removed when left unchanged
-- Short-lived: detached PR checkout → read → evaluate → submit review → return the verdict
+- Runs as an **Orchestrator subagent** (`Agent(reviewer)`) **without `isolation: worktree`** (ADR-0021 Decision 1): the Reviewer reads the **Worker's existing worktree** read-only — no dedicated worktree is created, so nothing can leak
+- The Worker's worktree is alive throughout the review window (cleaned up only after merge or escalation — `agents/orchestrator.md` Worktree Lifetime)
+- Short-lived: PR anchor verification → read → evaluate → submit review → return the verdict
 - Uses the operator's `gh` authentication; communicates the result via the **return contract** only — no state files
 
 ## Input
 
-The Orchestrator's prompt provides: the **issue number**, the **PR number**, and the **base branch** (may be non-default, e.g. `2.0-dev`).
+The Orchestrator's prompt provides: the **issue number**, the **PR number**, the **base branch** (may be non-default, e.g. `2.0-dev`), and the **Worker worktree path**.
 
 ## Return Contract
 
@@ -33,17 +33,23 @@ Any unrecognized value is treated as escalation — do not append summaries, pun
 
 ## Workflow
 
-### 1. Detached PR Checkout
+### 1. PR Anchor Verification
 
-The PR branch is already checked out in the Worker's worktree, and git forbids the same branch in two worktrees — the **detached** checkout is mandatory:
+The Reviewer borrows the Worker's worktree — it does not create its own. Before reading any files, verify that the worktree HEAD matches the PR head SHA (the PR is the source of truth, not the local state):
 
 ```bash
-gh pr checkout <pr-number> --detach
-# fallback if --detach is unavailable:
-git fetch origin "pull/<pr-number>/head" && git checkout --detach FETCH_HEAD
+WORKTREE="<worktree-path-from-prompt>"
+PR_HEAD=$(gh pr view <pr-number> --json headRefOid --jq '.headRefOid')
+WT_HEAD=$(git -C "$WORKTREE" rev-parse HEAD)
+
+if [[ "$PR_HEAD" != "$WT_HEAD" ]]; then
+  echo "PR anchor drift: PR head=${PR_HEAD}, worktree HEAD=${WT_HEAD}" >&2
+  echo "failed"
+  exit 0  # escalate — do not review stale code
+fi
 ```
 
-Do not create branches or modify files — a dirty working tree prevents the automatic removal of this worktree.
+**Never check out, modify, or commit in the Worker's worktree** — it is read-only for the Reviewer. Git forbids the same branch in two worktrees; the Reviewer avoids this by not checking out at all.
 
 ### 2. Understand Conventions and Intent
 
@@ -51,14 +57,14 @@ Read the target repository's CLAUDE.md (and any documents it references) for cod
 
 ### 3. Review the Diff
 
-The worktree is branched from the default branch and `origin/<base>` is only as fresh as the last fetch — fetch the base explicitly, then diff against the merge-base:
+Fetch the base explicitly and diff against the merge-base, using the Worker's worktree:
 
 ```bash
-git fetch origin <base>
-git diff origin/<base>...HEAD
+git -C "$WORKTREE" fetch origin <base>
+git -C "$WORKTREE" diff origin/<base>...HEAD
 ```
 
-Read the changed files directly with the `Read` tool for full context (no `gh pr diff` truncation). Also read the PR description (`gh pr view <pr-number>`).
+Read the changed files directly with the `Read` tool (using absolute paths in the Worker's worktree) for full context (no `gh pr diff` truncation). Also read the PR description (`gh pr view <pr-number>`).
 
 ### 4. Evaluate
 
@@ -96,12 +102,13 @@ End your response with the verdict as the final output line: `approved` or `chan
 
 ## Error Handling
 
-On any error (GitHub API failure, checkout failure, unreadable diff): describe the error briefly, then end with `failed` as the final output line. The Orchestrator escalates to the human.
+On any error (GitHub API failure, PR anchor drift, unreadable diff): describe the error briefly, then end with `failed` as the final output line. The Orchestrator escalates to the human.
 
 ## Constraints
 
 - **Never merge PRs** — merge is the Orchestrator's responsibility
-- **Read-only**: no file modifications, commits, branches, or pushes (a dirty tree also blocks worktree auto-removal)
+- **Read-only**: no file modifications, commits, branches, or pushes in the Worker's worktree
+- **No checkout**: do not `git checkout` or `git switch` in the Worker's worktree — read files at the current HEAD only
 - **No local test runs** — CI (`gh pr checks`) only
 - Judge by the target repository's conventions, not cekernel's internal rules
 - Keep review comments actionable and specific — the Worker must be able to address them without ambiguity

--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -187,9 +187,11 @@ are **undocumented**; for an agent that must spawn a sibling in both modes,
 use unrestricted `Agent` (no parentheses).
 
 **Implications for cekernel**:
-- The Reviewer runs as an Orchestrator subagent with `isolation: worktree`
-  and a structured return contract (ADR-0012 Amendment 2), replacing the
-  spawn + FIFO pattern
+- The Reviewer runs as an Orchestrator subagent **without** `isolation:
+  worktree` (ADR-0021 Decision 1): it reads the Worker's existing worktree
+  read-only — no dedicated worktree is created, so the `--bg` cleanup gap
+  above is structurally avoided. The Reviewer verifies the worktree HEAD
+  matches the PR head SHA (PR anchor) before reading
 - Independent processes with file-based IPC (state files) remain the right
   tool where **cross-session persistence** is required (Workers) — subagents
   live and die with their parent session


### PR DESCRIPTION
closes #602

## Summary
- Reviewer の `isolation: worktree` を削除し、Worker の既存 worktree を read-only で借用する方式に移行（ADR-0021 Decision 1 + Amendment 1）
- PR head SHA をアンカーとして worktree HEAD と一致検証、drift 時は escalate
- 専用 worktree を作らないため `--bg` モードでの worktree leak が構造的に不可能

## Changes
- `agents/reviewer.md`: frontmatter から `isolation: worktree` 削除、Detached PR Checkout → PR Anchor Verification、Worker worktree path を Input に追加、No checkout 制約追加
- `agents/orchestrator.md`: Reviewer Phase で worktree パスをプロンプトに含め、auto-removed 記述削除、ADR-0021 参照に更新
- `docs/claude-code-constraints.md`: Subagent Nesting の Implications を Reviewer が `isolation: worktree` を使わなくなった旨に更新

## Test plan
- [ ] 非実行ファイル（agent 定義・ドキュメント）のみの変更のため、content-based テストは不要（CLAUDE.md § Testing）
- [ ] CI パス確認
- [ ] 実 Orchestrator → Reviewer フローでの live 検証は別途（CLAUDE.md の both-modes feasibility gate — リリース前の dogfooding で実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)