### PR TITLE
fix: prevent Reviewer approval-word leakage and Orchestrator SECURITY WARNING bypass (#628)

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -182,11 +182,21 @@ submit the review, and end your response with the verdict
 
 The Reviewer inherits your session's tool permissions — a permission gap stalls the review silently (`blocked`). No worktree cleanup is needed: the Reviewer creates nothing.
 
-**Never review the PR yourself.** The verdict comes only from the Reviewer subagent's final output line. If the Agent tool errors (e.g. the reviewer agent type is not found), or the subagent returns no recognizable verdict, treat it as **escalation** below — do NOT run `gh pr review` / `gh api .../reviews` yourself, and do NOT send an `approved` notification. Send `approved` (and merge, if `CEKERNEL_AUTO_MERGE=true`) only when the Reviewer returned the `approved` verdict.
+**Never review the PR yourself.** The verdict comes only from the Reviewer subagent's final output line. If the Agent tool errors (e.g. the reviewer agent type is not found), or the subagent returns no recognizable verdict, treat it as **escalation** below — do NOT run `gh pr review` / `gh api .../reviews` yourself, and do NOT send an `approved` notification. Send `approved` (and merge, if `CEKERNEL_AUTO_MERGE=true`) only when the Reviewer returned the `approved` verdict **and** no SECURITY WARNING is present (see below).
+
+### SECURITY WARNING Check (ADR-0021 Decision 3)
+
+Before acting on the verdict, inspect the Agent tool's full result for SECURITY WARNING markers (e.g. `[Self-Approval]`, `[External-Write]`). If any SECURITY WARNING is present:
+
+1. **Do NOT auto-advance** — regardless of the verdict word, treat it as **unverified**
+2. **Surface the warning** in the completion summary: include the warning text and mark the verdict as `unverified`
+3. **Escalate** — follow the escalation path (cleanup, desktop notification, lock release) so a human can inspect the PR and the warning
+
+This prevents the Orchestrator from silently swallowing a security signal and reporting a clean approval (Rule of Repair).
 
 ### Handling the Verdict (final output line)
 
-**approved** — merge per `CEKERNEL_AUTO_MERGE`, then clean up immediately. Do NOT wait or poll for a human merge — the branch and PR remain on the remote:
+**approved** (no SECURITY WARNING) — merge per `CEKERNEL_AUTO_MERGE`, then clean up immediately. Do NOT wait or poll for a human merge — the branch and PR remain on the remote:
 
 ```bash
 gh pr merge <pr-number> --delete-branch     # only if CEKERNEL_AUTO_MERGE=true
@@ -211,7 +221,7 @@ watch.sh <issue>     # on ci-passed → Reviewer again (loop)
 
 Track the retry count in working memory; after `CEKERNEL_REVIEW_MAX_RETRIES` reject cycles, escalate.
 
-**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, or Agent tool error:
+**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **SECURITY WARNING detected** in the subagent result:
 
 ```bash
 cleanup-worktree.sh <issue>
@@ -245,7 +255,7 @@ source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <i
 ```
 - **Zombie / hang diagnosis**: `health-check.sh [issue]`; lifecycle logs live in `${CEKERNEL_IPC_DIR}/logs/` (`watch-logs.sh [issue]`) — a long-silent log suggests a hang
 - **CI failure**: the Worker retries up to `CEKERNEL_CI_MAX_RETRIES`, then reports `failed` — escalate to human
-- **Reviewer failure** (API outage, Agent tool error, `failed`, unrecognized line): treat as escalation (above)
+- **Reviewer failure** (API outage, Agent tool error, `failed`, unrecognized line, or SECURITY WARNING in subagent result): treat as escalation (above)
 
 ## Completion
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -96,9 +96,11 @@ gh api "repos/${OWNER_REPO}/pulls/<pr-number>/reviews" \
   -f event="$EVENT" -f body="..."
 ```
 
+**Self-review body constraint (ADR-0021 Decision 3)**: when `EVENT=COMMENT` (self-review), the review body must be **neutral** — it contains only your review findings (what you observed, what needs fixing if any). **Never write approval words** (`APPROVE`, `approve`, `LGTM`, etc.) in the body text. The GitHub COMMENT is an *artifact* of your review, not the *verdict*. Writing an approval word in a COMMENT body simulates an approval the GitHub identity cannot legitimately make, and trips the auto-mode `[Self-Approval]` security classifier. The verdict is conveyed exclusively via the return contract (final output line) — see below.
+
 ### 6. Return the Verdict
 
-End your response with the verdict as the final output line: `approved` or `changes-requested`. Return the **review verdict**, not the GitHub submission method — a self-review submitted as COMMENT still returns the verdict. Nothing may follow the verdict line.
+End your response with the verdict as the final output line: `approved` or `changes-requested`. Return the **review verdict**, not the GitHub submission method — a self-review submitted as COMMENT still returns the verdict. The verdict travels **out-of-band** (your final output line to the Orchestrator) and must not depend on or duplicate in the GitHub review body. Nothing may follow the verdict line.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

closes #628

ADR-0021 決定3 の実装。Reviewer が自 PR に投稿する COMMENT 本文に承認語を含めない制約と、Orchestrator が SECURITY WARNING を検出した場合に自動進行をブロックする規則を agent 定義に追加。

- **`agents/reviewer.md`**: Submit Review セクションに self-review body constraint を追加。自 PR への COMMENT 本文に承認語（`APPROVE`, `approve`, `LGTM` 等）を含めない。verdict は最終出力行（out-of-band）でのみ伝達
- **`agents/orchestrator.md`**: Reviewer Phase に SECURITY WARNING Check セクションを新設。`[Self-Approval]` 等の SECURITY WARNING が Agent ツール結果に含まれる場合、verdict を unverified 扱いとし escalation 処理へ回す。Error Handling の Reviewer failure 条件にも追加

## Test plan

- [x] 変更対象は非実行ファイル（agent 定義 `.md`）のみのため、CLAUDE.md テスト方針に従い新規テストは不要
- [ ] CI（既存テストスイート）が pass すること
- [ ] plugin モードでの dogfooding（リリース前に別レポで `--plugin-dir` 検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)