### PR TITLE
fix: gc sweeps reviewer IPC files so session dirs are reclaimed

### DIFF
--- a/docs/adr/0021-reviewer-subagent-contract.md
+++ b/docs/adr/0021-reviewer-subagent-contract.md
@@ -202,6 +202,14 @@ path already reasons about Orchestrator liveness, but does not clean
 `reviewer-*.state` today). Decide the exact mechanism when wiring
 `reviewer-*.state` into gc.
 
+*(Resolved by #678, 2026-07-12: the interim answer — exclude reviewer state
+from gc entirely — leaked IPC session dirs forever, since a leftover
+`reviewer-*.state` blocked `rmdir` (48 dirs observed). gc now sweeps
+`reviewer-*.*` under the standard orphan rule, and the Orchestrator-liveness
+check protects active reviewers exactly as anticipated here: when the
+orchestrator session is alive or unverifiable, its non-TERMINATED reviewers
+are registered as active before the sweep — never reap on doubt.)*
+
 ## Consequences
 
 ### Positive

--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -978,7 +978,18 @@ cmd_gc() {
         orch_verdict=$(claude_bg_token_verdict "$orch_token" 2>/dev/null) || true
         case "$orch_verdict" in
           done|stopped|not-listed) ;;  # verifiably dead — reap below
-          *) continue ;;               # alive/blocked or cannot verify
+          *)
+            # Alive/blocked or cannot verify — keep the session, and
+            # protect its active reviewers from the orphan sweep below
+            # (#678). Reviewers are Orchestrator subagents: they can
+            # only be running while the orchestrator session is alive,
+            # so orchestrator liveness is the reviewer liveness signal.
+            local rev_issue
+            for rev_issue in $(reviewer_state_list_active "$session_dir"); do
+              echo "${session_dir}:${rev_issue}" >> "$active_issues_file"
+            done
+            continue
+            ;;
         esac
       fi
 
@@ -991,9 +1002,11 @@ cmd_gc() {
         claude_bg_stop "$orch_token"
       fi
 
+      # claude-session-id (prefix-less) is the pre-v2 legacy name of
+      # orchestrator.claude-session-id — sweep it with the rest (#678).
       for meta_file in "$orch_sid_file" "$orch_legacy_pid_file" \
         "${session_dir}orchestrator.spawned" "${session_dir}repo" \
-        "${session_dir}env.sh"; do
+        "${session_dir}claude-session-id" "${session_dir}env.sh"; do
         if [[ -f "$meta_file" ]]; then
           if [[ "$dry_run" -eq 1 ]]; then
             echo "[dry-run] would remove stale metadata: $meta_file" >&2
@@ -1012,6 +1025,11 @@ cmd_gc() {
       [[ -d "$session_dir" ]] || continue
 
       _gc_clean_orphan_files "$session_dir" "worker-*.*"   "worker-"  "IPC file"
+      # Reviewer files (#678): reviewers are subagents — never active
+      # once the orchestrator session is dead. Active reviewers of live
+      # sessions are protected via active_issues (registered in the
+      # orchestrator liveness check above).
+      _gc_clean_orphan_files "$session_dir" "reviewer-*.*" "reviewer-" "reviewer file"
       _gc_clean_orphan_files "$session_dir" "handle-*.*"   "handle-"  "handle"
       _gc_clean_orphan_files "$session_dir" "pane-*.*"     "pane-"    "pane"
       _gc_clean_orphan_files "$session_dir" "payload-*.b64" "payload-" "payload"

--- a/tests/ctl/orchctl-mutating.bats
+++ b/tests/ctl/orchctl-mutating.bats
@@ -753,37 +753,82 @@ worker_state() {
   assert_match "detail is crashed:detected-by-gc" "crashed:detected-by-gc" "$state_content"
 }
 
-# ── gc: reviewer-*.state isolation (#627, ADR-0021 OQ2) ──
-# gc must NOT touch reviewer-*.state files. A REVIEWING record has no
-# session token, so the worker sweep would immediately reap it. The fix
-# is to not sweep reviewer state at all — staleness is bounded by the
-# Orchestrator's liveness (future scope).
+# ── gc: reviewer-*.* orphan sweep (#678, supersedes #627 / ADR-0021 OQ2) ──
+# ADR-0021 OQ2 originally excluded reviewer state from gc entirely, which
+# leaked IPC session dirs forever (rmdir never succeeded — 48 dirs observed).
+# New semantics: reviewers are Orchestrator subagents — they can only be
+# running while the orchestrator session is alive. gc protects active
+# (non-TERMINATED) reviewer state of alive/unverifiable orchestrator
+# sessions ("never reap on doubt"); everything else follows the same
+# orphan rule as worker files.
 
-@test "gc does NOT reap live REVIEWING reviewer state" {
+@test "gc preserves REVIEWING reviewer state while its orchestrator session is alive" {
+  mock_claude
   local session_dir="${IPC_BASE}/session-gc-rev1"
   mkdir -p "$session_dir"
+  echo "$SESSION_TOKEN" > "${session_dir}/orchestrator.claude-session-id"
   echo "REVIEWING:2026-07-09T10:00:00Z:review:in-progress" > "${session_dir}/reviewer-42.state"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$SESSION_TOKEN" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" gc
-  assert_file_exists "live REVIEWING state preserved" "${session_dir}/reviewer-42.state"
+  assert_file_exists "REVIEWING state of live session preserved" \
+    "${session_dir}/reviewer-42.state"
 }
 
-@test "gc does NOT reap TERMINATED reviewer state" {
+@test "gc removes reviewer files of a dead orchestrator session and reclaims the dir" {
+  mock_claude
   local session_dir="${IPC_BASE}/session-gc-rev2"
   mkdir -p "$session_dir"
+  echo "$SESSION_TOKEN" > "${session_dir}/orchestrator.claude-session-id"
+  echo "REVIEWING:2026-07-09T10:00:00Z:review:in-progress" > "${session_dir}/reviewer-42.state"
   echo "TERMINATED:2026-07-09T10:00:00Z:approved" > "${session_dir}/reviewer-43.state"
+  echo "1711000000" > "${session_dir}/reviewer-44.spawned"  # legacy artifact
+  # empty agents queue → [] → session not listed → verifiably dead
   run bash "$ORCHCTL" gc
-  assert_file_exists "TERMINATED reviewer state preserved" "${session_dir}/reviewer-43.state"
+  assert_not_exists "REVIEWING state of dead session removed" \
+    "${session_dir}/reviewer-42.state"
+  assert_not_exists "TERMINATED reviewer state removed" \
+    "${session_dir}/reviewer-43.state"
+  assert_not_exists "legacy reviewer .spawned removed" \
+    "${session_dir}/reviewer-44.spawned"
+  assert_not_exists "emptied session dir removed" "$session_dir"
+}
+
+@test "gc removes orphan reviewer state when no orchestrator metadata remains" {
+  # The reported leak (#678): a previous gc reaped the orchestrator
+  # metadata but left reviewer-*.state behind, so rmdir failed forever.
+  local session_dir="${IPC_BASE}/session-gc-rev3"
+  mkdir -p "$session_dir"
+  echo "TERMINATED:2026-07-09T10:00:00Z:approved" > "${session_dir}/reviewer-655.state"
+  run bash "$ORCHCTL" gc
+  assert_not_exists "orphan reviewer state removed" "${session_dir}/reviewer-655.state"
+  assert_not_exists "emptied session dir removed" "$session_dir"
+}
+
+@test "gc preserves reviewer state of an issue with an active worker" {
+  local session_dir="${IPC_BASE}/session-gc-rev4"
+  mkdir -p "$session_dir"
+  # Active worker (non-TERMINATED state + live handle) on the same issue
+  echo "RUNNING:2026-07-09T10:00:00Z:phase1:implement" > "${session_dir}/worker-60.state"
+  echo "$$" > "${session_dir}/handle-60.worker"
+  echo "TERMINATED:2026-07-09T10:00:00Z:changes-requested" > "${session_dir}/reviewer-60.state"
+  run bash "$ORCHCTL" gc
+  assert_file_exists "reviewer state of active issue preserved" \
+    "${session_dir}/reviewer-60.state"
 }
 
 @test "gc does NOT interfere with reviewer state when reaping stale workers" {
   mock_claude
-  local session_dir="${IPC_BASE}/session-gc-rev3"
+  local session_dir="${IPC_BASE}/session-gc-rev5"
   mkdir -p "$session_dir"
+  echo "$SESSION_TOKEN" > "${session_dir}/orchestrator.claude-session-id"
   # Stale worker: dead handle
   echo "RUNNING:2026-07-09T10:00:00Z:working" > "${session_dir}/worker-50.state"
   echo "99999999" > "${session_dir}/handle-50.worker"
-  # Live reviewer for a different issue
+  # Live reviewer for a different issue, orchestrator session alive
   echo "REVIEWING:2026-07-09T10:00:00Z:review:in-progress" > "${session_dir}/reviewer-51.state"
+  mock_claude_enqueue_agents \
+    "[$(mock_claude_agent_record "$SESSION_TOKEN" background /repo 1700000000000 busy)]"
   run bash "$ORCHCTL" gc
   # Worker should be reaped
   local worker_state
@@ -794,6 +839,28 @@ worker_state() {
   local reviewer_state
   reviewer_state=$(cat "${session_dir}/reviewer-51.state")
   assert_match "reviewer state unchanged" "^REVIEWING:" "$reviewer_state"
+}
+
+@test "gc --dry-run reports orphan reviewer files without removing them" {
+  local session_dir="${IPC_BASE}/session-gc-rev6"
+  mkdir -p "$session_dir"
+  echo "TERMINATED:2026-07-09T10:00:00Z:approved" > "${session_dir}/reviewer-70.state"
+  run bash "$ORCHCTL" gc --dry-run
+  assert_file_exists "dry-run preserves reviewer state" "${session_dir}/reviewer-70.state"
+  assert_match "dry-run reports the reviewer file" "reviewer-70.state" "$output"
+}
+
+@test "gc removes legacy prefix-less claude-session-id with dead orchestrator metadata" {
+  mock_claude
+  local session_dir="${IPC_BASE}/session-gc-rev7"
+  mkdir -p "$session_dir"
+  # Pre-v2 layout: orchestrator.pid + prefix-less claude-session-id
+  echo "99999999" > "${session_dir}/orchestrator.pid"
+  echo "some-old-session-uuid" > "${session_dir}/claude-session-id"
+  run bash "$ORCHCTL" gc
+  assert_not_exists "legacy pid file swept" "${session_dir}/orchestrator.pid"
+  assert_not_exists "legacy claude-session-id swept" "${session_dir}/claude-session-id"
+  assert_not_exists "emptied session dir removed" "$session_dir"
 }
 
 # ── gc: escalation-residue sweep — worktree + lock vs PR state (#671) ──


### PR DESCRIPTION
closes #678

## Summary

`orchctl gc` の orphan sweep が `reviewer-*.state` / `reviewer-*.spawned` を掃除対象にしておらず、Reviewer を使ったセッションの IPC dir が `rmdir` 常敗で永久残留していた(実測 48 dir)。

- **Section 4**: `reviewer-*.*` を worker と同じ orphan rule で sweep(legacy `reviewer-*.spawned` もカバー)
- **Section 3**: orchestrator session が alive / 検証不能な場合、その session の non-TERMINATED reviewer を active_issues に登録して保護。reviewer は Orchestrator の subagent なので、orchestrator の生死が reviewer の生死シグナル(never reap on doubt)。レビュー中は worker が既に TERMINATED のため、この保護がないと生きた REVIEWING state を消してしまう
- **Section 3**: pre-v2 legacy のプレフィックスなし `claude-session-id` を dead orchestrator metadata 削除リストに追加
- ADR-0021 の open question(gc が live reviewer state をどう保護するか)に resolution note を追記

既存の ADR-0021 OQ2 テスト(「gc は reviewer state に一切触らない」)は本修正で supersede されるため、新セマンティクスに書き換えた。

## Test Plan

- [x] `bats tests/ctl/orchctl-mutating.bats` — 67 tests pass
  - dead session に reviewer files のみ → dir ごと reclaim
  - orchestrator metadata なし session の reviewer state → 消える(実測 48 dir のケース)
  - alive orchestrator の REVIEWING reviewer → 保護
  - active worker がいる issue の reviewer state → 保護
  - `--dry-run` は報告のみで削除しない
  - legacy `claude-session-id` → dead orchestrator 掃除時に消える
- [x] CI (bats --recursive tests/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)