### PR TITLE
fix: watch.sh が chunk timeout 時に誤った完了 banner を出力する問題を修正

### DIFF
--- a/scripts/orchestrator/watch.sh
+++ b/scripts/orchestrator/watch.sh
@@ -263,9 +263,24 @@ for pid in "${PIDS[@]}"; do
   wait "$pid" || FAILED=$((FAILED + 1))
 done
 
-# Output results
+# Classify results: count how many workers are still running (watching sentinel)
+WATCHING=0
+for issue in "${ISSUE_NUMBERS[@]}"; do
+  if [[ -f "${RESULT_DIR}/${issue}" ]]; then
+    local_result=$(jq -r '.result' < "${RESULT_DIR}/${issue}" 2>/dev/null || true)
+    if [[ "$local_result" == "watching" ]]; then
+      WATCHING=$((WATCHING + 1))
+    fi
+  fi
+done
+
+# Output banner — gate "All workers finished" to true terminal states only (#651)
 echo "---" >&2
-echo "All workers finished. (failed: ${FAILED})" >&2
+if [[ $WATCHING -gt 0 ]]; then
+  echo "Chunk elapsed; ${WATCHING} worker(s) still running." >&2
+else
+  echo "All workers finished. (failed: ${FAILED})" >&2
+fi
 echo "---" >&2
 
 for issue in "${ISSUE_NUMBERS[@]}"; do

--- a/tests/orchestrator/watch.bats
+++ b/tests/orchestrator/watch.bats
@@ -471,3 +471,58 @@ teardown() {
   assert_match "result is ci-passed" '"result":"ci-passed"' "$result_json"
   assert_match "detail is 77" '"detail":"77"' "$result_json"
 }
+
+# ── #651: banner accuracy — chunk timeout vs true completion ──
+
+@test "chunk timeout banner says still running, not All workers finished" {
+  # When chunk timeout fires (watching sentinel), the banner must NOT say
+  # "All workers finished" — that is a Rule of Least Surprise violation.
+  worker_state_write 651 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-651.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$TOKEN" background /tmp/wt 1700000000000 busy)]"
+
+  export CEKERNEL_WATCH_CHUNK_TIMEOUT=2
+  export CEKERNEL_WORKER_TIMEOUT=10
+  export CEKERNEL_STATE_POLL_INTERVAL=1
+
+  date +%s > "${CEKERNEL_IPC_DIR}/worker-651.spawned"
+
+  run bash "$WATCH_SCRIPT" 651
+  assert_eq "watch exits 0 at chunk boundary" "0" "$status"
+  # "All workers finished" must NOT appear in output (stdout+stderr via run)
+  if [[ "$output" == *"All workers finished"* ]]; then
+    echo "FAIL: 'All workers finished' banner appeared during chunk timeout" >&2
+    echo "  output: $output" >&2
+    return 1
+  fi
+  # Correct banner for chunk timeout should mention still running
+  assert_match "banner says still running" "still running" "$output"
+}
+
+@test "true completion banner says All workers finished" {
+  # When all workers genuinely complete, the banner must still say
+  # "All workers finished" — only chunk timeouts should use a different banner.
+  worker_state_write 652 RUNNING "phase1:implement"
+  echo "$TOKEN" > "${CEKERNEL_IPC_DIR}/handle-652.worker"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$TOKEN" background /tmp/wt 1700000000000 busy)]"
+
+  export CEKERNEL_WATCH_CHUNK_TIMEOUT=10
+  export CEKERNEL_WORKER_TIMEOUT=3600
+  export CEKERNEL_STATE_POLL_INTERVAL=1
+
+  date +%s > "${CEKERNEL_IPC_DIR}/worker-652.spawned"
+
+  local out="${BATS_TEST_TMPDIR}/watch-out-652.json"
+  local err="${BATS_TEST_TMPDIR}/watch-err-652.txt"
+  bash "$WATCH_SCRIPT" 652 > "$out" 2>"$err" &
+  local watch_pid=$!
+  sleep 2
+  worker_state_write 652 TERMINATED "ci-passed:88"
+  wait "$watch_pid"
+
+  local stderr_text
+  stderr_text=$(cat "$err")
+  assert_match "banner says All workers finished" "All workers finished" "$stderr_text"
+}


### PR DESCRIPTION
closes #651

## Summary
- `watch.sh` の最終 banner を結果 JSON と一致させ、chunk timeout 時に "All workers finished." ではなく "Chunk elapsed; N worker(s) still running." を出力するよう修正
- 結果ファイルの `result` フィールドを参照して `watching` sentinel を検出し、banner を条件分岐

## Test Plan
- [x] chunk timeout 時に "All workers finished" が出力されないことを検証するテスト追加・PASS
- [x] 真の完了時に "All workers finished" が出力されることを検証するテスト追加・PASS
- [x] 既存 watch.bats 全23テスト PASS（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)