### PR TITLE
fix: add reason-based routing to SECURITY WARNING check

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -186,17 +186,30 @@ The Reviewer inherits your session's tool permissions — a permission gap stall
 
 ### SECURITY WARNING Check (ADR-0021 Decision 3)
 
-Before acting on the verdict, inspect the Agent tool's full result for SECURITY WARNING markers (e.g. `[Self-Approval]`, `[External-Write]`). If any SECURITY WARNING is present:
+Before acting on the verdict, inspect the Agent tool's full result for SECURITY WARNING markers (e.g. `[Self-Approval]`, `[External-Write]`). If any SECURITY WARNING is present, apply **reason-based routing**:
+
+**Actionable signals — escalate:**
+
+- `[External-Write]` — Reviewer wrote outside its read-only boundary
+- `[Self-Approval]` — Reviewer approved its own code
+
+For these:
 
 1. **Do NOT auto-advance** — regardless of the verdict word, do not trust the result
 2. **Write the Reviewer's actual verdict** to state: `reviewer-state-write.sh <issue> TERMINATED "<verdict>"` — record what the Reviewer said, not an Orchestrator-invented label
 3. **Escalate** — follow the escalation path (desktop notification, runbook comment — no cleanup) so a human can inspect the PR and the warning. Surface the SECURITY WARNING text in the runbook comment
 
-This prevents the Orchestrator from silently swallowing a security signal and reporting a clean approval (Rule of Repair).
+**Transient classifier errors — ignore and adopt the verdict:**
+
+- `Stage 2 classifier error` — auto-mode classifier's transient failure, unrelated to Reviewer behavior (#669: #660, #667)
+
+For these: **proceed normally with the Reviewer's verdict**. The classifier error does not invalidate the review — log the warning text for observability but do not escalate or block.
+
+This prevents the Orchestrator from silently swallowing a security signal and reporting a clean approval (Rule of Repair), while avoiding unnecessary escalation on transient platform errors (Rule of Economy).
 
 ### Handling the Verdict (final output line)
 
-**approved** (no SECURITY WARNING) — merge per `CEKERNEL_AUTO_MERGE`, then clean up immediately. Do NOT wait or poll for a human merge — the branch and PR remain on the remote:
+**approved** (no actionable SECURITY WARNING) — merge per `CEKERNEL_AUTO_MERGE`, then clean up immediately. Do NOT wait or poll for a human merge — the branch and PR remain on the remote:
 
 ```bash
 gh pr merge <pr-number> --delete-branch     # only if CEKERNEL_AUTO_MERGE=true
@@ -221,7 +234,7 @@ watch.sh <issue>     # on ci-passed → Reviewer again (loop)
 
 Track the retry count in working memory; after `CEKERNEL_REVIEW_MAX_RETRIES` reject cycles, escalate.
 
-**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **SECURITY WARNING detected** in the subagent result (ADR-0021 Amendment 2, γ):
+**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **actionable SECURITY WARNING detected** (i.e. `[External-Write]`, `[Self-Approval]` — NOT `Stage 2 classifier error`) in the subagent result (ADR-0021 Amendment 2, γ):
 
 ```bash
 # 1. Write the Reviewer's verdict to state (already done above)

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -205,7 +205,11 @@ For these:
 
 For these: **proceed normally with the Reviewer's verdict**. The classifier error does not invalidate the review — log the warning text for observability but do not escalate or block.
 
-This prevents the Orchestrator from silently swallowing a security signal and reporting a clean approval (Rule of Repair), while avoiding unnecessary escalation on transient platform errors (Rule of Economy).
+**Unrecognized SECURITY WARNING — escalate (fail safe):**
+
+Any SECURITY WARNING whose reason does not match the categories above must be treated as actionable and escalated. Do not silently proceed with the verdict — unknown warnings may indicate new security signals not yet categorized (Rule of Repair).
+
+This routing prevents the Orchestrator from silently swallowing a security signal and reporting a clean approval (Rule of Repair), while avoiding unnecessary escalation on transient platform errors (Rule of Economy).
 
 ### Handling the Verdict (final output line)
 
@@ -234,7 +238,7 @@ watch.sh <issue>     # on ci-passed → Reviewer again (loop)
 
 Track the retry count in working memory; after `CEKERNEL_REVIEW_MAX_RETRIES` reject cycles, escalate.
 
-**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **actionable SECURITY WARNING detected** (i.e. `[External-Write]`, `[Self-Approval]` — NOT `Stage 2 classifier error`) in the subagent result (ADR-0021 Amendment 2, γ):
+**escalation** — retry limit exceeded, verdict `failed`, unrecognized final line, Agent tool error, or **SECURITY WARNING detected** that is not in the transient-ignore list (currently only `Stage 2 classifier error`) in the subagent result (ADR-0021 Amendment 2, γ):
 
 ```bash
 # 1. Write the Reviewer's verdict to state (already done above)


### PR DESCRIPTION
## Summary

closes #669

- Orchestrator の SECURITY WARNING Check に reason-based routing を追加
- `Stage 2 classifier error`（auto-mode 分類器の一時障害）を actionable signal（`[External-Write]`, `[Self-Approval]`）と区別
- transient error の場合は Reviewer の verdict をそのまま採用し、escalation しない

## Background

#660, #667 で Reviewer が approved を返しているにもかかわらず `Stage 2 classifier error` が SECURITY WARNING として検出され、不要な escalation が発生していた。

## Changes

- `agents/orchestrator.md`: SECURITY WARNING Check セクションに reason-based routing を追加
- escalation トリガーリストから `Stage 2 classifier error` を除外

## Test plan

- [ ] 非実行ファイル（agent 定義）の変更のみのためテスト不要（CLAUDE.md ポリシー準拠）
- [ ] CI (bats) がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)