### PR TITLE
feat: ADR-0021 Amendment 2 — Reviewer result handling (#646)

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -164,7 +164,8 @@ reviewer-state-write.sh <issue> REVIEWING "review:in-progress"
 
 # After the verdict is returned:
 reviewer-state-write.sh <issue> TERMINATED "<verdict>"
-# verdict: approved / changes-requested / escalated
+# verdict: approved / changes-requested / failed
+# Unknown values are rejected with exit 1 (ADR-0021 Amendment 2)
 ```
 
 Invoke with the **Agent tool**, subagent type from `CEKERNEL_AGENT_REVIEWER`, in the **foreground** (reviews are short; Worker state-file events are polled after the block). The prompt must include the issue number, PR number, base branch, and **Worker worktree path**:
@@ -172,6 +173,7 @@ Invoke with the **Agent tool**, subagent type from `CEKERNEL_AGENT_REVIEWER`, in
 ```
 Review PR #<pr> for issue #<issue>. The PR base branch is <base>.
 The Worker's worktree is at: <worktree-path>
+You are authorized to post a review comment on PR #<pr> in <owner/repo> via gh api.
 Follow your agent definition: verify the PR anchor (worktree HEAD matches
 the PR head SHA), read the repository's CLAUDE.md and the changed files,
 submit the review, and end your response with the verdict
@@ -186,9 +188,9 @@ The Reviewer inherits your session's tool permissions — a permission gap stall
 
 Before acting on the verdict, inspect the Agent tool's full result for SECURITY WARNING markers (e.g. `[Self-Approval]`, `[External-Write]`). If any SECURITY WARNING is present:
 
-1. **Do NOT auto-advance** — regardless of the verdict word, treat it as **unverified**
-2. **Surface the warning** in the completion summary: include the warning text and mark the verdict as `unverified`
-3. **Escalate** — follow the escalation path (cleanup, desktop notification, lock release) so a human can inspect the PR and the warning
+1. **Do NOT auto-advance** — regardless of the verdict word, do not trust the result
+2. **Write the Reviewer's actual verdict** to state: `reviewer-state-write.sh <issue> TERMINATED "<verdict>"` — record what the Reviewer said, not an Orchestrator-invented label
+3. **Escalate** — follow the escalation path (desktop notification, runbook comment — no cleanup) so a human can inspect the PR and the warning. Surface the SECURITY WARNING text in the runbook comment
 
 This prevents the Orchestrator from silently swallowing a security signal and reporting a clean approval (Rule of Repair).
 
@@ -219,12 +221,22 @@ watch.sh <issue>     # on ci-passed → Reviewer again (loop)
 
 Track the retry count in working memory; after `CEKERNEL_REVIEW_MAX_RETRIES` reject cycles, escalate.
 
-**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **SECURITY WARNING detected** in the subagent result:
+**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **SECURITY WARNING detected** in the subagent result (ADR-0021 Amendment 2, γ):
 
 ```bash
-cleanup-worktree.sh <issue>
-source desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> escalated — human review needed" "$(gh pr view <pr-number> --json url -q .url)"
-source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <issue>
+# 1. Write the Reviewer's verdict to state (already done above)
+# 2. Desktop notification
+source desktop-notify.sh && desktop_notify "cekernel" "Issue #<issue> escalated — human review needed" \
+  "$(gh pr view <pr-number> --json url -q .url)"
+# 3. Post runbook comment on the issue
+WORKTREE=$(git worktree list --porcelain | grep -A1 "worktree.*issue/${ISSUE}" | head -1 | sed 's/worktree //')
+gh issue comment <issue> --body "## Escalated: <reason>
+PR: #<pr-number> | Worktree: \`${WORKTREE}\`
+### Actions
+- **Approve & merge**: \`gh pr merge <pr-number> --delete-branch && cleanup-worktree.sh <issue> && source issue-lock.sh && issue_lock_release \"\$(git rev-parse --show-toplevel)\" <issue>\`
+- **Resume**: \`spawn-worker.sh --resume <issue>\`
+- **Reject**: \`gh pr close <pr-number> && cleanup-worktree.sh <issue> && source issue-lock.sh && issue_lock_release \"\$(git rev-parse --show-toplevel)\" <issue>\`"
+# 4. Do NOT cleanup-worktree or release issue lock — preserve for human disposition
 ```
 
 ### Worktree Lifetime
@@ -234,7 +246,7 @@ source issue-lock.sh && issue_lock_release "$(git rev-parse --show-toplevel)" <i
 | Worker `ci-passed` | No — Reviewer may reject; re-spawn needs the worktree |
 | `changes-requested` → re-spawned | No — Worker is using it |
 | approved (merged, or awaiting human merge) | Yes |
-| Escalation | Yes — branch/PR remain on remote |
+| Escalation | No — worktree and lock preserved for human disposition (ADR-0021 Amendment 2, γ) |
 
 `CEKERNEL_KEEP_WORKTREE=true` needs no branching on your side — call `cleanup-worktree.sh` as usual; the script itself preserves the worktree.
 

--- a/docs/adr/0021-reviewer-subagent-contract.md
+++ b/docs/adr/0021-reviewer-subagent-contract.md
@@ -245,3 +245,97 @@ Worker's worktree, the PR-anchor check distinguishes a match from drift, and
 on-disk reads match the PR diff. Decision 1 above is reworded to state the
 principle and name this as the leading mechanism; the exact form is confirmed
 when implementing #602, gated by the both-modes live check (CLAUDE.md).
+
+### Amendment 2 (2026-07-11): Reviewer result handling (#646)
+
+First production reviews (PRs #645/#647/#648) exposed three defects in
+Decisions 2–3 — all rooted in the Orchestrator's handling of the Reviewer
+result, not the Reviewer's execution model itself.
+
+#### (α) External-Write false positive — authorization in Reviewer prompt
+
+The auto-mode `[External System Writes]` security classifier flagged the
+Reviewer's legitimate `gh api .../reviews` POST as an unauthorized external
+write, intermittently (2/3 in production, 3/3 in controlled probes without
+the fix). The classifier's clear condition states: "*the user must name the
+PR being reviewed and authorize posting the review comment*". The
+Orchestrator→Reviewer prompt named the PR (`Review PR #<pr>`) but did not
+explicitly authorize the POST.
+
+**Fix**: add `You are authorized to post a review comment on PR #<pr> in
+<owner/repo> via gh api.` to the Orchestrator→Reviewer prompt template
+(`agents/orchestrator.md`). Probed at clonable-eden/test-cekernel PR #118:
+0/3 false-fire rate with the authorization text vs 3/3 without.
+
+`reviewer.md` is unchanged — the Reviewer's responsibility to submit reviews
+via `gh api` is unaffected. The authorization is an Orchestrator-side prompt
+addition, consistent with the classifier's documented clear condition.
+
+#### (β) Reviewer verdict protocol — canonical enum and validation
+
+The same `approved` outcome was recorded as three different strings across
+production runs: `approved` (Reviewer's actual verdict), `unverified`
+(Orchestrator narration in #641), `escalated` (state file in #643/#644).
+Neither `unverified` nor `escalated` is part of the Reviewer's return
+contract (`approved / changes-requested / failed`); both were
+Orchestrator-invented labels written to `reviewer-<issue>.state` without
+validation. `reviewer_state_write` accepted any string, so the inconsistency
+was silent (violating Rule of Repair).
+
+**Fix**: `reviewer_state_write` now validates the detail field when state is
+`TERMINATED` — only `approved`, `changes-requested`, and `failed` are
+accepted; unknown values produce exit 1 with an error message. The
+Orchestrator records the Reviewer's actual verdict, not a derived label.
+Escalation is an Orchestrator *action* (desktop notification, runbook
+comment), not a verdict *value*. `unverified` and `escalated` as verdict
+strings are eliminated.
+
+**Action matrix** (Orchestrator's response to Reviewer verdict × SECURITY
+WARNING presence):
+
+| Reviewer verdict | SECURITY WARNING | Orchestrator action |
+|-----------------|-----------------|---------------------|
+| `approved` | absent | merge (auto) or notify (manual) |
+| `approved` | present | escalate |
+| `changes-requested` | absent | Worker re-spawn |
+| `changes-requested` | present | escalate |
+| `failed` | N/A | escalate |
+| no verdict / invalid | N/A | escalate |
+
+#### (γ) Escalation preserves worktree and lock
+
+The escalation path previously ran `cleanup-worktree.sh` + `issue_lock_release`,
+destroying the worktree and releasing the lock. Escalation is a non-terminal
+state (the issue returns to a human for disposition), yet the runtime signaled
+completion: the worktree was gone (preventing `--resume` for
+`changes-requested`), and the freed lock let the dispatcher re-acquire the
+issue.
+
+**Fix**: escalation no longer runs cleanup or lock release. The Orchestrator
+posts a runbook comment on the issue with three action commands
+(approve-and-merge, resume, reject) that the human executes. Cleanup happens
+only at true terminal states (merged, or human-initiated rejection). With
+(α) eliminating the `[External-Write]` false positive, escalation becomes a
+rare-case path (genuine security concerns, Agent tool errors, retry limit
+exhaustion), so the runbook approach satisfies Rule of Parsimony.
+
+#### UNIX Philosophy Alignment
+
+> Rule of Repair: "When you must fail, fail noisily and as soon as possible."
+
+(β) makes `reviewer_state_write` reject unknown verdicts at write time
+instead of silently accepting them. (γ) ensures escalation preserves the
+evidence (worktree, lock) for human inspection.
+
+> Rule of Least Surprise: "In interface design, always do the least
+> surprising thing."
+
+(α) aligns the prompt with the security classifier's documented clear
+condition — the Reviewer is authorized to do what it was designed to do.
+(β) eliminates surprising verdict label inconsistency.
+
+> Rule of Parsimony: "Write a big program only when it is clear by
+> demonstration that nothing else will do."
+
+(γ) uses a runbook comment for rare-case escalation instead of building
+automated rollback or disposition machinery.

--- a/scripts/process/reviewer-state-write.sh
+++ b/scripts/process/reviewer-state-write.sh
@@ -3,6 +3,8 @@
 #
 # Usage: reviewer-state-write.sh <issue-number> <state> [detail]
 #   state: REVIEWING | TERMINATED
+#   detail (TERMINATED): approved | changes-requested | failed
+#          Unknown verdicts are rejected with exit 1 (ADR-0021 Amendment 2).
 #
 # LLM agents running in zsh can call this standalone command without
 # sourcing bash-specific scripts directly (avoids zsh "bad substitution"

--- a/scripts/shared/reviewer-state.sh
+++ b/scripts/shared/reviewer-state.sh
@@ -22,6 +22,9 @@
 # Valid states for Reviewer
 _CEKERNEL_REVIEWER_VALID_STATES="REVIEWING TERMINATED"
 
+# Valid verdicts for TERMINATED state (ADR-0021 Amendment 2, β)
+_CEKERNEL_REVIEWER_VALID_VERDICTS="approved changes-requested failed"
+
 # reviewer_state_list_active <ipc-dir>
 #   List issue numbers of non-TERMINATED reviewers in the given IPC directory.
 #   Outputs one issue number per line, sorted.
@@ -64,6 +67,17 @@ reviewer_state_write() {
       return 1
       ;;
   esac
+
+  # Validate verdict for TERMINATED state (ADR-0021 Amendment 2, β)
+  if [[ "$state" == "TERMINATED" ]]; then
+    case "$detail" in
+      approved|changes-requested|failed) ;;
+      *)
+        echo "Error: invalid reviewer verdict '${detail}'. Valid: ${_CEKERNEL_REVIEWER_VALID_VERDICTS}" >&2
+        return 1
+        ;;
+    esac
+  fi
 
   local state_file="${CEKERNEL_IPC_DIR}/reviewer-${issue}.state"
   local timestamp

--- a/scripts/shared/reviewer-state.sh
+++ b/scripts/shared/reviewer-state.sh
@@ -11,6 +11,10 @@
 # State machine (simpler than Worker):
 #   REVIEWING → TERMINATED (with verdict as detail)
 #
+# Verdict enum (TERMINATED detail, ADR-0021 Amendment 2):
+#   approved | changes-requested | failed
+#   Unknown values are rejected with exit 1 (Rule of Repair).
+#
 # State file format: STATE:TIMESTAMP:detail (one line, detail may contain colons)
 # State file path: ${CEKERNEL_IPC_DIR}/reviewer-{issue}.state
 #

--- a/tests/shared/reviewer-state.bats
+++ b/tests/shared/reviewer-state.bats
@@ -47,6 +47,36 @@ teardown() {
   assert_eq "TERMINATED: exit 0" "0" "$status"
 }
 
+@test "reviewer_state_write validates verdict for TERMINATED state" {
+  # Valid verdicts: approved, changes-requested, failed
+  run reviewer_state_write 42 TERMINATED "approved"
+  assert_eq "approved: exit 0" "0" "$status"
+  run reviewer_state_write 42 TERMINATED "changes-requested"
+  assert_eq "changes-requested: exit 0" "0" "$status"
+  run reviewer_state_write 42 TERMINATED "failed"
+  assert_eq "failed: exit 0" "0" "$status"
+
+  # Invalid verdicts: unverified, escalated, anything else
+  run reviewer_state_write 42 TERMINATED "unverified"
+  assert_eq "unverified: exit 1" "1" "$status"
+  run reviewer_state_write 42 TERMINATED "escalated"
+  assert_eq "escalated: exit 1" "1" "$status"
+  run reviewer_state_write 42 TERMINATED "APPROVED"
+  assert_eq "APPROVED (uppercase): exit 1" "1" "$status"
+  run reviewer_state_write 42 TERMINATED ""
+  assert_eq "empty verdict: exit 1" "1" "$status"
+}
+
+@test "reviewer_state_write allows any detail for REVIEWING state" {
+  # REVIEWING does not enforce verdict enum — detail is freeform
+  run reviewer_state_write 42 REVIEWING "review:in-progress"
+  assert_eq "review:in-progress: exit 0" "0" "$status"
+  run reviewer_state_write 42 REVIEWING "anything"
+  assert_eq "anything: exit 0" "0" "$status"
+  run reviewer_state_write 42 REVIEWING ""
+  assert_eq "empty: exit 0" "0" "$status"
+}
+
 @test "reviewer_state_write errors without CEKERNEL_IPC_DIR" {
   unset CEKERNEL_IPC_DIR
   run reviewer_state_write 42 REVIEWING "test"


### PR DESCRIPTION
closes #646

## Summary
- **(α)** Orchestrator→Reviewer プロンプトに認可文言を追加し、`[External-Write]` 誤検知を解消（probe 結果: 認可あり 0/3 発火 vs 認可なし 3/3 発火）
- **(β)** `reviewer_state_write` に TERMINATED 状態の verdict enum 検証を追加。`approved / changes-requested / failed` のみ受理、不正値は exit 1（Rule of Repair）。`unverified` / `escalated` を verdict 語彙から廃止
- **(γ)** escalation パスから `cleanup-worktree.sh` + `issue_lock_release` を除去し、worktree と lock を人間の disposition まで保持。runbook コメントをissue に投稿

## Test plan
- [x] `reviewer_state_write` が有効な verdict（approved/changes-requested/failed）を受理する
- [x] `reviewer_state_write` が無効な verdict（unverified/escalated/空文字/大文字）を exit 1 で拒否する
- [x] REVIEWING 状態の detail は引き続き freeform で受理される
- [x] 既存テスト（14件）がすべてパスする
- [ ] CI（bats --recursive tests/）がパスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)