### PR TITLE
feat: add Renovate customManager for bats-core version tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,15 @@
   ],
   "platformAutomerge": true,
   "minimumReleaseAge": "7 days",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": ["--branch (?<currentValue>v[0-9.]+) https://github\\.com/bats-core/bats-core"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "bats-core/bats-core"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
closes #655

## Summary
- CI の bats-core pin バージョン(`v1.13.0`)を Renovate 追従対象にするため、`renovate.json` に regex customManager を追加
- git-clone 方式はそのまま維持し、`--branch vX.Y.Z` パターンを検出して `github-releases` datasource で更新 PR を生成
- 既存の `minimumReleaseAge: 7 days` / patch・minor automerge ポリシーに自然に乗る

## Test plan
- [x] Renovate が `renovate.json` の customManager を認識し、bats-core の更新 PR を生成することを確認
- [x] CI (cekernel tests) が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)