### PR TITLE
feat: add escalation-residue sweep to orchctl gc (worktree/lock vs PR state)

### DIFF
--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -31,6 +31,7 @@ source "${SCRIPT_DIR}/../shared/worker-state.sh"
 source "${SCRIPT_DIR}/../shared/reviewer-state.sh"
 source "${SCRIPT_DIR}/../shared/worker-priority.sh"
 source "${SCRIPT_DIR}/../shared/claude-bg.sh"
+source "${SCRIPT_DIR}/../shared/resolve-repo-root.sh"
 
 CEKERNEL_VAR_DIR="${CEKERNEL_VAR_DIR:-$HOME/.local/var/cekernel}"
 IPC_BASE="${CEKERNEL_IPC_BASE:-${CEKERNEL_VAR_DIR}/ipc}"
@@ -1046,7 +1047,106 @@ cmd_gc() {
   # ── Cleanup temp file ──
   rm -f "$active_issues_file"
 
-  # ── 5. Summary ──
+  # ── 5. Escalation-residue sweep: worktrees + locks vs PR state (#671) ──
+  # ADR-0021 Amendment 2 (γ): escalation preserves the worktree and lock
+  # for human disposition, and the runbook one-liner is the only reclaim
+  # path — if the human merges/closes the PR without executing it, both
+  # leak forever. This sweep reclaims them once the PR is verifiably
+  # terminal (merged or closed).
+  # Degradation policy (ADR-0018 — never reap on doubt): an open PR, a
+  # missing PR, a detached HEAD, or a failed gh query all preserve the
+  # worktree and lock. Scoped to the repo containing the CWD (worktrees
+  # are repo-local); outside a git repo this section is a no-op.
+  local sweep_root=""
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    sweep_root=$(resolve_repo_root)
+  fi
+  if [[ -n "$sweep_root" && -d "${sweep_root}/.worktrees/issue" ]]; then
+    local sweep_wt
+    for sweep_wt in "${sweep_root}/.worktrees/issue"/*/; do
+      [[ -d "$sweep_wt" ]] || continue
+      sweep_wt="${sweep_wt%/}"
+
+      # Never sweep the worktree the CWD is inside (CWD safety)
+      if [[ "${PWD}/" == "${sweep_wt}/"* ]]; then
+        continue
+      fi
+
+      local sweep_issue
+      sweep_issue=$(basename "$sweep_wt")
+      sweep_issue="${sweep_issue%%-*}"
+      [[ "$sweep_issue" =~ ^[0-9]+$ ]] || continue
+
+      # Active worker (non-TERMINATED state in ANY session) → keep.
+      # Cross-repo issue-number collisions stay conservative: an active
+      # worker with this number in any session blocks the sweep.
+      local sweep_active=0 sweep_session=""
+      if [[ -d "$IPC_BASE" ]]; then
+        for session_dir in "$IPC_BASE"/*/; do
+          [[ -f "${session_dir}worker-${sweep_issue}.state" ]] || continue
+          local sweep_line
+          sweep_line=$(cat "${session_dir}worker-${sweep_issue}.state")
+          if [[ "${sweep_line%%:*}" != "TERMINATED" ]]; then
+            sweep_active=1
+            break
+          fi
+          sweep_session=$(basename "$session_dir")
+        done
+      fi
+      if [[ "$sweep_active" -eq 1 ]]; then
+        continue
+      fi
+
+      # Branch under review — detached HEAD cannot be matched to a PR
+      local sweep_branch
+      sweep_branch=$(git -C "$sweep_wt" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
+      [[ -n "$sweep_branch" && "$sweep_branch" != "HEAD" ]] || continue
+
+      # PR state via gh — reclaim only on a verified terminal state:
+      # at least one PR for the branch and none of them open.
+      local sweep_pr_states
+      sweep_pr_states=$(cd "$sweep_root" && gh pr list --head "$sweep_branch" \
+        --state all --json state --jq '.[].state' 2>/dev/null) || continue
+      [[ -n "$sweep_pr_states" ]] || continue
+      if echo "$sweep_pr_states" | grep -qxF "OPEN"; then
+        continue
+      fi
+
+      if [[ "$dry_run" -eq 1 ]]; then
+        echo "[dry-run] would reclaim worktree: $sweep_wt" >&2
+        cleaned=$((cleaned + 1))
+      else
+        # cleanup-worktree.sh owns the removal mechanism (worktree +
+        # local branch removal, trust unregistration, IPC cleanup, and
+        # the CEKERNEL_KEEP_WORKTREE branch). Pass the session holding
+        # the TERMINATED state file so IPC cleanup targets it.
+        if CEKERNEL_SESSION_ID="${sweep_session:-${CEKERNEL_SESSION_ID:-}}" \
+          "${SCRIPT_DIR}/../orchestrator/cleanup-worktree.sh" "$sweep_issue"; then
+          cleaned=$((cleaned + 1))
+        else
+          echo "gc: cleanup-worktree.sh failed for issue #${sweep_issue} — lock kept" >&2
+          continue
+        fi
+      fi
+
+      # Release the issue lock under the same verified-terminal condition.
+      # Escalation holds the lock with an alive/blocked holder, so the
+      # holder-liveness sweep (section 2) never frees it.
+      local sweep_hash sweep_lock_dir
+      sweep_hash=$(issue_lock_repo_hash "$sweep_root")
+      sweep_lock_dir="${CEKERNEL_VAR_DIR}/locks/${sweep_hash}/${sweep_issue}.lock"
+      if [[ -d "$sweep_lock_dir" ]]; then
+        if [[ "$dry_run" -eq 1 ]]; then
+          echo "[dry-run] would release lock: $sweep_lock_dir" >&2
+        else
+          issue_lock_release "$sweep_root" "$sweep_issue"
+        fi
+        cleaned=$((cleaned + 1))
+      fi
+    done
+  fi
+
+  # ── 6. Summary ──
   if [[ "$cleaned" -eq 0 ]]; then
     echo "gc: nothing to clean." >&2
   else

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -12,7 +12,7 @@
 #   term <target>               Send TERM signal (graceful shutdown)
 #   kill <target>               Force kill worker
 #   nice <target> <priority>    Change worker priority
-#   gc [--dry-run]              Clean up stale IPC/lock resources
+#   gc [--dry-run]              Clean up stale IPC/lock/worktree resources
 #
 # Target formats:
 #   <issue>                     Match by issue number (unique across all sessions)
@@ -50,7 +50,7 @@ Commands:
   term <target>               Send TERM signal
   kill <target>               Force kill worker
   nice <target> <priority>    Change priority
-  gc [--dry-run]              Clean up stale resources
+  gc [--dry-run]              Clean up stale IPC/lock/worktree resources
 
 Target: <issue> | <repo>:<issue> | <issue> --session <id>
 USAGE

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -32,9 +32,15 @@ setup() {
   IPC="${IPC_BASE}/${SESSION}"
 
   BGPIDS=""
+
+  # gc's escalation-residue sweep (#671) enumerates the CWD repo's
+  # .worktrees/ — run every test outside any git repo so gc never
+  # touches the real repo's worktrees.
+  cd "$BATS_TEST_TMPDIR"
 }
 
 teardown() {
+  cd /
   local p
   for p in $BGPIDS; do
     kill "$p" 2>/dev/null || true
@@ -784,4 +790,129 @@ worker_state() {
   local reviewer_state
   reviewer_state=$(cat "${session_dir}/reviewer-51.state")
   assert_match "reviewer state unchanged" "^REVIEWING:" "$reviewer_state"
+}
+
+# ── gc: escalation-residue sweep — worktree + lock vs PR state (#671) ──
+# ADR-0021 Amendment 2 (γ): escalation preserves the worktree and lock for
+# human disposition. Once the PR reaches a terminal state (merged/closed),
+# gc reclaims both. Degradation policy (ADR-0018): an open PR, a missing
+# PR, or a failed gh query all preserve the resources — never reap on doubt.
+
+# Create a temp main repo with a spawn.sh-convention worktree for $1.
+# Sets: SWEEP_REPO, SWEEP_ROOT, SWEEP_BRANCH, SWEEP_WT
+make_sweep_repo() {
+  local issue="$1"
+  SWEEP_REPO="${BATS_TEST_TMPDIR}/sweep-repo"
+  mkdir -p "$SWEEP_REPO"
+  git -C "$SWEEP_REPO" init --quiet
+  git -C "$SWEEP_REPO" -c user.name=test -c user.email=test@test \
+    commit --allow-empty -m "initial" --quiet
+  SWEEP_BRANCH="issue/${issue}-sweep-test"
+  SWEEP_WT="${SWEEP_REPO}/.worktrees/${SWEEP_BRANCH}"
+  git -C "$SWEEP_REPO" worktree add -b "$SWEEP_BRANCH" "$SWEEP_WT" HEAD --quiet
+  # Path as the sweep resolves it (symlink-free), for the lock hash
+  SWEEP_ROOT=$(git -C "$SWEEP_REPO" rev-parse --show-toplevel)
+
+  # Isolate cleanup-worktree.sh side effects (trust registry, backend)
+  export CLAUDE_JSON="${BATS_TEST_TMPDIR}/claude.json"
+  export CEKERNEL_BACKEND=headless
+}
+
+# Create an issue lock for $1 with a LIVE holder ($$) — the escalation
+# case: section-2's holder-liveness gc must NOT free it; only the
+# PR-state sweep may. Sets: SWEEP_LOCK
+make_sweep_lock() {
+  local issue="$1"
+  source "${CEKERNEL_DIR}/scripts/shared/issue-lock.sh"
+  local hash
+  hash=$(issue_lock_repo_hash "$SWEEP_ROOT")
+  SWEEP_LOCK="${CEKERNEL_VAR_DIR}/locks/${hash}/${issue}.lock"
+  mkdir -p "$SWEEP_LOCK"
+  echo "$$" > "${SWEEP_LOCK}/pid"
+}
+
+run_gc_in_repo() {
+  run bash -c "cd '$SWEEP_REPO' && bash '$ORCHCTL' gc $*"
+}
+
+@test "gc sweep reclaims worktree, branch, and lock when PR is merged" {
+  make_sweep_repo 42
+  make_sweep_lock 42
+  # Worker finished: TERMINATED state counts as inactive
+  mkdir -p "$IPC"
+  echo "TERMINATED:2026-07-11T10:00:00Z:ci-passed:pr-99" > "${IPC}/worker-42.state"
+  mock_bin gh 'echo MERGED'
+
+  run_gc_in_repo
+  assert_eq "gc exit 0" "0" "$status"
+  assert_not_exists "worktree removed" "$SWEEP_WT"
+  assert_eq "local branch deleted" "" \
+    "$(git -C "$SWEEP_REPO" branch --list "$SWEEP_BRANCH")"
+  assert_not_exists "lock released despite live holder" "$SWEEP_LOCK"
+}
+
+@test "gc sweep reclaims worktree when PR is closed (rejected disposition)" {
+  make_sweep_repo 43
+  # No worker state at all → inactive
+  mock_bin gh 'echo CLOSED'
+
+  run_gc_in_repo
+  assert_eq "gc exit 0" "0" "$status"
+  assert_not_exists "worktree removed" "$SWEEP_WT"
+}
+
+@test "gc sweep preserves worktree and lock when PR is open" {
+  make_sweep_repo 44
+  make_sweep_lock 44
+  mock_bin gh 'echo OPEN'
+
+  run_gc_in_repo
+  assert_eq "gc exit 0" "0" "$status"
+  assert_dir_exists "worktree preserved (open PR = disposition pending)" "$SWEEP_WT"
+  assert_dir_exists "lock preserved" "$SWEEP_LOCK"
+}
+
+@test "gc sweep preserves worktree and lock when gh fails (cannot verify)" {
+  make_sweep_repo 45
+  make_sweep_lock 45
+  mock_bin gh 'exit 1'
+
+  run_gc_in_repo
+  assert_eq "gc exit 0 despite gh failure" "0" "$status"
+  assert_dir_exists "worktree preserved (gh failed → never reap on doubt)" "$SWEEP_WT"
+  assert_dir_exists "lock preserved" "$SWEEP_LOCK"
+}
+
+@test "gc sweep preserves worktree when no PR exists for the branch" {
+  make_sweep_repo 46
+  mock_bin gh ':'  # empty output, exit 0 — branch has no PR
+
+  run_gc_in_repo
+  assert_eq "gc exit 0" "0" "$status"
+  assert_dir_exists "worktree preserved (no PR to verify against)" "$SWEEP_WT"
+}
+
+@test "gc sweep preserves worktree of an active worker even when PR is merged" {
+  make_sweep_repo 47
+  mkdir -p "$IPC"
+  echo "WAITING:2026-07-11T10:00:00Z:phase3:ci-waiting" > "${IPC}/worker-47.state"
+  echo "$$" > "${IPC}/handle-47.worker"  # live handle → not reaped as stale
+  mock_bin gh 'echo MERGED'
+
+  run_gc_in_repo
+  assert_eq "gc exit 0" "0" "$status"
+  assert_dir_exists "worktree preserved (non-TERMINATED worker)" "$SWEEP_WT"
+}
+
+@test "gc --dry-run reports sweep candidates without reclaiming" {
+  make_sweep_repo 48
+  make_sweep_lock 48
+  mock_bin gh 'echo MERGED'
+
+  run_gc_in_repo --dry-run
+  assert_eq "gc exit 0" "0" "$status"
+  assert_dir_exists "worktree preserved in dry-run" "$SWEEP_WT"
+  assert_dir_exists "lock preserved in dry-run" "$SWEEP_LOCK"
+  assert_match "dry-run names the worktree" "would reclaim worktree" "$output"
+  assert_match "dry-run names the lock" "would release lock" "$output"
 }


### PR DESCRIPTION
closes #671

## Summary

#646 (ADR-0021 Amendment 2, γ) で escalation は worktree と issue lock を保持する設計になったが、回収経路が runbook のワンライナー実行のみで、実行忘れで永久リークしていた。`orchctl gc` に escalation 残留リソースの sweep(セクション 5)を追加する。

- **worktree 回収**: cwd の repo の `.worktrees/issue/N-*` を列挙し、(1) 全 session で worker state が存在しないか TERMINATED、(2) ブランチに PR が 1 件以上あり open が 0 件(`gh pr list --head <branch> --state all` で突合)、をすべて満たす場合のみ `cleanup-worktree.sh <issue>` で回収(`CEKERNEL_KEEP_WORKTREE` の分岐は既存実装に委譲)
- **lock 解放**: 同条件で `issue_lock_release`。escalation lock は holder が alive/blocked のためセクション 2 の holder-liveness sweep では解放されない — 本 sweep が PR 状態基準で解放する
- **degradation policy** (ADR-0018「疑わしきは reap しない」): open PR / PR なし / detached HEAD / `gh` 失敗はすべて保持。cwd が対象 worktree 内の場合も保持(CWD 削除ガード)
- **--dry-run**: 既存 gc と同じ `[dry-run] would ...` 形式で表示のみ

テストは全 test の setup で `cd "$BATS_TEST_TMPDIR"` を追加し、sweep が実 repo の worktree に触れないよう分離した。

## Test Plan

- [x] merged PR + 残存 worktree → worktree/ローカルブランチ/lock が回収される
- [x] closed PR → 回収される
- [x] open PR → 回収されない
- [x] gh 失敗 → 回収されない
- [x] PR なし → 回収されない
- [x] active worker(非 TERMINATED state)→ 回収されない
- [x] --dry-run → 表示のみ
- [x] 既存 orchctl-mutating / orchctl-read / cleanup-worktree の全テスト pass(125 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)