### PR TITLE
feat: Worker CI待ちブロッキング primitive (wait-ci.sh)

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -116,12 +116,24 @@ PR title, body, and issue link format follow the target repository's conventions
 
 > `phase-transition.sh <issue> WAITING "phase3:ci-waiting"` — when fixing failures: `phase-transition.sh <issue> RUNNING "phase3:ci-fixing"`
 
-On entry, load the env profile (reads `CEKERNEL_CI_MAX_RETRIES` etc.; `CEKERNEL_ENV` is already in your environment). If sourcing fails, fall back to the defaults stated in this document:
+On entry, load the env profile (reads `CEKERNEL_CI_MAX_RETRIES` etc.; `CEKERNEL_ENV` is already in your environment). If sourcing fails, fall back to the defaults stated in this document.
+
+**Use `wait-ci.sh` — the sanctioned blocking CI wait primitive**:
 
 ```bash
 source load-env.sh
-gh pr checks <pr-number> --watch
+wait-ci.sh <pr-number>    # foreground, chunk-timeout: 540s (Bash tool safe)
+# Result JSON: {"result":"passed|failed|watching", "pr":<N>}
+# - "passed"  → CI green, proceed to Phase 4
+# - "failed"  → read `gh pr checks`, fix, push, re-invoke wait-ci.sh
+# - "watching" → chunk timeout expired, re-invoke wait-ci.sh (NOT an error)
 ```
+
+**Anti-pattern — do NOT**:
+- Poll `gh run view` or `gh pr checks` (without `--watch`) in a loop
+- Detach `gh pr checks --watch` to background and `tail` the output file
+- Run multiple concurrent `gh pr checks --watch` or `bats` background processes
+- Read CI output files repeatedly when a background task notification is pending
 
 On CI failure: check `gh pr checks`, fix, push, wait again. After `CEKERNEL_CI_MAX_RETRIES` failures (default: 3), post a Result comment (Status: failed, reason in Summary) and run `notify-complete.sh <issue-number> failed "reason"`.
 
@@ -150,3 +162,4 @@ notify-complete.sh <issue-number> ci-passed <pr-number>
 - **Never merge PRs** — merge is the Orchestrator's responsibility after Reviewer approval
 - Do not delete the worktree (that is the Orchestrator's responsibility)
 - Do not read or modify orchestrator scripts (`scripts/orchestrator/`) — outside Worker authority
+- **Use `git rm` to delete tracked files** — plain `rm` on tracked files triggers an interactive prompt that stalls the session; `git rm` avoids this and correctly stages the deletion

--- a/envs/README.md
+++ b/envs/README.md
@@ -18,6 +18,7 @@ These can be set via env profiles or explicit `export`.
 | `CEKERNEL_WATCH_QUERY_RETRY_MAX` | `3` | Positive integer | `watch.sh` | Consecutive unverifiable liveness polls (`query-failed` / `unknown-value` verdicts, ADR-0018) tolerated before watch escalates an `error` result. The escalation detail warns the Worker may still be running — do not clean up on this result alone |
 | `CEKERNEL_CHECKPOINT_FILENAME` | `.cekernel-checkpoint.md` | Any filename | `checkpoint-file.sh` | Checkpoint file name in worktree |
 | `CEKERNEL_TASK_FILENAME` | `.cekernel-task.md` | Any filename | `task-file.sh` | Task file name in worktree |
+| `CEKERNEL_CI_CHUNK_TIMEOUT` | `540` | Positive integer (seconds) | `wait-ci.sh` | Max seconds per `wait-ci.sh` invocation before returning a `watching` sentinel (exit 0). Must be shorter than the Bash tool's 600s hard limit to avoid SIGTERM. The Worker re-calls `wait-ci.sh` on a `watching` result (#650) |
 | `CEKERNEL_CI_MAX_RETRIES` | `3` | Positive integer | `worker.md` (Phase 3) | Maximum CI retry attempts before Worker reports failure |
 | `CEKERNEL_AUTO_MERGE` | `false` | `true`, `false` | Orchestrator | `true`: Orchestrator auto-merges after Reviewer approval. `false`: desktop notification only, human merges manually |
 | `CEKERNEL_KEEP_WORKTREE` | `false` | `true`, `false` | `cleanup-worktree.sh` | `true`: preserve the worktree and local branch on cleanup (Worker is still killed, IPC still removed). `--force` always removes regardless. Useful with `CEKERNEL_AUTO_MERGE=false` for manual pre-merge verification |

--- a/scripts/process/wait-ci.sh
+++ b/scripts/process/wait-ci.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# wait-ci.sh — Foreground blocking CI wait primitive for Workers
+#
+# Usage: wait-ci.sh <pr-number>
+#
+# Runs `gh pr checks <pr> --watch` in the foreground with chunk timeout
+# control to avoid the Bash tool's 600s hard limit (#650). Follows the
+# same chunk pattern as watch.sh (#630).
+#
+# Environment:
+#   CEKERNEL_CI_CHUNK_TIMEOUT — Max seconds per invocation before
+#     returning a "watching" sentinel (default: 540). Must be shorter
+#     than the Bash tool's 600s hard limit to avoid SIGTERM.
+#     The Worker re-calls wait-ci.sh on a "watching" result.
+#
+# Output (JSON to stdout):
+#   {"result":"passed","pr":<N>}     — All CI checks passed
+#   {"result":"failed","pr":<N>}     — One or more CI checks failed
+#   {"result":"watching","pr":<N>}   — Chunk timeout; re-invoke needed
+#
+# Exit codes:
+#   0 — Always (caller inspects JSON result)
+#   1 — Usage error (missing arguments)
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: wait-ci.sh <pr-number>}"
+CHUNK_TIMEOUT="${CEKERNEL_CI_CHUNK_TIMEOUT:-540}"
+
+# Run gh pr checks --watch in background so we can enforce chunk timeout
+gh pr checks "$PR_NUMBER" --watch &
+GH_PID=$!
+
+# Wait for gh to finish, enforcing chunk timeout
+ELAPSED=0
+while kill -0 "$GH_PID" 2>/dev/null; do
+  if [[ $ELAPSED -ge $CHUNK_TIMEOUT ]]; then
+    # Chunk timeout reached — kill gh and return watching sentinel
+    kill "$GH_PID" 2>/dev/null || true
+    wait "$GH_PID" 2>/dev/null || true
+    echo "{\"result\":\"watching\",\"pr\":${PR_NUMBER}}"
+    exit 0
+  fi
+  sleep 1
+  ELAPSED=$((ELAPSED + 1))
+done
+
+# gh finished — check its exit code
+GH_EXIT=0
+wait "$GH_PID" || GH_EXIT=$?
+
+if [[ $GH_EXIT -eq 0 ]]; then
+  echo "{\"result\":\"passed\",\"pr\":${PR_NUMBER}}"
+else
+  echo "{\"result\":\"failed\",\"pr\":${PR_NUMBER}}"
+fi

--- a/tests/process/wait-ci.bats
+++ b/tests/process/wait-ci.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# wait-ci.bats — Tests for scripts/process/wait-ci.sh
+#
+# wait-ci.sh is a foreground blocking CI wait primitive for Workers.
+# It wraps `gh pr checks --watch` with chunk timeout control to avoid
+# Bash tool's 600s hard limit, following watch.sh's chunk pattern (#630).
+#
+# Contract:
+#   - Runs `gh pr checks <pr> --watch` in foreground
+#   - Self-limits to CEKERNEL_CI_CHUNK_TIMEOUT (default: 540s)
+#   - Returns JSON: {"result":"passed|failed|watching", ...}
+#   - Exit 0 for all results (caller inspects JSON)
+
+load '../helpers/assertions'
+load '../helpers/session'
+load '../helpers/mock-bin'
+
+setup() {
+  CEKERNEL_DIR="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  WAIT_CI_SCRIPT="${CEKERNEL_DIR}/scripts/process/wait-ci.sh"
+
+  set_test_session_id
+  source "${CEKERNEL_DIR}/scripts/shared/session-id.sh"
+  rm -rf "$CEKERNEL_IPC_DIR"
+  mkdir -p "$CEKERNEL_IPC_DIR"
+
+  export CEKERNEL_CI_CHUNK_TIMEOUT=5
+}
+
+teardown() {
+  rm -rf "$CEKERNEL_IPC_DIR"
+}
+
+# ── Usage error ──
+
+@test "wait-ci exits 1 without arguments" {
+  run bash "$WAIT_CI_SCRIPT"
+  assert_eq "exits 1" "1" "$status"
+}
+
+# ── All checks passed ──
+
+@test "wait-ci reports passed when gh pr checks --watch exits 0" {
+  mock_bin gh 'echo "All checks were successful"; exit 0'
+
+  run bash "$WAIT_CI_SCRIPT" 123
+  assert_eq "exits 0" "0" "$status"
+  assert_match "result is passed" '"result":"passed"' "$output"
+  assert_match "pr number" '"pr":123' "$output"
+}
+
+# ── Checks failed ──
+
+@test "wait-ci reports failed when gh pr checks --watch exits non-zero" {
+  mock_bin gh 'echo "Some checks were not successful"; exit 1'
+
+  run bash "$WAIT_CI_SCRIPT" 456
+  assert_eq "exits 0" "0" "$status"
+  assert_match "result is failed" '"result":"failed"' "$output"
+  assert_match "pr number" '"pr":456' "$output"
+}
+
+# ── Chunk timeout (watching sentinel) ──
+
+@test "wait-ci returns watching when chunk timeout expires" {
+  # gh pr checks --watch that never exits (simulated with sleep)
+  mock_bin gh 'sleep 60'
+  export CEKERNEL_CI_CHUNK_TIMEOUT=2
+
+  run bash "$WAIT_CI_SCRIPT" 789
+  assert_eq "exits 0" "0" "$status"
+  assert_match "result is watching" '"result":"watching"' "$output"
+  assert_match "pr number" '"pr":789' "$output"
+}
+
+# ── gh receives correct arguments ──
+
+@test "wait-ci passes correct arguments to gh pr checks" {
+  mock_bin gh '
+    echo "$@" > "${BATS_TEST_TMPDIR}/gh-args.log"
+    echo "All checks were successful"
+    exit 0
+  '
+
+  run bash "$WAIT_CI_SCRIPT" 42
+  local args
+  args=$(cat "${BATS_TEST_TMPDIR}/gh-args.log")
+  assert_match "pr checks with --watch" "pr checks 42 --watch" "$args"
+}


### PR DESCRIPTION
closes #650

## Summary
- `scripts/process/wait-ci.sh`: `gh pr checks --watch` をフォアグラウンドで実行し、chunk timeout (540s) で自己制限するブロッキング CI 待ち primitive を追加
- `agents/worker.md` Phase 3: `wait-ci.sh` を sanctioned な CI 待ち手段として明記。busy-polling アンチパターン（`gh run view` ループ、background detach + tail、複数並行 `--watch`）を禁止リストに追加
- `agents/worker.md` Constraints: tracked file 削除は `git rm` を使用（`rm` の対話 prompt 回避）
- `envs/README.md`: `CEKERNEL_CI_CHUNK_TIMEOUT` を変数カタログに追加

## Test Plan
- [x] `tests/process/wait-ci.bats`: passed / failed / watching の各パス、usage error、gh 引数検証 (5 tests)
- [ ] CI (bats --recursive tests/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)