### PR TITLE
fix: recognize waiting/blocked as blocked verdict (claude v2.1.214 schema drift)

### DIFF
--- a/docs/claude-code-constraints.md
+++ b/docs/claude-code-constraints.md
@@ -302,7 +302,7 @@ roster observation; claude v2.1.202):
   detection never fires (#591).
 - **Observed (status, state) matrix** (ADR-0018 — this table is the
   contract; it is mirrored in `scripts/shared/claude-bg.sh` and
-  `tests/helpers/mock-claude.bash`; last updated v2.1.205, 2026-07-09):
+  `tests/helpers/mock-claude.bash`; last updated v2.1.214, 2026-07-18):
 
   | `status` | `state` | Verdict |
   |----------|---------|---------|
@@ -312,6 +312,7 @@ roster observation; claude v2.1.202):
   | `idle` | `working` | alive (v2.1.205: between turns, #638) |
   | `blocked` | `working` | blocked (v2.1.201 shape) |
   | `idle` | `blocked` | blocked (v2.1.202 shape) |
+  | `waiting` | `blocked` | blocked (v2.1.214: permission prompt, #681) |
   | (absent) | `blocked` | blocked (pre-split legacy shape) |
   | `idle` | `done` | terminal (`done`) |
   | (absent) | `done` | terminal (`done`; `--all`, daemon-restart rows) |
@@ -321,11 +322,23 @@ roster observation; claude v2.1.202):
   | any pair not above | | unknown-value |
 
   Real roster tally (2026-07-07, v2.1.202; updated 2026-07-09,
-  v2.1.205): `busy/working`, `busy/(absent)` (interactive),
-  `idle/working` (v2.1.205, live session between turns, #638),
-  `idle/blocked`, `idle/done`, `(absent)/done`, `(absent)/stopped`.
+  v2.1.205; updated 2026-07-18, v2.1.214): `busy/working`,
+  `busy/(absent)` (interactive), `idle/working` (v2.1.205, live session
+  between turns, #638), `idle/blocked`, `waiting/blocked` (v2.1.214,
+  #681), `idle/done`, `(absent)/done`, `(absent)/stopped`.
   Note `blocked` appeared in `state` with `status: "idle"` — NOT in
   `status` as ADR-0018 originally predicted from v2.1.201.
+- **Permission-blocked sessions report `waiting/blocked` with a
+  `waitingFor` field** (v2.1.214, live probe 2026-07-18, #681): a
+  session genuinely stalled on a permission prompt carries
+  `status: "waiting"`, `state: "blocked"`, and `waitingFor: "permission
+  prompt"` — matching the official agent-view semantics
+  (`state: blocked` + `waitingFor`). Reproduce with
+  `claude --bg --permission-mode default` and a tool the settings do
+  not auto-approve (`defaultMode: "auto"` auto-approves Write, so the
+  explicit `--permission-mode default` is required). `waitingFor` is
+  observational only for now — ingesting it as a verdict-split input
+  is #673 scope.
 - **`agents --json` does not resurrect the daemon** (isolated-HOME
   probe, v2.1.202, #593): with no daemon running, `claude agents
   --json` (and `--all`) returns `[]` with exit 0, starts no `claude

--- a/scripts/shared/claude-bg.sh
+++ b/scripts/shared/claude-bg.sh
@@ -15,7 +15,7 @@
 #   bg-session.sh  — lifecycle core, predicates only
 #   backends / watch / orchctl / wrapper / issue-lock — verdict consumers
 #
-# ── Observed (status, state) matrix — v2.1.205, 2026-07-09 (ADR-0018) ──
+# ── Observed (status, state) matrix — v2.1.214, 2026-07-18 (ADR-0018) ──
 #
 #   | `status`  | `state`   | Verdict            |
 #   |-----------|-----------|--------------------|
@@ -25,6 +25,7 @@
 #   | idle      | working   | alive   (v2.1.205: between turns, #638)  |
 #   | blocked   | working   | blocked (v2.1.201 shape)              |
 #   | idle      | blocked   | blocked (v2.1.202 shape)              |
+#   | waiting   | blocked   | blocked (v2.1.214: permission prompt, #681)  |
 #   | (absent)  | blocked   | blocked (pre-split legacy shape)      |
 #   | idle      | done      | done               |
 #   | (absent)  | done      | done    (--all, daemon-restart rows)  |
@@ -162,7 +163,10 @@ claude_bg_token_verdict_from_json() {
       echo "alive"
       return 0
       ;;
-    blocked/working|blocked/-|idle/blocked|-/blocked)
+    blocked/working|blocked/-|idle/blocked|waiting/blocked|-/blocked)
+      # waiting/blocked: v2.1.214 shape (#681) — session stalled on a
+      # permission prompt (record also carries waitingFor: "permission
+      # prompt"; ingesting that field is #673 scope).
       echo "blocked"
       return 0
       ;;

--- a/tests/helpers/mock-claude.bash
+++ b/tests/helpers/mock-claude.bash
@@ -9,7 +9,7 @@
 # `agents --json` records carry extra fields — pid, id, name — and a
 # numeric epoch-millis startedAt, with a realpath'd cwd).
 #
-# ── Observed (status, state) matrix — v2.1.205, 2026-07-09 (ADR-0018) ──
+# ── Observed (status, state) matrix — v2.1.214, 2026-07-18 (ADR-0018) ──
 #
 #   | `status`  | `state`   | Verdict            |
 #   |-----------|-----------|--------------------|
@@ -19,6 +19,7 @@
 #   | idle      | working   | alive   (v2.1.205: between turns, #638)  |
 #   | blocked   | working   | blocked (v2.1.201 shape)              |
 #   | idle      | blocked   | blocked (v2.1.202 shape)              |
+#   | waiting   | blocked   | blocked (v2.1.214: permission prompt, #681)  |
 #   | (absent)  | blocked   | blocked (pre-split legacy shape)      |
 #   | idle      | done      | done               |
 #   | (absent)  | done      | done    (--all, daemon-restart rows)  |
@@ -87,8 +88,12 @@
 #                                 <status|-> <state|->
 #     Prints one FULL agents record with an EXPLICIT (status, state)
 #     pair; "-" omits the field. Covers the non-canonical matrix rows
-#     (busy/-, -/done, blocked/working, pre-split legacy -/busy) and
+#     (busy/-, -/done, blocked/working, waiting/blocked — the v2.1.214
+#     permission-prompt shape #681 — pre-split legacy -/busy) and
 #     out-of-matrix pairs for unknown-value contract tests (ADR-0018).
+#     (The real waiting/blocked record also carries waitingFor:
+#     "permission prompt" — an ADDITIONAL field per the non-exclusive
+#     field-set rule below; emit support for it is #673 scope.)
 #
 #   mock_claude_fail_agents
 #     Makes every subsequent `claude agents --json` call fail (exit 1,

--- a/tests/shared/claude-bg.bats
+++ b/tests/shared/claude-bg.bats
@@ -69,6 +69,17 @@ enqueue_pair() {
   assert_eq "verdict" "blocked" "$output"
 }
 
+@test "verdict matrix: waiting/blocked is blocked (v2.1.214 shape, #681)" {
+  # claude 2.1.214: a session genuinely stalled on a permission prompt
+  # reports status=waiting, state=blocked (with waitingFor: "permission
+  # prompt" — ingestion of that field is #673 scope). Observed 2026-07-18
+  # via live probe.
+  enqueue_pair waiting blocked
+  run claude_bg_token_verdict "$FULL_UUID"
+  assert_eq "exit status" "0" "$status"
+  assert_eq "verdict" "blocked" "$output"
+}
+
 @test "verdict matrix: legacy pre-split state:blocked (no status) is blocked" {
   enqueue_pair - blocked
   run claude_bg_token_verdict "$FULL_UUID"


### PR DESCRIPTION
closes #681

## Summary

claude v2.1.214 の実機プローブで、permission prompt で本当にブロックされたセッションが `(status=waiting, state=blocked, waitingFor: "permission prompt")` を返すことを確認した。この pair は ADR-0018 の (status, state) matrix に存在せず `unknown-value` (rc=5) に落ちるため、`watch.sh` の blocked ハンドラが発火せず、schema-drift 警告が出続けていた。

ADR-0018 の STALENESS COUPLING に従い 3点同時更新:

- `scripts/shared/claude-bg.sh` — verdict case とヘッダ matrix 表に `waiting/blocked → blocked` を追加
- `docs/claude-code-constraints.md` — matrix 表の更新 + `waitingFor` フィールドの観測記録(再現手順含む)
- `tests/helpers/mock-claude.bash` — matrix 表コメント更新(shape の emit は既存の `mock_claude_agent_record_pair` 明示 pair 経路で対応済み)

`waitingFor` の取り込み(blocked verdict 分割の判定材料)は #673 のスコープとし、本 PR は matrix 追随のみの最小修正。#638(`idle/working` drift)と同じ 3点セット修正の前例に従う。

## Test Plan

- [x] RED: `tests/shared/claude-bg.bats` に `waiting/blocked → blocked` テストを追加し、rc=5 (unknown-value) で失敗することを確認
- [x] GREEN: matrix 追加後、`bats tests/shared/claude-bg.bats` 36件全パス
- [ ] CI (`bats --recursive tests/`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)