### PR TITLE
fix: orchctl ls/ps の0件時メッセージを stderr へ移動(JSON Lines 汚染の解消)

### DIFF
--- a/scripts/ctl/orchctl.sh
+++ b/scripts/ctl/orchctl.sh
@@ -211,7 +211,7 @@ cmd_ls() {
   local found=0
 
   if [[ ! -d "$IPC_BASE" ]]; then
-    echo "no workers."
+    echo "no workers." >&2
     return 0
   fi
 
@@ -303,7 +303,7 @@ cmd_ls() {
   done
 
   if [[ "$found" -eq 0 ]]; then
-    echo "no workers."
+    echo "no workers." >&2
   fi
 }
 
@@ -339,7 +339,7 @@ cmd_ps() {
   local found=0
 
   if [[ ! -d "$IPC_BASE" ]]; then
-    echo "no orchestrators."
+    echo "no orchestrators." >&2
     return 0
   fi
 
@@ -444,7 +444,7 @@ cmd_ps() {
   done
 
   if [[ "$found" -eq 0 ]]; then
-    echo "no orchestrators."
+    echo "no orchestrators." >&2
   fi
 }
 

--- a/skills/orchctl/SKILL.md
+++ b/skills/orchctl/SKILL.md
@@ -38,8 +38,8 @@ Try `<issue>` alone first; if multiple sessions match, show the candidates and a
 
 | Command | Behavior | Present to user as |
 |---------|----------|--------------------|
-| `ls` | JSON Lines, one per Worker (`session`, `repo`, `issue`, `type`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`); `no workers.` if none | Table: Session / Repo / Issue / Type / State / Detail / Priority / Elapsed / Backend. Use `orchctl ls \| jq 'select(.issue == N)'` to filter a specific worker |
-| `ps [--session <id>]` | JSON Lines, one per process (`session`, `type` [orchestrator/worker/reviewer], `claude`, `elapsed`, `verdict`, plus `issue`/`phase`/`priority` for workers, `state`/`detail` for reviewers); `no orchestrators.` if none | Table: Session / Type / Issue / Verdict / Phase / Priority / Elapsed |
+| `ls` | JSON Lines, one per Worker (`session`, `repo`, `issue`, `type`, `state`, `detail`, `priority`, `priority_name`, `elapsed`, `backend`); if none, stdout is empty (0 lines) and `no workers.` goes to stderr | Table: Session / Repo / Issue / Type / State / Detail / Priority / Elapsed / Backend. Use `orchctl ls \| jq 'select(.issue == N)'` to filter a specific worker |
+| `ps [--session <id>]` | JSON Lines, one per process (`session`, `type` [orchestrator/worker/reviewer], `claude`, `elapsed`, `verdict`, plus `issue`/`phase`/`priority` for workers, `state`/`detail` for reviewers); if none, stdout is empty (0 lines) and `no orchestrators.` goes to stderr | Table: Session / Type / Issue / Verdict / Phase / Priority / Elapsed |
 | `suspend <target>` | Sends SUSPEND (RUNNING/WAITING/READY only); Worker checkpoints and stops at the next phase boundary | Confirm action |
 | `resume <target>` | SUSPENDED (or TERMINATED with `crashed*` detail) → READY; prints the restart command | Confirm, then show the printed `spawn-worker.sh --resume` command for the user to run |
 | `recover <target>` | Marks a dead RUNNING/WAITING Worker as `TERMINATED`/`crashed:detected-by-recover`; errors if the process is alive (suggest `term`/`kill`) | Confirm transition, suggest `orchctl resume` next |

--- a/tests/ctl/orchctl-read.bats
+++ b/tests/ctl/orchctl-read.bats
@@ -76,15 +76,25 @@ make_handle() {
 
 # ── ls ──
 
-@test "ls with no sessions prints 'no workers.'" {
-  run bash "$ORCHCTL" ls
-  assert_eq "ls no sessions" "no workers." "$output"
+@test "ls with no sessions: empty stdout, 'no workers.' on stderr, exit 0" {
+  run --separate-stderr bash "$ORCHCTL" ls
+  assert_eq "ls no sessions: exit 0" "0" "$status"
+  assert_eq "ls no sessions: stdout empty" "" "$output"
+  assert_eq "ls no sessions: message on stderr" "no workers." "$stderr"
 }
 
-@test "ls with empty session prints 'no workers.'" {
+@test "ls with empty session: empty stdout, 'no workers.' on stderr, exit 0" {
   mkdir -p "$IPC_A"
-  run bash "$ORCHCTL" ls
-  assert_eq "ls empty session" "no workers." "$output"
+  run --separate-stderr bash "$ORCHCTL" ls
+  assert_eq "ls empty session: exit 0" "0" "$status"
+  assert_eq "ls empty session: stdout empty" "" "$output"
+  assert_eq "ls empty session: message on stderr" "no workers." "$stderr"
+}
+
+@test "ls with no workers pipes cleanly into jq" {
+  run bash -c "bash '$ORCHCTL' ls 2>/dev/null | jq ."
+  assert_eq "ls | jq exit 0" "0" "$status"
+  assert_eq "ls | jq stdout empty" "" "$output"
 }
 
 @test "ls one worker: one JSON line with session, issue, state, priority" {
@@ -229,15 +239,25 @@ make_handle() {
 
 # ── ps (session-ID based, ADR-0016 Phase 2) ──
 
-@test "ps with no sessions prints 'no orchestrators.'" {
-  run bash "$ORCHCTL" ps
-  assert_eq "ps no sessions" "no orchestrators." "$output"
+@test "ps with no sessions: empty stdout, 'no orchestrators.' on stderr, exit 0" {
+  run --separate-stderr bash "$ORCHCTL" ps
+  assert_eq "ps no sessions: exit 0" "0" "$status"
+  assert_eq "ps no sessions: stdout empty" "" "$output"
+  assert_eq "ps no sessions: message on stderr" "no orchestrators." "$stderr"
 }
 
-@test "ps with session but no orchestrator.claude-session-id prints 'no orchestrators.'" {
+@test "ps with session but no orchestrator.claude-session-id: empty stdout, message on stderr" {
   mkdir -p "$IPC_A"
-  run bash "$ORCHCTL" ps
-  assert_eq "ps no session token" "no orchestrators." "$output"
+  run --separate-stderr bash "$ORCHCTL" ps
+  assert_eq "ps no session token: exit 0" "0" "$status"
+  assert_eq "ps no session token: stdout empty" "" "$output"
+  assert_eq "ps no session token: message on stderr" "no orchestrators." "$stderr"
+}
+
+@test "ps with no orchestrators pipes cleanly into jq" {
+  run bash -c "bash '$ORCHCTL' ps 2>/dev/null | jq ."
+  assert_eq "ps | jq exit 0" "0" "$status"
+  assert_eq "ps | jq stdout empty" "" "$output"
 }
 
 @test "ps outputs JSON Lines with type=orchestrator for orchestrator row" {
@@ -308,17 +328,21 @@ make_handle() {
   fi
 }
 
-@test "ps --session with non-existent session prints 'no orchestrators.'" {
+@test "ps --session with non-existent session: empty stdout, message on stderr" {
   make_orchestrator "$IPC_A" "$ORCH_TOKEN_A"
-  run bash "$ORCHCTL" ps --session "nonexistent-session"
-  assert_eq "nonexistent session" "no orchestrators." "$output"
+  run --separate-stderr bash "$ORCHCTL" ps --session "nonexistent-session"
+  assert_eq "nonexistent session: exit 0" "0" "$status"
+  assert_eq "nonexistent session: stdout empty" "" "$output"
+  assert_eq "nonexistent session: message on stderr" "no orchestrators." "$stderr"
 }
 
 @test "ps ignores a legacy orchestrator.pid file (v2 is session-ID based)" {
   mkdir -p "$IPC_A"
   echo "$$" > "${IPC_A}/orchestrator.pid"
-  run bash "$ORCHCTL" ps
-  assert_eq "legacy pid file alone shows nothing" "no orchestrators." "$output"
+  run --separate-stderr bash "$ORCHCTL" ps
+  assert_eq "legacy pid file alone: exit 0" "0" "$status"
+  assert_eq "legacy pid file alone: stdout empty" "" "$output"
+  assert_eq "legacy pid file alone: message on stderr" "no orchestrators." "$stderr"
 }
 
 # ── ps managed rows (agents --json view layer, ADR-0016 Phase 4 / #549) ──


### PR DESCRIPTION
closes #686

## Summary

`orchctl ls` / `orchctl ps` は JSON Lines を stdout に出力するが、0件時のみ `no workers.` / `no orchestrators.` という非 JSON 文字列を stdout に出しており、`orchctl ls | jq ...` がパースエラーになっていた(Rule of Composition 違反)。

- 0件時は stdout に何も出さない(0行、Rule of Silence)
- 現行メッセージは stderr へ移動(対話利用時の見た目は不変)
- exit 0 は維持
- `scripts/ctl/orchctl.sh` の4箇所(`cmd_ls` ×2、`cmd_ps` ×2)へ `>&2` を付与
- `skills/orchctl/SKILL.md` の ls/ps 出力仕様2行を更新

## Test Plan

- [x] RED: 0件時テスト6件を `run --separate-stderr` による「stdout 空・stderr にメッセージ・exit 0」検証へ更新+`| jq .` 正常終了テスト2件追加、失敗を確認
- [x] GREEN: `>&2` 付与で `tests/ctl/orchctl-read.bats` 全55件 pass
- [x] 回帰確認: `tests/ctl/orchctl-mutating.bats` 全73件 pass
- [x] CI (`bats --recursive tests/`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)