### PR TITLE
feat: env.sh ファイル経由の Orchestrator env 配送 (#652)

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -16,32 +16,30 @@ Operates in the main working tree and manages the issue lifecycle:
 
 ## Process Environment
 
-You run as an independent `claude --bg` background session (ADR-0016 Phase 2). `spawn-orchestrator.sh` sets your process environment at spawn:
+You run as an independent `claude --bg` background session (ADR-0016 Phase 2). Shell state does not persist between Bash tool calls — every call starts from scratch.
 
-- `CEKERNEL_SESSION_ID`, `CEKERNEL_ENV`, `CEKERNEL_IPC_DIR` — session-scoped configuration
-- `PATH` — includes `scripts/orchestrator/`, `scripts/process/`, `scripts/shared/`
+`spawn-orchestrator.sh` writes `${CEKERNEL_IPC_DIR}/env.sh` before launching your session. This file contains all `CEKERNEL_*` variables, `PATH` (with `scripts/orchestrator/`, `scripts/process/`, `scripts/shared/`), and `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`. Your prompt provides the `CEKERNEL_IPC_DIR` path.
 
-Every Bash call inherits these. Do **not** prefix commands with `export CEKERNEL_...` chains, and invoke scripts by bare name:
+**Startup checklist** (every Bash call, in this order):
+
+1. `source "<CEKERNEL_IPC_DIR>/env.sh"` — substitute the literal path from your prompt
+2. `verify-env.sh` — validates required vars and PATH (exit 1 = STOP, do not proceed)
 
 ```bash
-# Good
+source "<CEKERNEL_IPC_DIR>/env.sh" && verify-env.sh
+# now all CEKERNEL_* vars and PATH are set — invoke scripts by bare name
 spawn-worker.sh 4
-
-# Unnecessary — env is already set; full paths not needed
-export CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID} && ${CEKERNEL_SCRIPTS}/orchestrator/spawn-worker.sh 4
 ```
 
-Shared helpers are sourced by bare name too (PATH-resolved): `source issue-lock.sh`, `source desktop-notify.sh`.
+If `verify-env.sh` fails, **STOP immediately**. Do **not** fall back to inline `export` — manual exports drift and drop variables (#652, #641-644). The env file is the sole delivery channel.
 
-**Startup check** (once, in your first Bash call): env delivery relies on the `claude --bg` daemon having been started with your values — a pre-existing daemon keeps its own environment (verified 2026-07-07, v2.1.202). Verify against your prompt:
+After sourcing, invoke scripts by bare name (PATH-resolved):
 
 ```bash
-echo "SID=${CEKERNEL_SESSION_ID:-UNSET} ENV=${CEKERNEL_ENV:-UNSET} spawn=$(command -v spawn-worker.sh || echo MISSING)"
+spawn-worker.sh 4
+source issue-lock.sh
+source desktop-notify.sh
 ```
-
-If a value is missing or differs from your prompt, the prompt is authoritative: prefix every subsequent script call with literal exports of the prompt values, and use `${CEKERNEL_SCRIPTS}`-prefixed paths from the prompt.
-
-The same applies to the other prompt-provided values (`CEKERNEL_AGENT_WORKER`, `CEKERNEL_AGENT_REVIEWER`, `CEKERNEL_AUTO_MERGE`, ...): normally already in your environment; on mismatch, use the prompt's literal values. If `CEKERNEL_AGENT_REVIEWER` is absent, derive it from `CEKERNEL_AGENT_WORKER` (`worker` → `reviewer`, `cekernel:worker` → `cekernel:reviewer`).
 
 Your Claude Code session UUID (separate from `CEKERNEL_SESSION_ID`) is captured and persisted by `spawn-orchestrator.sh` at spawn time. Never re-discover or overwrite it — a heuristic rewrite mis-attributes concurrent sessions (#571).
 

--- a/scripts/ctl/spawn-orchestrator.sh
+++ b/scripts/ctl/spawn-orchestrator.sh
@@ -51,15 +51,29 @@ CEKERNEL_ORCHESTRATOR_SCRIPTS="$(cd "${SCRIPT_DIR}/../orchestrator" && pwd)"
 CEKERNEL_PROCESS_SCRIPTS="$(cd "${SCRIPT_DIR}/../process" && pwd)"
 CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
 
+# ── Generate env.sh for Orchestrator env delivery (#652) ──
+# The daemon's inherited environment is UNSPECIFIED: a pre-existing daemon
+# keeps its own env, so subshell exports below only reach auto-started
+# daemons (ADR-0018 Decision 3, #589). env.sh is the reliable delivery
+# channel — the Orchestrator sources it on every Bash call.
+{
+  # Dump all CEKERNEL_* variables from the current environment
+  while IFS='=' read -r _key _val; do
+    [[ "$_key" == CEKERNEL_* ]] || continue
+    printf 'export %s="%s"\n' "$_key" "$_val"
+  done < <(env | grep '^CEKERNEL_' | sort)
+  # PATH with cekernel script directories
+  printf 'export PATH="%s:%s:%s:$PATH"\n' \
+    "$CEKERNEL_ORCHESTRATOR_SCRIPTS" \
+    "$CEKERNEL_PROCESS_SCRIPTS" \
+    "$CEKERNEL_SHARED_SCRIPTS"
+  # Disable background tasks (#558 — session re-invocation unverified)
+  printf 'export CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1\n'
+} > "${CEKERNEL_IPC_DIR}/env.sh"
+
 # ── Launch Orchestrator as a background agent session ──
-# The --bg invocation and spawn-line parsing live in claude_bg_spawn
-# (ADR-0018 Decision 1); this spawner injects the session env explicitly
-# (ADR-0018 Decision 3, #589 — the daemon's inherited environment is
-# UNSPECIFIED: these exports reach the session only when this call
-# auto-starts the daemon; a pre-existing daemon keeps its own env. The
-# reliable channel for CEKERNEL_* values is the prompt, which the
-# orchestrate/dispatch skills populate; the Orchestrator verifies env at
-# startup).
+# Subshell exports are best-effort (reach auto-started daemons only).
+# The reliable env channel is env.sh above — the Orchestrator sources it.
 # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 stays for now: under --bg an
 # auto-detached Bash call no longer kills the process (#558), but whether
 # a background-task completion re-invokes a `done` session is unverified —

--- a/scripts/ctl/spawn-orchestrator.sh
+++ b/scripts/ctl/spawn-orchestrator.sh
@@ -57,11 +57,19 @@ CEKERNEL_SHARED_SCRIPTS="$(cd "${SCRIPT_DIR}/../shared" && pwd)"
 # daemons (ADR-0018 Decision 3, #589). env.sh is the reliable delivery
 # channel — the Orchestrator sources it on every Bash call.
 {
-  # Dump all CEKERNEL_* variables from the current environment
+  # Required variables — always include (some may not be exported, e.g.
+  # CEKERNEL_ENV is set but not exported by load-env.sh)
+  printf 'export CEKERNEL_SESSION_ID="%s"\n' "$CEKERNEL_SESSION_ID"
+  printf 'export CEKERNEL_IPC_DIR="%s"\n' "$CEKERNEL_IPC_DIR"
+  printf 'export CEKERNEL_ENV="%s"\n' "${CEKERNEL_ENV:-default}"
+  # Additional CEKERNEL_* variables from the exported environment
+  # (agent names, auto-merge, etc. — set by the invoking skill)
   while IFS='=' read -r _key _val; do
-    [[ "$_key" == CEKERNEL_* ]] || continue
-    printf 'export %s="%s"\n' "$_key" "$_val"
-  done < <(env | grep '^CEKERNEL_' | sort)
+    case "$_key" in
+      CEKERNEL_SESSION_ID|CEKERNEL_IPC_DIR|CEKERNEL_ENV) continue ;;
+      CEKERNEL_*) printf 'export %s="%s"\n' "$_key" "$_val" ;;
+    esac
+  done < <(env | sort)
   # PATH with cekernel script directories
   printf 'export PATH="%s:%s:%s:$PATH"\n' \
     "$CEKERNEL_ORCHESTRATOR_SCRIPTS" \

--- a/scripts/shared/verify-env.sh
+++ b/scripts/shared/verify-env.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# verify-env.sh — Validate required CEKERNEL_* environment variables
+#
+# Usage: verify-env.sh
+#
+# Checks that required CEKERNEL_* vars are non-empty and that
+# spawn-worker.sh is on PATH. Exits 1 with a descriptive error on
+# any failure; exits 0 silently on success (Rule of Silence).
+#
+# Intended to be called after sourcing ${CEKERNEL_IPC_DIR}/env.sh
+# to catch env delivery failures early (fail-loud, Rule of Repair).
+#
+# Required variables:
+#   CEKERNEL_SESSION_ID — Session identifier
+#   CEKERNEL_IPC_DIR    — IPC directory path
+#   CEKERNEL_ENV        — Environment profile name
+#
+# PATH check:
+#   spawn-worker.sh must be resolvable via `command -v`
+set -euo pipefail
+
+ERRORS=()
+
+# ── Required variables ──
+for var in CEKERNEL_SESSION_ID CEKERNEL_IPC_DIR CEKERNEL_ENV; do
+  val="${!var:-}"
+  if [[ -z "$val" ]]; then
+    ERRORS+=("${var} is not set or empty")
+  fi
+done
+
+# ── PATH check ──
+if ! command -v spawn-worker.sh >/dev/null 2>&1; then
+  ERRORS+=("spawn-worker.sh not found on PATH")
+fi
+
+# ── Report ──
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo "verify-env: environment validation failed:" >&2
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}" >&2
+  done
+  exit 1
+fi

--- a/skills/references/orchestrator-launch.md
+++ b/skills/references/orchestrator-launch.md
@@ -59,9 +59,10 @@ _path="${_url#*:}"; _path="${_path#*//}"; _path="${_path%.git}"
 echo "${_path#*/}" > "${CEKERNEL_IPC_DIR}/repo"
 
 echo "CEKERNEL_SESSION_ID=${CEKERNEL_SESSION_ID}"
+echo "CEKERNEL_IPC_DIR=${CEKERNEL_IPC_DIR}"
 ```
 
-Capture `CEKERNEL_SESSION_ID` from the output line. It must be the `{repo}-{hex8}` value, **not** the Claude Code session UUID. (The Claude Code session ID is captured and persisted by `spawn-orchestrator.sh` itself — neither the skill nor the Orchestrator writes it.)
+Capture `CEKERNEL_SESSION_ID` and `CEKERNEL_IPC_DIR` from the output lines. `CEKERNEL_SESSION_ID` must be the `{repo}-{hex8}` value, **not** the Claude Code session UUID. `CEKERNEL_IPC_DIR` is used in the prompt's environment bootstrap line. (The Claude Code session ID is captured and persisted by `spawn-orchestrator.sh` itself — neither the skill nor the Orchestrator writes it.)
 
 ## Step E: Construct the Prompt and Launch
 
@@ -73,13 +74,11 @@ Process the following issues: <#N title, #M title, ...>
 <Base branch: <branch> if specified, otherwise omit this line>
 <Issue repo: <owner/repo> — pass --repo <owner/repo> to spawn-worker.sh and to issue-related gh commands. Only for cross-repo issues, otherwise omit this line>
 
-Environment values to propagate in ALL script invocations:
-- CEKERNEL_SESSION_ID=<session-id>
-- CEKERNEL_ENV=<profile>
-- CEKERNEL_SCRIPTS=<scripts-path>
-- CEKERNEL_AGENT_WORKER=<worker-agent-name>
-- CEKERNEL_AGENT_REVIEWER=<reviewer-agent-name>
+Environment bootstrap (run at the start of every Bash call):
+  source "<ipc-dir>/env.sh" && verify-env.sh
 ```
+
+The `<ipc-dir>` is the literal `CEKERNEL_IPC_DIR` path (from Step D). `env.sh` sets all `CEKERNEL_*` variables (session ID, env profile, agent names, etc.) and `PATH`. Do **not** list individual variable values in the prompt — `env.sh` is the sole delivery channel (#652).
 
 **MUST NOT**: do not include Worker spawn instructions using Agent tool language (`subagent_type`, `Agent(worker)`, etc.) in the prompt. Workers are spawned by the Orchestrator via `spawn-worker.sh` (Bash); the Reviewer is invoked by the Orchestrator itself as a subagent, following its own agent definition.
 

--- a/tests/ctl/spawn-orchestrator.bats
+++ b/tests/ctl/spawn-orchestrator.bats
@@ -176,6 +176,51 @@ enqueue_capture() {
 
 # ── conditional --bare (ADR-0016 Amendment 1) ──
 
+# ── env.sh generation (#652) ──
+
+@test "spawn generates env.sh in CEKERNEL_IPC_DIR with CEKERNEL_* vars" {
+  enqueue_capture
+  export CEKERNEL_AGENT_WORKER="cekernel:worker"
+  export CEKERNEL_AGENT_REVIEWER="cekernel:reviewer"
+  run_spawn "test prompt"
+  assert_eq "exit status" "0" "$status"
+
+  assert_file_exists "env.sh generated" "${CEKERNEL_IPC_DIR}/env.sh"
+  local content
+  content=$(cat "${CEKERNEL_IPC_DIR}/env.sh")
+  assert_match "env.sh has CEKERNEL_SESSION_ID" "CEKERNEL_SESSION_ID=" "$content"
+  assert_match "env.sh has CEKERNEL_IPC_DIR" "CEKERNEL_IPC_DIR=" "$content"
+  assert_match "env.sh has CEKERNEL_ENV" "CEKERNEL_ENV=" "$content"
+  assert_match "env.sh has CEKERNEL_AGENT_WORKER" "CEKERNEL_AGENT_WORKER=" "$content"
+  assert_match "env.sh has CEKERNEL_AGENT_REVIEWER" "CEKERNEL_AGENT_REVIEWER=" "$content"
+}
+
+@test "env.sh includes PATH with orchestrator, process, and shared scripts" {
+  enqueue_capture
+  run_spawn "test prompt"
+  assert_eq "exit status" "0" "$status"
+
+  local content
+  content=$(cat "${CEKERNEL_IPC_DIR}/env.sh")
+  assert_match "env.sh has PATH export" "export PATH=" "$content"
+  assert_match "env.sh PATH includes orchestrator scripts" "scripts/orchestrator" "$content"
+  assert_match "env.sh PATH includes process scripts" "scripts/process" "$content"
+  assert_match "env.sh PATH includes shared scripts" "scripts/shared" "$content"
+}
+
+@test "env.sh is sourceable and sets variables" {
+  enqueue_capture
+  run_spawn "test prompt"
+  assert_eq "exit status" "0" "$status"
+
+  # Source env.sh in a clean environment and verify
+  local sid
+  sid=$(bash -c "unset CEKERNEL_SESSION_ID; source '${CEKERNEL_IPC_DIR}/env.sh' && echo \$CEKERNEL_SESSION_ID")
+  assert_eq "sourcing env.sh sets CEKERNEL_SESSION_ID" "$CEKERNEL_SESSION_ID" "$sid"
+}
+
+# ── conditional --bare (ADR-0016 Amendment 1) ──
+
 @test "spawn succeeds without --bare-compatible auth, dropping --bare (OAuth)" {
   enqueue_capture
   unset ANTHROPIC_API_KEY

--- a/tests/shared/verify-env.bats
+++ b/tests/shared/verify-env.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# verify-env.bats — tests for scripts/shared/verify-env.sh
+#
+# verify-env.sh validates that required CEKERNEL_* env vars are set and
+# that spawn-worker.sh is on PATH. It exits 1 with a descriptive error
+# on any failure, and exits 0 silently on success (Rule of Silence).
+
+load '../helpers/assertions'
+load '../helpers/session'
+load '../helpers/mock-bin'
+
+setup() {
+  CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  VERIFY="${CEKERNEL_DIR}/scripts/shared/verify-env.sh"
+
+  set_test_session_id
+  source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+  rm -rf "$CEKERNEL_IPC_DIR"
+  mkdir -p "$CEKERNEL_IPC_DIR"
+
+  # Create a mock spawn-worker.sh on PATH
+  MOCK_BIN="${BATS_TEST_TMPDIR}/mock-bin"
+  mkdir -p "$MOCK_BIN"
+  echo '#!/usr/bin/env bash' > "${MOCK_BIN}/spawn-worker.sh"
+  chmod +x "${MOCK_BIN}/spawn-worker.sh"
+  export PATH="${MOCK_BIN}:${PATH}"
+}
+
+teardown() {
+  rm -rf "$CEKERNEL_IPC_DIR"
+}
+
+# ── success path ──
+
+@test "verify-env exits 0 when all required vars are set and spawn-worker.sh is on PATH" {
+  run bash "$VERIFY"
+  assert_eq "exit status" "0" "$status"
+}
+
+@test "verify-env produces no output on success (Rule of Silence)" {
+  run bash "$VERIFY"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "no stdout" "" "$output"
+}
+
+# ── missing required vars ──
+
+@test "verify-env exits 1 when CEKERNEL_SESSION_ID is unset" {
+  unset CEKERNEL_SESSION_ID
+  run bash "$VERIFY"
+  assert_eq "exit status" "1" "$status"
+  assert_match "error mentions CEKERNEL_SESSION_ID" "CEKERNEL_SESSION_ID" "$output"
+}
+
+@test "verify-env exits 1 when CEKERNEL_IPC_DIR is unset" {
+  unset CEKERNEL_IPC_DIR
+  run bash "$VERIFY"
+  assert_eq "exit status" "1" "$status"
+  assert_match "error mentions CEKERNEL_IPC_DIR" "CEKERNEL_IPC_DIR" "$output"
+}
+
+@test "verify-env exits 1 when CEKERNEL_ENV is unset" {
+  unset CEKERNEL_ENV
+  run bash "$VERIFY"
+  assert_eq "exit status" "1" "$status"
+  assert_match "error mentions CEKERNEL_ENV" "CEKERNEL_ENV" "$output"
+}
+
+@test "verify-env exits 1 when CEKERNEL_SESSION_ID is empty" {
+  export CEKERNEL_SESSION_ID=""
+  run bash "$VERIFY"
+  assert_eq "exit status" "1" "$status"
+  assert_match "error mentions CEKERNEL_SESSION_ID" "CEKERNEL_SESSION_ID" "$output"
+}
+
+# ── PATH check ──
+
+@test "verify-env exits 1 when spawn-worker.sh is not on PATH" {
+  export PATH="/usr/bin:/bin"
+  run bash "$VERIFY"
+  assert_eq "exit status" "1" "$status"
+  assert_match "error mentions spawn-worker.sh" "spawn-worker.sh" "$output"
+}

--- a/tests/shared/verify-env.bats
+++ b/tests/shared/verify-env.bats
@@ -15,6 +15,7 @@ setup() {
 
   set_test_session_id
   source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+  export CEKERNEL_ENV="${CEKERNEL_ENV:-default}"
   rm -rf "$CEKERNEL_IPC_DIR"
   mkdir -p "$CEKERNEL_IPC_DIR"
 


### PR DESCRIPTION
## Summary

closes #652

- `spawn-orchestrator.sh` が `${CEKERNEL_IPC_DIR}/env.sh` を `claude_bg_spawn` 直前に生成（全 `CEKERNEL_*` 変数 + PATH + `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`）
- 新規 `verify-env.sh` で必須変数と PATH 検証（fail-loud, Rule of Repair）
- `orchestrator.md` の Process Environment を env.sh source + verify-env.sh チェックリストに変更、inline export フォールバックを禁止
- `orchestrator-launch.md` のプロンプトテンプレートを個別変数リストから bootstrap 行に簡素化

## Test plan

- [x] `tests/shared/verify-env.bats` — verify-env.sh の正常系・異常系（7 tests）
- [x] `tests/ctl/spawn-orchestrator.bats` — env.sh 生成の検証（3 tests追加、既存12 tests通過）
- [x] CI で `bats --recursive tests/` が全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)