### PR TITLE
feat: orchctl.sh ps を JSON Lines 出力に変更

### DIFF
--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -321,6 +321,11 @@ cmd_ls() {
 }
 
 # ── ps: agents --json view layer (ADR-0016 Phase 4, ADR-0021 #627) ──
+# Outputs JSON Lines — one line per orchestrator/worker/reviewer — with a
+# `type` field distinguishing process kinds (#660). Schema matches `ls`
+# with `type` added. Tree structure assembly is the consumer's
+# responsibility (skill / jq).
+#
 # `claude agents --json` is fetched ONCE per invocation (the body is an
 # OPAQUE snapshot — only claude-bg.sh predicates parse it, ADR-0018);
 # every registered token (orchestrator.claude-session-id,
@@ -381,11 +386,17 @@ cmd_ps() {
           elapsed=$(format_elapsed "$(($(date +%s) - spawned_at))")
         fi
 
-        local state
-        state=$(claude_bg_token_verdict_from_json "$agents_json" "$token") || true
+        local verdict
+        verdict=$(claude_bg_token_verdict_from_json "$agents_json" "$token") || true
 
         found=$((found + 1))
-        echo "orchestrator  claude=${token}  session=${sid}  elapsed=${elapsed}  ${state}"
+        jq -cn \
+          --arg session "$sid" \
+          --arg type "orchestrator" \
+          --arg claude "$token" \
+          --arg elapsed "${elapsed:-}" \
+          --arg verdict "$verdict" \
+          '{session: $session, type: $type, claude: $claude, elapsed: $elapsed, verdict: $verdict}'
       fi
     fi
 
@@ -403,8 +414,8 @@ cmd_ps() {
       mtoken=$(tr -d '[:space:]' < "$handle_file")
       [[ -n "$mtoken" ]] || continue
 
-      local mstate
-      mstate=$(claude_bg_token_verdict_from_json "$agents_json" "$mtoken") || true
+      local mverdict
+      mverdict=$(claude_bg_token_verdict_from_json "$agents_json" "$mtoken") || true
 
       # Join cekernel-specific columns from state/priority files.
       # CEKERNEL_IPC_DIR is scoped to each command substitution (subshell)
@@ -414,7 +425,15 @@ cmd_ps() {
       priority=$(CEKERNEL_IPC_DIR="$session_dir" worker_priority_read "$issue" | jq -r '.priority')
 
       found=$((found + 1))
-      echo "  ${mtype}  #${issue}  claude=${mtoken}  phase=${phase}  priority=${priority}  ${mstate}"
+      jq -cn \
+        --arg session "$sid" \
+        --arg type "$mtype" \
+        --argjson issue "$issue" \
+        --arg claude "$mtoken" \
+        --arg phase "$phase" \
+        --argjson priority "$priority" \
+        --arg verdict "$mverdict" \
+        '{session: $session, type: $type, issue: $issue, claude: $claude, phase: $phase, priority: $priority, verdict: $verdict}'
     done
 
     # ── Managed rows: Reviewer subagents (state-file based, ADR-0021 #627) ──
@@ -427,7 +446,13 @@ cmd_ps() {
       rdetail=$(echo "$rstate_json" | jq -r '.detail')
 
       found=$((found + 1))
-      echo "  reviewer  #${rissue}  state=${rstate}  detail=${rdetail}"
+      jq -cn \
+        --arg session "$sid" \
+        --arg type "reviewer" \
+        --argjson issue "$rissue" \
+        --arg state "$rstate" \
+        --arg detail "$rdetail" \
+        '{session: $session, type: $type, issue: $issue, state: $state, detail: $detail}'
     done
   done
 

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -5,7 +5,7 @@
 #
 # Commands:
 #   ls                          List all workers across all sessions
-#   ps [--session <id>]         Show orchestrator process trees
+#   ps [--session <id>]         List process tree as JSON Lines
 #   inspect <target>            Detailed worker view
 #   suspend <target>            Suspend a worker (send SUSPEND signal)
 #   resume <target>             Resume a suspended or crashed worker
@@ -44,7 +44,7 @@ Usage: orchctl.sh <command> [args...]
 
 Commands:
   ls                          List all workers
-  ps [--session <id>]         Show orchestrator process trees
+  ps [--session <id>]         List process tree as JSON Lines
   inspect <target>            Detailed worker view
   suspend <target>            Suspend a worker
   resume <target>             Resume a suspended or crashed worker

--- a/skills/orchctl/SKILL.md
+++ b/skills/orchctl/SKILL.md
@@ -39,7 +39,7 @@ Try `<issue>` alone first; if multiple sessions match, show the candidates and a
 | Command | Behavior | Present to user as |
 |---------|----------|--------------------|
 | `ls` | JSON Lines, one per Worker (`session`, `repo`, `issue`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`); `no workers.` if none | Table: Session / Repo / Issue / State / Priority / Elapsed / Backend |
-| `ps [--session <id>]` | Pre-formatted tree of Orchestrator sessions and their Worker/Reviewer sessions (single `claude agents --json` fetch joined with issue/phase/priority — ADR-0016 Phase 4) | As-is |
+| `ps [--session <id>]` | JSON Lines, one per process (`session`, `type` [orchestrator/worker/reviewer], `claude`, `elapsed`, `verdict`, plus `issue`/`phase`/`priority` for workers, `state`/`detail` for reviewers); `no orchestrators.` if none | Table: Session / Type / Issue / Verdict / Phase / Priority / Elapsed |
 | `inspect <target>` | JSON: `session`, `issue`, `state`, `priority`, `elapsed`, `backend`, `worktree`, `checkpoint` | Structured summary, highlighting checkpoint data (phase, completed work, next steps, key decisions) |
 | `suspend <target>` | Sends SUSPEND (RUNNING/WAITING/READY only); Worker checkpoints and stops at the next phase boundary | Confirm action |
 | `resume <target>` | SUSPENDED (or TERMINATED with `crashed*` detail) → READY; prints the restart command | Confirm, then show the printed `spawn-worker.sh --resume` command for the user to run |
@@ -48,6 +48,6 @@ Try `<issue>` alone first; if multiple sessions match, show the candidates and a
 | `kill <target>` | Immediate termination + TERMINATED (when `term` is insufficient) | Confirm action |
 | `nice <target> <priority>` | Change priority: `critical` (0), `high` (5), `normal` (10), `low` (15), or numeric 0-19 (lower = higher) | Confirm action |
 
-`ps` notes: Worker rows show the raw `claude agents --json` trailing state (`busy`, `blocked`, `done`, ...); `missing` = no longer listed. **`blocked` means stalled on a permission dialog — surface it prominently.** Reviewer rows come from `reviewer-*.state` files (subagents have no session token) and show `state=REVIEWING` / `TERMINATED`. Sessions spawned by an interactive Orchestrator have no `orchestrator` row, but their Worker rows still appear.
+`ps` notes: Output is JSON Lines (same as `ls`). Each line has a `type` field: `orchestrator`, `worker`, or `reviewer`. The `verdict` field shows the ADR-0018 verdict (`alive`, `blocked`, `done`, `not-listed`, etc.). **`blocked` means stalled on a permission dialog — surface it prominently.** Reviewer rows come from `reviewer-*.state` files (subagents have no session token) and show `state`/`detail`. Sessions spawned by an interactive Orchestrator have no `orchestrator` row, but their Worker rows still appear. Tree structure assembly (grouping workers under their orchestrator) is the skill's responsibility.
 
 Crash recovery sequence: `health-check.sh` (detect zombie) → `orchctl recover` → `orchctl resume` → `spawn-worker.sh --resume`.

--- a/tests/ctl/orchctl-read.bats
+++ b/tests/ctl/orchctl-read.bats
@@ -271,14 +271,19 @@ make_handle() {
   assert_eq "ps no session token" "no orchestrators." "$output"
 }
 
-@test "ps shows session, claude token, and the alive verdict" {
+@test "ps outputs JSON Lines with type=orchestrator for orchestrator row" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "shows session" "$SESSION_A" "$output"
-  assert_match "shows claude token" "$ORCH_TOKEN_A" "$output"
-  assert_match "shows alive verdict" "alive" "$output"
+  local line
+  line=$(echo "$output" | grep '"type":"orchestrator"')
+  assert_match "shows session" "$SESSION_A" "$line"
+  assert_match "shows claude token" "$ORCH_TOKEN_A" "$line"
+  assert_match "shows alive verdict" '"verdict":"alive"' "$line"
+  # Verify it's valid JSON
+  echo "$line" | jq . >/dev/null 2>&1
+  assert_eq "valid JSON" "0" "$?"
 }
 
 @test "ps surfaces a blocked session distinctly (ADR-0016)" {
@@ -286,14 +291,14 @@ make_handle() {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 blocked)]"
   run bash "$ORCHCTL" ps
-  assert_match "shows blocked state" "blocked" "$output"
+  assert_match "shows blocked verdict" '"verdict":"blocked"' "$output"
 }
 
 @test "ps shows not-listed when the session is absent (ADR-0018 vocabulary)" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   # queue empty → agents --json replies []
   run bash "$ORCHCTL" ps
-  assert_match "shows not-listed" "not-listed" "$output"
+  assert_match "shows not-listed" '"verdict":"not-listed"' "$output"
 }
 
 @test "ps elapsed reads from orchestrator.spawned" {
@@ -302,10 +307,10 @@ make_handle() {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "elapsed from .spawned (epoch 0 → hours)" 'elapsed=[0-9]+h' "$output"
+  assert_match "elapsed from .spawned (epoch 0 → hours)" '"elapsed":"[0-9]+h' "$output"
 }
 
-@test "ps lists multiple sessions" {
+@test "ps lists multiple sessions as JSON Lines" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   make_orchestrator "$IPC_B" "$ORCH_TOKEN_B"
   mock_claude_enqueue_agents "[
@@ -314,9 +319,9 @@ make_handle() {
   ]"
   run bash "$ORCHCTL" ps
   local line_count
-  line_count=$(echo "$output" | grep -c "orchestrator" || true)
-  assert_eq "two orchestrators" "2" "$line_count"
-  assert_match "done state shown as-is" "done" "$output"
+  line_count=$(echo "$output" | grep -c '"type":"orchestrator"' || true)
+  assert_eq "two orchestrator JSON lines" "2" "$line_count"
+  assert_match "done verdict shown" '"verdict":"done"' "$output"
 }
 
 @test "ps --session filters to the given session" {
@@ -327,7 +332,7 @@ make_handle() {
     $(mock_claude_agent_record "$ORCH_TOKEN_B" background /repo 1700000001000 busy)
   ]"
   run bash "$ORCHCTL" ps --session "$SESSION_B"
-  assert_match "shows filtered session" "$SESSION_B" "$output"
+  assert_match "shows filtered session" '"session":"'"$SESSION_B"'"' "$output"
   if [[ "$output" == *"$SESSION_A"* ]]; then
     echo "FAIL: ps --session should not show other sessions" >&2
     return 1
@@ -349,7 +354,7 @@ make_handle() {
 
 # ── ps managed rows (agents --json view layer, ADR-0016 Phase 4 / #549) ──
 
-@test "ps joins worker row: issue, phase, priority from cekernel files" {
+@test "ps joins worker row: JSON with issue, phase, priority, verdict" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   make_worker "$IPC_A" 10
   make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
@@ -359,12 +364,15 @@ make_handle() {
   ]"
   run bash "$ORCHCTL" ps
   local worker_line
-  worker_line=$(echo "$output" | grep "#10")
-  assert_match "row shows type worker" "worker" "$worker_line"
-  assert_match "row shows claude token" "claude=${WORKER_TOKEN}" "$worker_line"
-  assert_match "row joins phase from state file" "phase=phase1:implement" "$worker_line"
-  assert_match "row joins priority from priority file" "priority=10" "$worker_line"
-  assert_match "row shows alive verdict" "alive" "$worker_line"
+  worker_line=$(echo "$output" | grep '"issue":10')
+  assert_match "row shows type worker" '"type":"worker"' "$worker_line"
+  assert_match "row shows claude token" "$WORKER_TOKEN" "$worker_line"
+  assert_match "row joins phase from state file" '"phase":"phase1:implement"' "$worker_line"
+  assert_match "row joins priority from priority file" '"priority":10' "$worker_line"
+  assert_match "row shows alive verdict" '"verdict":"alive"' "$worker_line"
+  # Verify valid JSON
+  echo "$worker_line" | jq . >/dev/null 2>&1
+  assert_eq "valid JSON" "0" "$?"
 }
 
 @test "ps surfaces a blocked worker session distinctly (ADR-0016 MUST)" {
@@ -376,7 +384,7 @@ make_handle() {
     $(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 blocked)
   ]"
   run bash "$ORCHCTL" ps
-  assert_match "worker row shows blocked" "blocked" "$(echo "$output" | grep "#10")"
+  assert_match "worker row shows blocked" '"verdict":"blocked"' "$(echo "$output" | grep '"issue":10')"
 }
 
 @test "ps shows not-listed for a worker token absent from the roster" {
@@ -386,7 +394,7 @@ make_handle() {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "worker row shows not-listed" "not-listed" "$(echo "$output" | grep "#10")"
+  assert_match "worker row shows not-listed" '"verdict":"not-listed"' "$(echo "$output" | grep '"issue":10')"
 }
 
 @test "ps shows worker rows in a session without an orchestrator token" {
@@ -397,8 +405,8 @@ make_handle() {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "worker row shown" "#10" "$output"
-  assert_match "worker row shows alive" "alive" "$(echo "$output" | grep "#10")"
+  assert_match "worker row shown" '"issue":10' "$output"
+  assert_match "worker row shows alive" '"verdict":"alive"' "$(echo "$output" | grep '"issue":10')"
   if [[ "$output" == *"no orchestrators."* ]]; then
     echo "FAIL: worker rows found — must not print 'no orchestrators.'" >&2
     return 1
@@ -411,7 +419,7 @@ make_handle() {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$REVIEWER_TOKEN" background /repo 1700000001000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "row shows type reviewer" "reviewer" "$(echo "$output" | grep "#11")"
+  assert_match "row shows type reviewer" '"type":"reviewer"' "$(echo "$output" | grep '"issue":11')"
 }
 
 @test "ps --session filter applies to worker rows" {
@@ -424,8 +432,8 @@ make_handle() {
     $(mock_claude_agent_record "$REVIEWER_TOKEN" background /repo 1700000002000 busy)
   ]"
   run bash "$ORCHCTL" ps --session "$SESSION_A"
-  assert_match "filtered session worker shown" "#10" "$output"
-  if [[ "$output" == *"#20"* ]]; then
+  assert_match "filtered session worker shown" '"issue":10' "$output"
+  if [[ "$output" == *'"issue":20'* ]]; then
     echo "FAIL: ps --session should not show other sessions' workers" >&2
     return 1
   fi
@@ -596,15 +604,20 @@ make_reviewer_state() {
 
 # ── ps: reviewer-*.state surface (#627) ──
 
-@test "ps shows reviewer row from reviewer-*.state (no handle needed)" {
+@test "ps shows reviewer row from reviewer-*.state as JSON" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   make_reviewer_state "$IPC_A" 10
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
-  assert_match "reviewer row shown" "#10" "$output"
-  assert_match "row shows type reviewer" "reviewer" "$(echo "$output" | grep "#10")"
-  assert_match "row shows state" "REVIEWING" "$(echo "$output" | grep "#10")"
+  local reviewer_line
+  reviewer_line=$(echo "$output" | grep '"issue":10')
+  assert_match "row shows type reviewer" '"type":"reviewer"' "$reviewer_line"
+  assert_match "row shows state" '"state":"REVIEWING"' "$reviewer_line"
+  assert_match "row shows detail" '"detail":"review:in-progress"' "$reviewer_line"
+  # Verify valid JSON
+  echo "$reviewer_line" | jq . >/dev/null 2>&1
+  assert_eq "valid JSON" "0" "$?"
 }
 
 @test "ps excludes TERMINATED reviewer from reviewer-*.state" {
@@ -613,13 +626,13 @@ make_reviewer_state() {
   mock_claude_enqueue_agents \
     "[$(mock_claude_agent_record "$ORCH_TOKEN_A" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" ps
-  if [[ "$output" == *"#10"* ]]; then
+  if [[ "$output" == *'"issue":10'* ]]; then
     echo "FAIL: TERMINATED reviewer should not appear in ps" >&2
     return 1
   fi
 }
 
-@test "ps shows both worker and reviewer rows" {
+@test "ps shows both worker and reviewer rows as JSON Lines" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
   make_worker "$IPC_A" 10
   make_handle "$IPC_A" 10 worker "$WORKER_TOKEN"
@@ -629,8 +642,8 @@ make_reviewer_state() {
     $(mock_claude_agent_record "$WORKER_TOKEN" background /repo 1700000001000 busy)
   ]"
   run bash "$ORCHCTL" ps
-  assert_match "worker row" "#10" "$output"
-  assert_match "reviewer row" "#11" "$output"
+  assert_match "worker row" '"issue":10' "$output"
+  assert_match "reviewer row" '"issue":11' "$output"
 }
 
 @test "ps --session filter applies to reviewer rows" {
@@ -638,7 +651,7 @@ make_reviewer_state() {
   make_reviewer_state "$IPC_B" 20
   mock_claude_enqueue_agents "[]"
   run bash "$ORCHCTL" ps --session "$SESSION_A"
-  if [[ "$output" == *"#20"* ]]; then
+  if [[ "$output" == *'"issue":20'* ]]; then
     echo "FAIL: ps --session should not show other sessions' reviewers" >&2
     return 1
   fi


### PR DESCRIPTION
closes #660

## Summary
- `orchctl.sh ps` の出力を pre-formatted text から JSON Lines に変更
- `ls` と統一された出力形式: `type` フィールド (orchestrator/worker/reviewer) で種別を区別
- tree 構造の組み立ては消費者（skill / jq）の責務に分離（Rule of Composition）
- `/orchctl` skill の `ps` 説明を JSON Lines 出力に合わせて更新

## Test plan
- [x] `orchctl-read.bats` の ps テスト 21 件すべて通過（JSON Lines 出力を検証）
- [x] `orchctl-mutating.bats` の全 56 テスト通過（副作用なし）
- [x] CI で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)