### PR TITLE
fix: add idle/working → alive to liveness matrix (#638)

### DIFF
--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -302,13 +302,14 @@ roster observation; claude v2.1.202):
   detection never fires (#591).
 - **Observed (status, state) matrix** (ADR-0018 — this table is the
   contract; it is mirrored in `scripts/shared/claude-bg.sh` and
-  `tests/helpers/mock-claude.bash`):
+  `tests/helpers/mock-claude.bash`; last updated v2.1.205, 2026-07-09):
 
   | `status` | `state` | Verdict |
   |----------|---------|---------|
   | `busy` | `working` | alive |
   | `busy` | (absent) | alive |
   | (absent) | `busy` | alive (pre-split legacy shape) |
+  | `idle` | `working` | alive (v2.1.205: between turns, #638) |
   | `blocked` | `working` | blocked (v2.1.201 shape) |
   | `idle` | `blocked` | blocked (v2.1.202 shape) |
   | (absent) | `blocked` | blocked (pre-split legacy shape) |
@@ -319,11 +320,12 @@ roster observation; claude v2.1.202):
   | — session absent — | | not-listed |
   | any pair not above | | unknown-value |
 
-  Real roster tally (2026-07-07, v2.1.202): `busy/working`,
-  `busy/(absent)` (interactive), `idle/blocked`, `idle/done`,
-  `(absent)/done`, `(absent)/stopped`. Note `blocked` appeared in
-  `state` with `status: "idle"` — NOT in `status` as ADR-0018
-  originally predicted from v2.1.201.
+  Real roster tally (2026-07-07, v2.1.202; updated 2026-07-09,
+  v2.1.205): `busy/working`, `busy/(absent)` (interactive),
+  `idle/working` (v2.1.205, live session between turns, #638),
+  `idle/blocked`, `idle/done`, `(absent)/done`, `(absent)/stopped`.
+  Note `blocked` appeared in `state` with `status: "idle"` — NOT in
+  `status` as ADR-0018 originally predicted from v2.1.201.
 - **`agents --json` does not resurrect the daemon** (isolated-HOME
   probe, v2.1.202, #593): with no daemon running, `claude agents
   --json` (and `--all`) returns `[]` with exit 0, starts no `claude

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -155,7 +155,10 @@ claude_bg_token_verdict_from_json() {
   # The observed (status, state) matrix — see the header table. Liveness
   # lives in `status`, terminality in `state` (#581, #591).
   case "${status}/${state}" in
-    busy/working|busy/-|-/busy)
+    busy/working|busy/-|-/busy|idle/working)
+      # idle/working: v2.1.205 shape (#638) — live session between active
+      # turns. idle = not currently in a turn (not terminal), working =
+      # session not finished → alive. Same verdict as busy/working.
       echo "alive"
       return 0
       ;;

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -15,13 +15,14 @@
 #   bg-session.sh  — lifecycle core, predicates only
 #   backends / watch / orchctl / wrapper / issue-lock — verdict consumers
 #
-# ── Observed (status, state) matrix — v2.1.202, 2026-07-07 (ADR-0018) ──
+# ── Observed (status, state) matrix — v2.1.205, 2026-07-09 (ADR-0018) ──
 #
 #   | `status`  | `state`   | Verdict            |
 #   |-----------|-----------|--------------------|
 #   | busy      | working   | alive              |
 #   | busy      | (absent)  | alive              |
 #   | (absent)  | busy      | alive   (pre-split legacy shape)      |
+#   | idle      | working   | alive   (v2.1.205: between turns, #638)  |
 #   | blocked   | working   | blocked (v2.1.201 shape)              |
 #   | idle      | blocked   | blocked (v2.1.202 shape)              |
 #   | (absent)  | blocked   | blocked (pre-split legacy shape)      |

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -462,7 +462,7 @@ worker_state() {
   echo "RUNNING:2026-02-28T10:00:00Z:working" > "${session_dir}/worker-576.state"
   echo "$SESSION_TOKEN" > "${session_dir}/handle-576.worker"
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record_pair "$SESSION_TOKEN" background /tmp/wt 1700000000000 idle working)]"
+    "[$(mock_claude_agent_record_pair "$SESSION_TOKEN" background /tmp/wt 1700000000000 running active)]"
   run bash "$ORCHCTL" gc
   assert_file_exists "state preserved (unknown-value → assume alive)" \
     "${session_dir}/worker-576.state"

--- a/tests/ctl/orchctl-read.bats
+++ b/tests/ctl/orchctl-read.bats
@@ -500,7 +500,7 @@ make_handle() {
   # — schema drift counts as alive.
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record_pair "$ORCH_TOKEN_A" background /repo 1700000000000 idle working)]"
+    "[$(mock_claude_agent_record_pair "$ORCH_TOKEN_A" background /repo 1700000000000 running active)]"
   run --separate-stderr bash "$ORCHCTL" count
   assert_eq "unknown-value counted as alive" "1" "$output"
 }

--- a/tests/helpers/mock-claude.bash
+++ b/tests/helpers/mock-claude.bash
@@ -9,13 +9,14 @@
 # `agents --json` records carry extra fields — pid, id, name — and a
 # numeric epoch-millis startedAt, with a realpath'd cwd).
 #
-# ── Observed (status, state) matrix — v2.1.202, 2026-07-07 (ADR-0018) ──
+# ── Observed (status, state) matrix — v2.1.205, 2026-07-09 (ADR-0018) ──
 #
 #   | `status`  | `state`   | Verdict            |
 #   |-----------|-----------|--------------------|
 #   | busy      | working   | alive              |
 #   | busy      | (absent)  | alive              |
 #   | (absent)  | busy      | alive   (pre-split legacy shape)      |
+#   | idle      | working   | alive   (v2.1.205: between turns, #638)  |
 #   | blocked   | working   | blocked (v2.1.201 shape)              |
 #   | idle      | blocked   | blocked (v2.1.202 shape)              |
 #   | (absent)  | blocked   | blocked (pre-split legacy shape)      |

--- a/tests/orchestrator/health-check.bats
+++ b/tests/orchestrator/health-check.bats
@@ -80,7 +80,7 @@ _active_worker() {
 @test "health-check does not zombie-flag on an unknown (status, state) pair (ADR-0018)" {
   _active_worker 94
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 idle working)]"
+    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 running active)]"
 
   run bash "$HEALTH_SCRIPT" 94
   assert_eq "exit 0 (inconclusive is not unhealthy)" "0" "$status"

--- a/tests/orchestrator/watch.bats
+++ b/tests/orchestrator/watch.bats
@@ -196,7 +196,7 @@ teardown() {
   worker_state_write 594 RUNNING "phase1:implement"
   echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-594.worker"
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 idle working)]"
+    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 running active)]"
   export CEKERNEL_WATCH_QUERY_RETRY_MAX=10
 
   local out="${BATS_TEST_TMPDIR}/watch-out.json"

--- a/tests/shared/backend-headless.bats
+++ b/tests/shared/backend-headless.bats
@@ -308,7 +308,7 @@ FULL_UUID="aaaa1111-2222-4333-8444-555566667777"
 @test "backend_worker_status propagates unknown-value (never coerced)" {
   echo "$FULL_UUID" > "${CEKERNEL_IPC_DIR}/handle-500.worker"
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record_pair "$FULL_UUID" background "$WORKTREE_REAL" 1700000000000 idle working)]"
+    "[$(mock_claude_agent_record_pair "$FULL_UUID" background "$WORKTREE_REAL" 1700000000000 running active)]"
   run --separate-stderr backend_worker_status 500
   assert_eq "exit status" "5" "$status"
   assert_eq "report" "unknown-value" "$output"

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -91,6 +91,16 @@ enqueue_pair() {
   assert_eq "verdict" "done" "$output"
 }
 
+@test "verdict matrix: idle/working is alive (v2.1.205 shape, #638)" {
+  # claude 2.1.205: live session between active turns reports status=idle,
+  # state=working. idle = between turns (not terminal), working = session
+  # not finished → alive. Observed 2026-07-09, stable across 3 samples.
+  enqueue_pair idle working
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "alive" "$output"
+}
+
 @test "verdict matrix: idle/stopped and absent/stopped are stopped" {
   enqueue_pair idle stopped
   run claude_bg_token_verdict "$FULL_UUID"
@@ -120,12 +130,12 @@ enqueue_pair() {
 }
 
 @test "verdict: out-of-matrix pair reports unknown-value with exit 5 and stderr warning" {
-  enqueue_pair idle working
+  enqueue_pair running active
   run --separate-stderr claude_bg_token_verdict "$FULL_UUID"
   assert_eq "exit status" "5" "$status"
   assert_eq "report" "unknown-value" "$output"
-  assert_match "stderr warning names the pair" "idle" "$stderr"
-  assert_match "stderr warning names the pair" "working" "$stderr"
+  assert_match "stderr warning names the pair" "running" "$stderr"
+  assert_match "stderr warning names the pair" "active" "$stderr"
 }
 
 @test "verdict_from_json: malformed body reports query-failed" {
@@ -182,9 +192,16 @@ enqueue_pair() {
 
 @test "token_alive_from_json: unknown-value propagates as exit 5" {
   local json
-  json="[$(mock_claude_agent_record_pair "$FULL_UUID" background /tmp/x 1700000000000 idle working)]"
+  json="[$(mock_claude_agent_record_pair "$FULL_UUID" background /tmp/x 1700000000000 running active)]"
   run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
   assert_eq "unknown-value propagates as 5" "5" "$status"
+}
+
+@test "token_alive_from_json: idle/working is alive (v2.1.205 shape, #638)" {
+  local json
+  json="[$(mock_claude_agent_record_pair "$FULL_UUID" background /tmp/x 1700000000000 idle working)]"
+  run claude_bg_token_alive_from_json "$json" "$FULL_UUID"
+  assert_eq "idle/working is alive" "0" "$status"
 }
 
 @test "token_alive_from_json: busy and blocked are alive; done and missing are not" {

--- a/tests/shared/issue-lock.bats
+++ b/tests/shared/issue-lock.bats
@@ -236,7 +236,7 @@ lock_with_token() {
   mock_claude
   lock_with_token
   mock_claude_enqueue_agents \
-    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 idle working)]"
+    "[$(mock_claude_agent_record_pair "$TOKEN" background /tmp/wt 1700000000000 running active)]"
   run issue_lock_acquire "$REPO_A" "$ISSUE"
   assert_eq "acquire fails (unknown-value → assume alive)" "1" "$status"
 }


### PR DESCRIPTION
closes #638

## Summary
- `claude-bg.sh` の (status, state) マトリクスに `idle/working → alive` を追加（claude 2.1.205 で観測された live session のターン間状態）
- ADR-0018 の3点セット（`claude-bg.sh`、`claude-code-constraints.md`、`mock-claude.bash`）を同時更新
- `idle/working` の alive 判定テストを追加（verdict + token_alive_from_json）

## Test plan
- [x] `bats tests/shared/claude-bg.bats` — 38 tests pass（RED→GREEN→REFACTOR）
- [x] `idle/working` verdict = `alive`（exit 0）
- [x] `idle/working` token_alive_from_json = alive（exit 0）
- [x] 既存マトリクス行の判定に回帰なし
- [ ] CI 全テスト通過